### PR TITLE
PEP 3114 -- Renaming iterator.next() to iterator.__next__()

### DIFF
--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1537,12 +1537,12 @@ namespace IronPython.Modules {
         }
 
         public static object next(CodeContext/*!*/ context, object iter) {
-            return PythonOps.Invoke(context, iter, "next");
+            return PythonOps.Invoke(context, iter, "__next__");
         }
 
         public static object next(CodeContext/*!*/ context, object iter, object defaultVal) {
             try {
-                return PythonOps.Invoke(context, iter, "next");
+                return PythonOps.Invoke(context, iter, "__next__");
             } catch (StopIterationException) {
                 return defaultVal;
             }

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1503,6 +1503,11 @@ namespace IronPython.Modules {
             return value;
         }
 
+        /// <summary>
+        /// Calls the __next__ method of an iterable
+        /// </summary>
+        /// <param name="iter">Iterable instance</param>
+        /// <returns>Next object or throws an StopIterator exception</returns>
         public static object next(IEnumerator iter) {
             if (iter.MoveNext()) {
                 return iter.Current;
@@ -1511,6 +1516,12 @@ namespace IronPython.Modules {
             }
         }
 
+        /// <summary>
+        /// Calls the __next__ method of an iterable
+        /// </summary>
+        /// <param name="iter">Iterable instance</param>
+        /// <param name="defaultVal">Default operation value</param>
+        /// <returns>Next object or throws an StopIterator exception</returns>
         public static object next(IEnumerator iter, object defaultVal) {
             if (iter.MoveNext()) {
                 return iter.Current;
@@ -1537,14 +1548,12 @@ namespace IronPython.Modules {
         }
 
         public static object next(CodeContext/*!*/ context, object iter) {
-
             // PEP 3114 -- Renaming iterator.next() to iterator.__next__()
             return PythonOps.Invoke(context, iter, "__next__");
         }
 
         public static object next(CodeContext/*!*/ context, object iter, object defaultVal) {
-            try {
-                
+            try {                
                 // PEP 3114 -- Renaming iterator.next() to iterator.__next__()
                 return PythonOps.Invoke(context, iter, "__next__");
             } catch (StopIterationException) {

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1537,11 +1537,15 @@ namespace IronPython.Modules {
         }
 
         public static object next(CodeContext/*!*/ context, object iter) {
+
+            // PEP 3114 -- Renaming iterator.next() to iterator.__next__()
             return PythonOps.Invoke(context, iter, "__next__");
         }
 
         public static object next(CodeContext/*!*/ context, object iter, object defaultVal) {
             try {
+                
+                // PEP 3114 -- Renaming iterator.next() to iterator.__next__()
                 return PythonOps.Invoke(context, iter, "__next__");
             } catch (StopIterationException) {
                 return defaultVal;

--- a/Src/IronPython/Runtime/Enumerate.cs
+++ b/Src/IronPython/Runtime/Enumerate.cs
@@ -256,7 +256,7 @@ namespace IronPython.Runtime {
 
         public bool MoveNext() {
             if (_nextMethod == null) {
-                if (!PythonOps.TryGetBoundAttr(_baseObject, "next", out _nextMethod) || _nextMethod == null) {
+                if (!PythonOps.TryGetBoundAttr(_baseObject, "__next__", out _nextMethod) || _nextMethod == null) {
                     throw PythonOps.TypeError("instance has no next() method");
                 }
             }

--- a/Src/IronPython/Runtime/Enumerate.cs
+++ b/Src/IronPython/Runtime/Enumerate.cs
@@ -256,6 +256,7 @@ namespace IronPython.Runtime {
 
         public bool MoveNext() {
             if (_nextMethod == null) {
+                // PEP 3114 -- Renaming iterator.next() to iterator.__next__()
                 if (!PythonOps.TryGetBoundAttr(_baseObject, "__next__", out _nextMethod) || _nextMethod == null) {
                     throw PythonOps.TypeError("instance has no next() method");
                 }

--- a/Src/IronPython/Runtime/Enumerate.cs
+++ b/Src/IronPython/Runtime/Enumerate.cs
@@ -254,6 +254,10 @@ namespace IronPython.Runtime {
             }
         }
 
+        /// <summary>
+        /// Move to the next item in this iterable
+        /// </summary>
+        /// <returns>True if moving was successfull</returns>
         public bool MoveNext() {
             if (_nextMethod == null) {
                 // PEP 3114 -- Renaming iterator.next() to iterator.__next__()

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -646,6 +646,8 @@ namespace IronPython.Runtime.Types {
                 new OneOffResolver("__exit__", ExitResolver),
                 new OneOffResolver("__len__", LengthResolver),
                 new OneOffResolver("__format__", FormatResolver),
+
+                // PEP 3114 -- Renaming iterator.next() to iterator.__next__()
                 new OneOffResolver("next", NextResolver),
 
                 new OneOffResolver("__complex__", ComplexResolver),

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -646,8 +646,6 @@ namespace IronPython.Runtime.Types {
                 new OneOffResolver("__exit__", ExitResolver),
                 new OneOffResolver("__len__", LengthResolver),
                 new OneOffResolver("__format__", FormatResolver),
-
-                // PEP 3114 -- Renaming iterator.next() to iterator.__next__()
                 new OneOffResolver("next", NextResolver),
 
                 new OneOffResolver("__complex__", ComplexResolver),


### PR DESCRIPTION
Iterable must now implement `__next__` instead of `next`. Builtin `next` now calls `__next__`.

Works pretty well:

```python
>>> class Test04:
...     def __init__(self):
...         self.l = iter([1, 2, 3, 4])
...     def __iter__(self):
...         return self
...     def __next__(self):
...         return next(self.l)
...
>>> for a in Test04():
...     print (a)
```

Old style does not work anymore:

```python
>>> class Test05:
...     def __init__(self):
...         self.l = iter([1, 2, 3, 4])
...     def __iter__(self):
...         return self
...     def next(self):
...         return next(self.l)
...
>>> for b in Test05():
...     print (b)
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: instance has no next() method
```