### PR TITLE
Specify target platform for MSBUILD

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -103,12 +103,12 @@ set _flavour=Release
 goto :main
 
 :distclean
-msbuild /t:DistClean /p:BuildFlavour=Release /verbosity:minimal /nologo
-msbuild /t:DistClean /p:BuildFlavour=Debug /verbosity:minimal /nologo
+msbuild /t:DistClean /p:BuildFlavour=Release /verbosity:minimal /nologo /p:Platform="Any CPU"
+msbuild /t:DistClean /p:BuildFlavour=Debug /verbosity:minimal /nologo /p:Platform="Any CPU"
 goto :main
 
 :main
-msbuild Build.proj /t:%_target% /p:BuildFlavour=%_flavour% /verbosity:minimal /nologo
+msbuild Build.proj /t:%_target% /p:BuildFlavour=%_flavour% /verbosity:minimal /nologo /p:Platform="Any CPU"
 goto :exit
 
 :exit


### PR DESCRIPTION
MSBUILD defaults to platform X64 if none is specified on the command line
on a 64bit machine. If the configuration in the solution does not exist,
MSBUILD will fail.

The is the output on a 64bit machine.
e:\dev\gitrepos\ironpython3\IronPython.sln.metaproj : error MSB4126: The specified solution configuration "v2Debug|X64" is
invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe So lution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution config uration. [E:\Dev\gitrepos\ironpython3\IronPython.sln]
