### PR TITLE
Fix byte-array iterator result

### DIFF
--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -31,7 +31,8 @@ using System.Numerics;
 using Microsoft.Scripting.Math;
 #endif
 
-namespace IronPython.Runtime {
+namespace IronPython.Runtime
+{
     /// <summary>
     /// bytearray(string, encoding[, errors]) -> bytearray
     /// bytearray(iterable) -> bytearray
@@ -55,73 +56,93 @@ namespace IronPython.Runtime {
     {
         internal List<byte>/*!*/ _bytes;
 
-        public ByteArray() {
+        public ByteArray()
+        {
             _bytes = new List<byte>(0);
         }
 
-        internal ByteArray(List<byte> bytes) {
+        internal ByteArray(List<byte> bytes)
+        {
             _bytes = bytes;
         }
 
-        internal ByteArray (byte[] bytes) {
+        internal ByteArray(byte[] bytes)
+        {
             _bytes = new List<byte>(bytes);
         }
 
-        public void __init__() {
+        public void __init__()
+        {
             _bytes = new List<byte>();
         }
 
-        public void __init__(int source) {
+        public void __init__(int source)
+        {
             _bytes = new List<byte>(source);
-            for (int i = 0; i < source; i++) {
+            for (int i = 0; i < source; i++)
+            {
                 _bytes.Add(0);
             }
         }
 
-        public void __init__(BigInteger source) {
+        public void __init__(BigInteger source)
+        {
             __init__((int)source);
         }
 
-        public void __init__([NotNull]IList<byte>/*!*/ source) {            
+        public void __init__([NotNull]IList<byte>/*!*/ source)
+        {
             _bytes = new List<byte>(source);
         }
 
-        public void __init__(object source) {
+        public void __init__(object source)
+        {
             __init__(GetBytes(source));
         }
 
-        public void __init__(CodeContext/*!*/ context, string source, string encoding, [DefaultParameterValue("strict")]string errors) {
+        public void __init__(CodeContext/*!*/ context, string source, string encoding, [DefaultParameterValue("strict")]string errors)
+        {
             _bytes = new List<byte>(StringOps.encode(context, source, encoding, errors).MakeByteArray());
         }
 
         #region Public Mutable Sequence API
-        
-        public void append(int item) {
-            lock (this) {
+
+        public void append(int item)
+        {
+            lock (this)
+            {
                 _bytes.Add(item.ToByteChecked());
             }
         }
 
-        public void append(object item) {
-            lock(this) {
+        public void append(object item)
+        {
+            lock (this)
+            {
                 _bytes.Add(GetByte(item));
             }
         }
 
-        public void extend([NotNull]IEnumerable<byte>/*!*/ seq) {
-            using (new OrderedLocker(this, seq)) {
+        public void extend([NotNull]IEnumerable<byte>/*!*/ seq)
+        {
+            using (new OrderedLocker(this, seq))
+            {
                 // use the original count for if we're extending this w/ this
                 _bytes.AddRange(seq);
             }
         }
 
-        public void extend(object seq) {
+        public void extend(object seq)
+        {
             extend(GetBytes(seq));
         }
 
-        public void insert(int index, int value) {
-            lock (this) {
-                if (index >= Count) {
+        public void insert(int index, int value)
+        {
+            lock (this)
+            {
+                if (index >= Count)
+                {
                     append(value);
                     return;
                 }
@@ -132,13 +153,17 @@ namespace IronPython.Runtime {
             }
         }
 
-        public void insert(int index, object value) {
+        public void insert(int index, object value)
+        {
             insert(index, Converter.ConvertToIndex(value));
         }
 
-        public int pop() {
-            lock (this) {
-                if (Count == 0) {
+        public int pop()
+        {
+            lock (this)
+            {
+                if (Count == 0)
+                {
                     throw PythonOps.IndexError("pop off of empty bytearray");
                 }
 
@@ -148,9 +173,12 @@ namespace IronPython.Runtime {
             }
         }
 
-        public int pop(int index) {
-            lock (this) {
-                if (Count == 0) {
+        public int pop(int index)
+        {
+            lock (this)
+            {
+                if (Count == 0)
+                {
                     throw PythonOps.IndexError("pop off of empty bytearray");
                 }
 
@@ -162,25 +190,33 @@ namespace IronPython.Runtime {
             }
         }
 
-        public void remove(int value) {
-            lock (this) {
+        public void remove(int value)
+        {
+            lock (this)
+            {
                 _bytes.RemoveAt(_bytes.IndexOfByte(value.ToByteChecked(), 0, _bytes.Count));
             }
         }
 
-        public void remove(object value) {
-            lock (this) {
-                if (value is ByteArray) {
+        public void remove(object value)
+        {
+            lock (this)
+            {
+                if (value is ByteArray)
+                {
                     throw PythonOps.TypeError("an integer or string of size 1 is required");
                 }
                 _bytes.RemoveAt(_bytes.IndexOfByte(GetByte(value), 0, _bytes.Count));
             }
         }
-        
-        public void reverse() {
-            lock (this) {
+
+        public void reverse()
+        {
+            lock (this)
+            {
                 List<byte> reversed = new List<byte>();
-                for (int i = _bytes.Count - 1; i >= 0; i--) {
+                for (int i = _bytes.Count - 1; i >= 0; i--)
+                {
                     reversed.Add(_bytes[i]);
                 }
                 _bytes = reversed;
@@ -188,24 +224,30 @@ namespace IronPython.Runtime {
         }
 
         [SpecialName]
-        public ByteArray InPlaceAdd(ByteArray other) {
-            using (new OrderedLocker(this, other)) {
+        public ByteArray InPlaceAdd(ByteArray other)
+        {
+            using (new OrderedLocker(this, other))
+            {
                 _bytes.AddRange(other._bytes);
                 return this;
             }
         }
 
         [SpecialName]
-        public ByteArray InPlaceAdd(Bytes other) {
-            lock (this) {
+        public ByteArray InPlaceAdd(Bytes other)
+        {
+            lock (this)
+            {
                 _bytes.AddRange(other);
                 return this;
             }
         }
 
         [SpecialName]
-        public ByteArray InPlaceMultiply(int len) {
-            lock (this) {
+        public ByteArray InPlaceMultiply(int len)
+        {
+            lock (this)
+            {
                 _bytes = (this * len)._bytes;
                 return this;
             }
@@ -215,21 +257,27 @@ namespace IronPython.Runtime {
 
         #region Public Python API surface
 
-        public ByteArray/*!*/ capitalize() {
-            lock (this) {
+        public ByteArray/*!*/ capitalize()
+        {
+            lock (this)
+            {
                 return new ByteArray(_bytes.Capitalize());
             }
         }
 
-        public ByteArray/*!*/ center(int width) {
+        public ByteArray/*!*/ center(int width)
+        {
             return center(width, " ");
         }
 
-        public ByteArray/*!*/ center(int width, [NotNull]string fillchar) {
-            lock (this) {                
+        public ByteArray/*!*/ center(int width, [NotNull]string fillchar)
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.TryCenter(width, fillchar.ToByte("center", 2));
-                
-                if (res == null) {
+
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -237,11 +285,14 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ center(int width, [BytesConversion]IList<byte> fillchar) {
-            lock (this) {
+        public ByteArray/*!*/ center(int width, [BytesConversion]IList<byte> fillchar)
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.TryCenter(width, fillchar.ToByte("center", 2));
 
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -249,104 +300,136 @@ namespace IronPython.Runtime {
             }
         }
 
-        public int count([BytesConversion]IList<byte>/*!*/ sub) {
+        public int count([BytesConversion]IList<byte>/*!*/ sub)
+        {
             return count(sub, 0, _bytes.Count);
         }
 
-        public int count([BytesConversion]IList<byte>/*!*/ sub, int start) {
+        public int count([BytesConversion]IList<byte>/*!*/ sub, int start)
+        {
             return count(sub, start, _bytes.Count);
         }
 
-        public int count([BytesConversion]IList<byte>/*!*/ ssub, int start, int end) {
-            lock (this) {
+        public int count([BytesConversion]IList<byte>/*!*/ ssub, int start, int end)
+        {
+            lock (this)
+            {
                 return _bytes.CountOf(ssub, start, end);
             }
         }
-        
-        public string decode(CodeContext/*!*/ context, [Optional]object encoding, [DefaultParameterValue("strict")]string errors) {
+
+        public string decode(CodeContext/*!*/ context, [Optional]object encoding, [DefaultParameterValue("strict")]string errors)
+        {
             return StringOps.decode(context, _bytes.MakeString(), encoding, errors);
         }
 
-        public bool endswith([BytesConversion]IList<byte>/*!*/ suffix) {
-            lock (this) {
+        public bool endswith([BytesConversion]IList<byte>/*!*/ suffix)
+        {
+            lock (this)
+            {
                 return _bytes.EndsWith(suffix);
             }
         }
 
-        public bool endswith([BytesConversion]IList<byte>/*!*/ suffix, int start) {
-            lock (this) {
+        public bool endswith([BytesConversion]IList<byte>/*!*/ suffix, int start)
+        {
+            lock (this)
+            {
                 return _bytes.EndsWith(suffix, start);
             }
         }
 
-        public bool endswith([BytesConversion]IList<byte>/*!*/ suffix, int start, int end) {
-            lock (this) {
+        public bool endswith([BytesConversion]IList<byte>/*!*/ suffix, int start, int end)
+        {
+            lock (this)
+            {
                 return _bytes.EndsWith(suffix, start, end);
             }
         }
 
-        public bool endswith(PythonTuple/*!*/ suffix) {
-            lock (this) {
+        public bool endswith(PythonTuple/*!*/ suffix)
+        {
+            lock (this)
+            {
                 return _bytes.EndsWith(suffix);
             }
         }
 
-        public bool endswith(PythonTuple/*!*/ suffix, int start) {
-            lock (this) {
+        public bool endswith(PythonTuple/*!*/ suffix, int start)
+        {
+            lock (this)
+            {
                 return _bytes.EndsWith(suffix, start);
             }
         }
 
-        public bool endswith(PythonTuple/*!*/ suffix, int start, int end) {
-            lock (this) {
+        public bool endswith(PythonTuple/*!*/ suffix, int start, int end)
+        {
+            lock (this)
+            {
                 return _bytes.EndsWith(suffix, start, end);
             }
         }
 
-        public ByteArray/*!*/ expandtabs() {
+        public ByteArray/*!*/ expandtabs()
+        {
             return expandtabs(8);
         }
 
-        public ByteArray/*!*/ expandtabs(int tabsize) {
-            lock (this) {
+        public ByteArray/*!*/ expandtabs(int tabsize)
+        {
+            lock (this)
+            {
                 return new ByteArray(_bytes.ExpandTabs(tabsize));
             }
         }
 
-        public int find([BytesConversion]IList<byte>/*!*/ sub) {
-            lock (this) {
+        public int find([BytesConversion]IList<byte>/*!*/ sub)
+        {
+            lock (this)
+            {
                 return _bytes.Find(sub);
             }
         }
 
-        public int find([BytesConversion]IList<byte>/*!*/ sub, int start) {
-            lock (this) {
+        public int find([BytesConversion]IList<byte>/*!*/ sub, int start)
+        {
+            lock (this)
+            {
                 return _bytes.Find(sub, start);
             }
         }
 
-        public int find([BytesConversion]IList<byte>/*!*/ sub, int start, int end) {
-            lock (this) {
+        public int find([BytesConversion]IList<byte>/*!*/ sub, int start, int end)
+        {
+            lock (this)
+            {
                 return _bytes.Find(sub, start, end);
             }
         }
 
-        public static ByteArray/*!*/ fromhex(string/*!*/ @string) {
+        public static ByteArray/*!*/ fromhex(string/*!*/ @string)
+        {
             return new ByteArray(IListOfByteOps.FromHex(@string));
         }
 
-        public int index([BytesConversion]IList<byte>/*!*/ item) {
+        public int index([BytesConversion]IList<byte>/*!*/ item)
+        {
             return index(item, 0, _bytes.Count);
         }
 
-        public int index([BytesConversion]IList<byte>/*!*/ item, int start) {
+        public int index([BytesConversion]IList<byte>/*!*/ item, int start)
+        {
             return index(item, start, _bytes.Count);
         }
 
-        public int index([BytesConversion]IList<byte>/*!*/ item, int start, int stop) {
-            lock (this) {
+        public int index([BytesConversion]IList<byte>/*!*/ item, int start, int stop)
+        {
+            lock (this)
+            {
                 int res = find(item, start, stop);
-                if (res == -1) {
+                if (res == -1)
+                {
                     throw PythonOps.ValueError("bytearray.index(item): item not in bytearray");
                 }
 
@@ -354,32 +437,42 @@ namespace IronPython.Runtime {
             }
         }
 
-        public bool isalnum() {
-            lock (this) {
+        public bool isalnum()
+        {
+            lock (this)
+            {
                 return _bytes.IsAlphaNumeric();
             }
         }
 
-        public bool isalpha() {
-            lock (this) {
+        public bool isalpha()
+        {
+            lock (this)
+            {
                 return _bytes.IsLetter();
             }
         }
 
-        public bool isdigit() {
-            lock (this) {
+        public bool isdigit()
+        {
+            lock (this)
+            {
                 return _bytes.IsDigit();
             }
         }
 
-        public bool islower() {
-            lock (this) {
+        public bool islower()
+        {
+            lock (this)
+            {
                 return _bytes.IsLower();
             }
         }
 
-        public bool isspace() {
-            lock (this) {
+        public bool isspace()
+        {
+            lock (this)
+            {
                 return _bytes.IsWhiteSpace();
             }
         }
@@ -390,14 +483,18 @@ namespace IronPython.Runtime {
         /// characters (e.g. whitespace) and lowercase characters only cased ones. 
         /// return false otherwise.
         /// </summary>
-        public bool istitle() {
-            lock (this) {
+        public bool istitle()
+        {
+            lock (this)
+            {
                 return _bytes.IsTitle();
             }
         }
 
-        public bool isupper() {
-            lock (this) {
+        public bool isupper()
+        {
+            lock (this)
+            {
                 return _bytes.IsUpper();
             }
         }
@@ -407,16 +504,19 @@ namespace IronPython.Runtime {
         /// in the sequence seq. The separator between elements is the 
         /// string providing this method
         /// </summary>
-        public ByteArray/*!*/ join(object/*!*/ sequence) {
-            IEnumerator seq = PythonOps.GetEnumerator(sequence);            
-            if (!seq.MoveNext()) {
+        public ByteArray/*!*/ join(object/*!*/ sequence)
+        {
+            IEnumerator seq = PythonOps.GetEnumerator(sequence);
+            if (!seq.MoveNext())
+            {
                 return new ByteArray();
             }
 
             // check if we have just a sequnce of just one value - if so just
             // return that value.
             object curVal = seq.Current;
-            if (!seq.MoveNext()) {
+            if (!seq.MoveNext())
+            {
                 return JoinOne(curVal);
             }
 
@@ -424,7 +524,8 @@ namespace IronPython.Runtime {
             ByteOps.AppendJoin(curVal, 0, ret);
 
             int index = 1;
-            do {
+            do
+            {
                 ret.AddRange(this);
 
                 ByteOps.AppendJoin(seq.Current, index, ret);
@@ -435,19 +536,24 @@ namespace IronPython.Runtime {
             return new ByteArray(ret);
         }
 
-        public ByteArray/*!*/ join([NotNull]List/*!*/ sequence) {
-            if (sequence.__len__() == 0) {
+        public ByteArray/*!*/ join([NotNull]List/*!*/ sequence)
+        {
+            if (sequence.__len__() == 0)
+            {
                 return new ByteArray();
             }
 
-            lock (this) {
-                if (sequence.__len__() == 1) {
+            lock (this)
+            {
+                if (sequence.__len__() == 1)
+                {
                     return JoinOne(sequence[0]);
                 }
 
                 List<byte> ret = new List<byte>();
                 ByteOps.AppendJoin(sequence._data[0], 0, ret);
-                for (int i = 1; i < sequence._size; i++) {
+                for (int i = 1; i < sequence._size; i++)
+                {
                     ret.AddRange(this);
                     ByteOps.AppendJoin(sequence._data[i], i, ret);
                 }
@@ -456,41 +562,52 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ ljust(int width) {
+        public ByteArray/*!*/ ljust(int width)
+        {
             return ljust(width, (byte)' ');
         }
 
-        public ByteArray/*!*/ ljust(int width, [NotNull]string/*!*/ fillchar) {
+        public ByteArray/*!*/ ljust(int width, [NotNull]string/*!*/ fillchar)
+        {
             return ljust(width, fillchar.ToByte("ljust", 2));
         }
 
-        public ByteArray/*!*/ ljust(int width, IList<byte>/*!*/ fillchar) {
+        public ByteArray/*!*/ ljust(int width, IList<byte>/*!*/ fillchar)
+        {
             return ljust(width, fillchar.ToByte("ljust", 2));
         }
 
-        private ByteArray/*!*/ ljust(int width, byte fillchar) {
-            lock (this) {
+        private ByteArray/*!*/ ljust(int width, byte fillchar)
+        {
+            lock (this)
+            {
                 int spaces = width - _bytes.Count;
 
                 List<byte> ret = new List<byte>(width);
                 ret.AddRange(_bytes);
-                for (int i = 0; i < spaces; i++) {
+                for (int i = 0; i < spaces; i++)
+                {
                     ret.Add(fillchar);
                 }
                 return new ByteArray(ret);
             }
         }
 
-        public ByteArray/*!*/ lower() {
-            lock (this) {
+        public ByteArray/*!*/ lower()
+        {
+            lock (this)
+            {
                 return new ByteArray(_bytes.ToLower());
             }
         }
 
-        public ByteArray/*!*/ lstrip() {
-            lock (this) {
+        public ByteArray/*!*/ lstrip()
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.LeftStrip();
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -498,10 +615,13 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ lstrip([BytesConversionNoString]IList<byte> bytes) {
-            lock (this) {
+        public ByteArray/*!*/ lstrip([BytesConversionNoString]IList<byte> bytes)
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.LeftStrip(bytes);
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -509,20 +629,28 @@ namespace IronPython.Runtime {
             }
         }
 
-        public PythonTuple/*!*/ partition(IList<byte>/*!*/ sep) {
-            if (sep == null) {
+        public PythonTuple/*!*/ partition(IList<byte>/*!*/ sep)
+        {
+            if (sep == null)
+            {
                 throw PythonOps.TypeError("expected string, got NoneType");
-            } else if (sep.Count == 0) {
+            }
+            else if (sep.Count == 0)
+            {
                 throw PythonOps.ValueError("empty separator");
             }
 
             object[] obj = new object[3] { new ByteArray(), new ByteArray(), new ByteArray() };
 
-            if (_bytes.Count != 0) {
+            if (_bytes.Count != 0)
+            {
                 int index = find(sep);
-                if (index == -1) {
+                if (index == -1)
+                {
                     obj[0] = this;
-                } else {
+                }
+                else
+                {
                     obj[0] = new ByteArray(_bytes.Substring(0, index));
                     obj[1] = sep;
                     obj[2] = new ByteArray(_bytes.Substring(index + sep.Count, _bytes.Count - index - sep.Count));
@@ -532,22 +660,29 @@ namespace IronPython.Runtime {
             return new PythonTuple(obj);
         }
 
-        public PythonTuple/*!*/ partition([NotNull]List/*!*/ sep) {
+        public PythonTuple/*!*/ partition([NotNull]List/*!*/ sep)
+        {
             return partition(GetBytes(sep));
         }
 
-        public ByteArray/*!*/ replace([BytesConversion]IList<byte>/*!*/ old, [BytesConversion]IList<byte> @new) {
-            if (old == null) {
+        public ByteArray/*!*/ replace([BytesConversion]IList<byte>/*!*/ old, [BytesConversion]IList<byte> @new)
+        {
+            if (old == null)
+            {
                 throw PythonOps.TypeError("expected bytes or bytearray, got NoneType");
             }
 
             return replace(old, @new, _bytes.Count);
         }
 
-        public ByteArray/*!*/ replace([BytesConversion]IList<byte>/*!*/ old, [BytesConversion]IList<byte>/*!*/ @new, int count) {
-            if (old == null) {
+        public ByteArray/*!*/ replace([BytesConversion]IList<byte>/*!*/ old, [BytesConversion]IList<byte>/*!*/ @new, int count)
+        {
+            if (old == null)
+            {
                 throw PythonOps.TypeError("expected bytes or bytearray, got NoneType");
-            } else if (count == 0) {
+            }
+            else if (count == 0)
+            {
                 return CopyThis();
             }
 
@@ -555,61 +690,76 @@ namespace IronPython.Runtime {
         }
 
 
-        public int rfind([BytesConversion]IList<byte>/*!*/ sub) {
+        public int rfind([BytesConversion]IList<byte>/*!*/ sub)
+        {
             return rfind(sub, 0, _bytes.Count);
         }
 
-        public int rfind([BytesConversion]IList<byte>/*!*/ sub, int start) {
+        public int rfind([BytesConversion]IList<byte>/*!*/ sub, int start)
+        {
             return rfind(sub, start, _bytes.Count);
         }
 
-        public int rfind([BytesConversion]IList<byte>/*!*/ sub, int start, int end) {
-            lock (this) {
+        public int rfind([BytesConversion]IList<byte>/*!*/ sub, int start, int end)
+        {
+            lock (this)
+            {
                 return _bytes.ReverseFind(sub, start, end);
             }
         }
 
-        public int rindex([BytesConversion]IList<byte>/*!*/ sub) {
+        public int rindex([BytesConversion]IList<byte>/*!*/ sub)
+        {
             return rindex(sub, 0, _bytes.Count);
         }
 
-        public int rindex([BytesConversion]IList<byte>/*!*/ sub, int start) {
+        public int rindex([BytesConversion]IList<byte>/*!*/ sub, int start)
+        {
             return rindex(sub, start, _bytes.Count);
         }
 
-        public int rindex([BytesConversion]IList<byte>/*!*/ sub, int start, int end) {
+        public int rindex([BytesConversion]IList<byte>/*!*/ sub, int start, int end)
+        {
             int ret = rfind(sub, start, end);
-            
-            if (ret == -1) {
+
+            if (ret == -1)
+            {
                 throw PythonOps.ValueError("substring {0} not found in {1}", sub, this);
             }
 
             return ret;
         }
 
-        public ByteArray/*!*/ rjust(int width) {
+        public ByteArray/*!*/ rjust(int width)
+        {
             return rjust(width, (byte)' ');
         }
 
-        public ByteArray/*!*/ rjust(int width, [NotNull]string/*!*/ fillchar) {
+        public ByteArray/*!*/ rjust(int width, [NotNull]string/*!*/ fillchar)
+        {
             return rjust(width, fillchar.ToByte("rjust", 2));
         }
 
-        public ByteArray/*!*/ rjust(int width, [BytesConversion]IList<byte>/*!*/ fillchar) {
+        public ByteArray/*!*/ rjust(int width, [BytesConversion]IList<byte>/*!*/ fillchar)
+        {
             return rjust(width, fillchar.ToByte("rjust", 2));
         }
 
-        private ByteArray/*!*/ rjust(int width, int fillchar) {
+        private ByteArray/*!*/ rjust(int width, int fillchar)
+        {
             byte fill = fillchar.ToByteChecked();
 
-            lock (this) {
+            lock (this)
+            {
                 int spaces = width - _bytes.Count;
-                if (spaces <= 0) {
+                if (spaces <= 0)
+                {
                     return CopyThis();
                 }
 
                 List<byte> ret = new List<byte>(width);
-                for (int i = 0; i < spaces; i++) {
+                for (int i = 0; i < spaces; i++)
+                {
                     ret.Add(fill);
                 }
                 ret.AddRange(_bytes);
@@ -617,20 +767,29 @@ namespace IronPython.Runtime {
             }
         }
 
-        public PythonTuple/*!*/ rpartition(IList<byte>/*!*/ sep) {
-            if (sep == null) {
+        public PythonTuple/*!*/ rpartition(IList<byte>/*!*/ sep)
+        {
+            if (sep == null)
+            {
                 throw PythonOps.TypeError("expected string, got NoneType");
-            } else if (sep.Count == 0) {
+            }
+            else if (sep.Count == 0)
+            {
                 throw PythonOps.ValueError("empty separator");
             }
 
-            lock (this) {
+            lock (this)
+            {
                 object[] obj = new object[3] { new ByteArray(), new ByteArray(), new ByteArray() };
-                if (_bytes.Count != 0) {
+                if (_bytes.Count != 0)
+                {
                     int index = rfind(sep);
-                    if (index == -1) {
+                    if (index == -1)
+                    {
                         obj[2] = this;
-                    } else {
+                    }
+                    else
+                    {
                         obj[0] = new ByteArray(_bytes.Substring(0, index));
                         obj[1] = new ByteArray(new List<byte>(sep));
                         obj[2] = new ByteArray(_bytes.Substring(index + sep.Count, Count - index - sep.Count));
@@ -640,28 +799,36 @@ namespace IronPython.Runtime {
             }
         }
 
-        public PythonTuple/*!*/ rpartition([NotNull]List/*!*/ sep) {
+        public PythonTuple/*!*/ rpartition([NotNull]List/*!*/ sep)
+        {
             return rpartition(GetBytes(sep));
         }
 
-        public List/*!*/ rsplit() {
-            lock (this) {
+        public List/*!*/ rsplit()
+        {
+            lock (this)
+            {
                 return _bytes.SplitInternal((byte[])null, -1, x => new ByteArray(x));
             }
         }
 
-        public List/*!*/ rsplit([BytesConversionNoString]IList<byte>/*!*/ sep) {
+        public List/*!*/ rsplit([BytesConversionNoString]IList<byte>/*!*/ sep)
+        {
             return rsplit(sep, -1);
         }
 
-        public List/*!*/ rsplit([BytesConversionNoString]IList<byte>/*!*/ sep, int maxsplit) {
+        public List/*!*/ rsplit([BytesConversionNoString]IList<byte>/*!*/ sep, int maxsplit)
+        {
             return _bytes.RightSplit(sep, maxsplit, x => new ByteArray(new List<byte>(x)));
         }
 
-        public ByteArray/*!*/ rstrip() {
-            lock (this) {
+        public ByteArray/*!*/ rstrip()
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.RightStrip();
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -669,10 +836,13 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/  rstrip([BytesConversionNoString]IList<byte> bytes) {
-            lock (this) {
+        public ByteArray/*!*/  rstrip([BytesConversionNoString]IList<byte> bytes)
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.RightStrip(bytes);
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -680,44 +850,59 @@ namespace IronPython.Runtime {
             }
         }
 
-        public List/*!*/ split() {
-            lock (this) {
+        public List/*!*/ split()
+        {
+            lock (this)
+            {
                 return _bytes.SplitInternal((byte[])null, -1, x => new ByteArray(x));
             }
         }
 
-        public List/*!*/ split([BytesConversionNoString]IList<byte> sep) {
+        public List/*!*/ split([BytesConversionNoString]IList<byte> sep)
+        {
             return split(sep, -1);
         }
 
-        public List/*!*/ split([BytesConversionNoString]IList<byte> sep, int maxsplit) {
-            lock (this) {
+        public List/*!*/ split([BytesConversionNoString]IList<byte> sep, int maxsplit)
+        {
+            lock (this)
+            {
                 return _bytes.Split(sep, maxsplit, x => new ByteArray(x));
             }
         }
 
-        public List/*!*/ splitlines() {
+        public List/*!*/ splitlines()
+        {
             return splitlines(false);
         }
 
-        public List/*!*/ splitlines(bool keepends) {
-            lock (this) {
+        public List/*!*/ splitlines(bool keepends)
+        {
+            lock (this)
+            {
                 return _bytes.SplitLines(keepends, x => new ByteArray(x));
             }
         }
 
-        public bool startswith([BytesConversion]IList<byte>/*!*/ prefix) {
-            lock (this) {
+        public bool startswith([BytesConversion]IList<byte>/*!*/ prefix)
+        {
+            lock (this)
+            {
                 return _bytes.StartsWith(prefix);
             }
         }
 
-        public bool startswith([BytesConversion]IList<byte>/*!*/ prefix, int start) {
-            lock (this) {
+        public bool startswith([BytesConversion]IList<byte>/*!*/ prefix, int start)
+        {
+            lock (this)
+            {
                 int len = Count;
-                if (start > len) {
+                if (start > len)
+                {
                     return false;
-                } else if (start < 0) {
+                }
+                else if (start < 0)
+                {
                     start += len;
                     if (start < 0) start = 0;
                 }
@@ -725,34 +910,45 @@ namespace IronPython.Runtime {
             }
         }
 
-        public bool startswith([BytesConversion]IList<byte>/*!*/ prefix, int start, int end) {
-            lock (this) {
+        public bool startswith([BytesConversion]IList<byte>/*!*/ prefix, int start, int end)
+        {
+            lock (this)
+            {
                 return _bytes.StartsWith(prefix, start, end);
             }
         }
 
-        public bool startswith(PythonTuple/*!*/ prefix) {
-            lock (this) {
+        public bool startswith(PythonTuple/*!*/ prefix)
+        {
+            lock (this)
+            {
                 return _bytes.StartsWith(prefix);
             }
         }
 
-        public bool startswith(PythonTuple/*!*/ prefix, int start) {
-            lock (this) {
+        public bool startswith(PythonTuple/*!*/ prefix, int start)
+        {
+            lock (this)
+            {
                 return _bytes.StartsWith(prefix, start);
             }
         }
 
-        public bool startswith(PythonTuple/*!*/ prefix, int start, int end) {
-            lock (this) {
+        public bool startswith(PythonTuple/*!*/ prefix, int start, int end)
+        {
+            lock (this)
+            {
                 return _bytes.StartsWith(prefix, start, end);
             }
         }
 
-        public ByteArray/*!*/ strip() {
-            lock (this) {
+        public ByteArray/*!*/ strip()
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.Strip();
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -760,10 +956,13 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ strip([BytesConversionNoString]IList<byte> chars) {
-            lock (this) {
+        public ByteArray/*!*/ strip([BytesConversionNoString]IList<byte> chars)
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.Strip(chars);
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -771,17 +970,22 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ swapcase() {
-            lock (this) {
+        public ByteArray/*!*/ swapcase()
+        {
+            lock (this)
+            {
                 return new ByteArray(_bytes.SwapCase());
             }
         }
 
-        public ByteArray/*!*/ title() {
-            lock (this) {
+        public ByteArray/*!*/ title()
+        {
+            lock (this)
+            {
                 List<byte> res = _bytes.Title();
 
-                if (res == null) {
+                if (res == null)
+                {
                     return CopyThis();
                 }
 
@@ -789,14 +993,19 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ translate([BytesConversion]IList<byte>/*!*/ table) {
-           
-            lock (this) {
-                if (table != null) {
-                    if (table.Count != 256) {
+        public ByteArray/*!*/ translate([BytesConversion]IList<byte>/*!*/ table)
+        {
+
+            lock (this)
+            {
+                if (table != null)
+                {
+                    if (table.Count != 256)
+                    {
                         throw PythonOps.ValueError("translation table must be 256 characters long");
                     }
-                    else if (Count == 0) {
+                    else if (Count == 0)
+                    {
                         return CopyThis();
                     }
                 }
@@ -806,29 +1015,38 @@ namespace IronPython.Runtime {
         }
 
 
-        public ByteArray/*!*/ translate([BytesConversion]IList<byte>/*!*/ table, [BytesConversion]IList<byte>/*!*/ deletechars) {
-            if (table == null && deletechars == null) {
+        public ByteArray/*!*/ translate([BytesConversion]IList<byte>/*!*/ table, [BytesConversion]IList<byte>/*!*/ deletechars)
+        {
+            if (table == null && deletechars == null)
+            {
                 throw PythonOps.TypeError("expected bytearray or bytes, got NoneType");
             }
-            else if (deletechars == null) {
+            else if (deletechars == null)
+            {
                 throw PythonOps.TypeError("expected bytes or bytearray, got None");
             }
-            
-            lock (this) {
+
+            lock (this)
+            {
                 return new ByteArray(_bytes.Translate(table, deletechars));
             }
         }
 
-        public ByteArray/*!*/ upper() {
-            lock (this) {
+        public ByteArray/*!*/ upper()
+        {
+            lock (this)
+            {
                 return new ByteArray(_bytes.ToUpper());
             }
         }
 
-        public ByteArray/*!*/ zfill(int width) {
-            lock (this) {
+        public ByteArray/*!*/ zfill(int width)
+        {
+            lock (this)
+            {
                 int spaces = width - Count;
-                if (spaces <= 0) {
+                if (spaces <= 0)
+                {
                     return CopyThis();
                 }
 
@@ -836,28 +1054,38 @@ namespace IronPython.Runtime {
             }
         }
 
-        public int __alloc__() {
-            if (_bytes.Count == 0) {
+        public int __alloc__()
+        {
+            if (_bytes.Count == 0)
+            {
                 return 0;
             }
 
             return _bytes.Count + 1;
         }
 
-        public bool __contains__([BytesConversionNoString]IList<byte> bytes) {
+        public bool __contains__([BytesConversionNoString]IList<byte> bytes)
+        {
             return this.IndexOf(bytes, 0) != -1;
         }
 
-        public bool __contains__(int value) {
+        public bool __contains__(int value)
+        {
             return IndexOf(value.ToByteChecked()) != -1;
         }
 
-        public bool __contains__(CodeContext/*!*/ context, object value) {
-            if (value is Extensible<int>) {
+        public bool __contains__(CodeContext/*!*/ context, object value)
+        {
+            if (value is Extensible<int>)
+            {
                 return IndexOf(((Extensible<int>)value).Value.ToByteChecked()) != -1;
-            } else if (value is BigInteger) {
+            }
+            else if (value is BigInteger)
+            {
                 return IndexOf(((BigInteger)value).ToByteChecked()) != -1;
-            } else if (value is Extensible<BigInteger>) {
+            }
+            else if (value is Extensible<BigInteger>)
+            {
                 return IndexOf(((Extensible<BigInteger>)value).Value.ToByteChecked()) != -1;
             }
 
@@ -865,9 +1093,10 @@ namespace IronPython.Runtime {
                 PythonContext.GetContext(context).PythonOptions.Python30 ? PythonTypeOps.GetOldName(value) : PythonTypeOps.GetName(value));
         }
 
-        public PythonTuple __reduce__(CodeContext/*!*/ context) {
+        public PythonTuple __reduce__(CodeContext/*!*/ context)
+        {
             return PythonTuple.MakeTuple(
-                DynamicHelpers.GetPythonType(this), 
+                DynamicHelpers.GetPythonType(this),
                 PythonTuple.MakeTuple(
                     PythonOps.MakeString(this),
                     "latin-1"
@@ -876,33 +1105,41 @@ namespace IronPython.Runtime {
             );
         }
 
-        public virtual string/*!*/ __repr__(CodeContext/*!*/ context) {
-            lock (this) {
+        public virtual string/*!*/ __repr__(CodeContext/*!*/ context)
+        {
+            lock (this)
+            {
                 return "bytearray(" + _bytes.BytesRepr() + ")";
             }
         }
 
-        public static ByteArray operator +(ByteArray self, ByteArray other) {
-            if (self == null) {
+        public static ByteArray operator +(ByteArray self, ByteArray other)
+        {
+            if (self == null)
+            {
                 throw PythonOps.TypeError("expected ByteArray, got None");
             }
-            
+
             List<byte> bytes;
 
-            lock (self) {
+            lock (self)
+            {
                 bytes = new List<byte>(self._bytes);
             }
-            lock (other) {
+            lock (other)
+            {
                 bytes.AddRange(other._bytes);
             }
 
             return new ByteArray(bytes);
         }
 
-        public static ByteArray operator +(ByteArray self, Bytes other) {
+        public static ByteArray operator +(ByteArray self, Bytes other)
+        {
             List<byte> bytes;
 
-            lock (self) {
+            lock (self)
+            {
                 bytes = new List<byte>(self._bytes);
             }
 
@@ -911,9 +1148,12 @@ namespace IronPython.Runtime {
             return new ByteArray(bytes);
         }
 
-        public static ByteArray operator *(ByteArray x, int y) {
-            lock (x) {
-                if (y == 1) {
+        public static ByteArray operator *(ByteArray x, int y)
+        {
+            lock (x)
+            {
+                if (y == 1)
+                {
                     return x.CopyThis();
                 }
 
@@ -921,109 +1161,144 @@ namespace IronPython.Runtime {
             }
         }
 
-        public static ByteArray operator *(int x, ByteArray y) {
+        public static ByteArray operator *(int x, ByteArray y)
+        {
             return y * x;
         }
 
-        public static bool operator >(ByteArray/*!*/ x, ByteArray y) {
-            if (y == null) {
+        public static bool operator >(ByteArray/*!*/ x, ByteArray y)
+        {
+            if (y == null)
+            {
                 return true;
             }
 
-            using (new OrderedLocker(x, y)) {
+            using (new OrderedLocker(x, y))
+            {
                 return x._bytes.Compare(y._bytes) > 0;
             }
         }
 
-        public static bool operator <(ByteArray/*!*/ x, ByteArray y) {
-            if (y == null) {
+        public static bool operator <(ByteArray/*!*/ x, ByteArray y)
+        {
+            if (y == null)
+            {
                 return false;
             }
 
-            using (new OrderedLocker(x, y)) {
+            using (new OrderedLocker(x, y))
+            {
                 return x._bytes.Compare(y._bytes) < 0;
             }
         }
 
-        public static bool operator >=(ByteArray/*!*/ x, ByteArray y) {
-            if (y == null) {
+        public static bool operator >=(ByteArray/*!*/ x, ByteArray y)
+        {
+            if (y == null)
+            {
                 return true;
             }
-            using (new OrderedLocker(x, y)) {
+            using (new OrderedLocker(x, y))
+            {
                 return x._bytes.Compare(y._bytes) >= 0;
             }
         }
 
-        public static bool operator <=(ByteArray/*!*/ x, ByteArray y) {
-            if (y == null) {
+        public static bool operator <=(ByteArray/*!*/ x, ByteArray y)
+        {
+            if (y == null)
+            {
                 return false;
             }
-            using (new OrderedLocker(x, y)) {
+            using (new OrderedLocker(x, y))
+            {
                 return x._bytes.Compare(y._bytes) <= 0;
             }
         }
 
-        public static bool operator >(ByteArray/*!*/ x, Bytes y) {
-            if (y == null) {
+        public static bool operator >(ByteArray/*!*/ x, Bytes y)
+        {
+            if (y == null)
+            {
                 return true;
             }
-            lock (x) {
+            lock (x)
+            {
                 return x._bytes.Compare(y) > 0;
             }
         }
 
-        public static bool operator <(ByteArray/*!*/ x, Bytes y) {
-            if (y == null) {
+        public static bool operator <(ByteArray/*!*/ x, Bytes y)
+        {
+            if (y == null)
+            {
                 return false;
             }
-            lock (x) {
+            lock (x)
+            {
                 return x._bytes.Compare(y) < 0;
             }
         }
 
-        public static bool operator >=(ByteArray/*!*/ x, Bytes y) {
-            if (y == null) {
+        public static bool operator >=(ByteArray/*!*/ x, Bytes y)
+        {
+            if (y == null)
+            {
                 return true;
             }
-            lock (x) {
+            lock (x)
+            {
                 return x._bytes.Compare(y) >= 0;
             }
         }
 
-        public static bool operator <=(ByteArray/*!*/ x, Bytes y) {
-            if (y == null) {
+        public static bool operator <=(ByteArray/*!*/ x, Bytes y)
+        {
+            if (y == null)
+            {
                 return false;
             }
-            lock (x) {
+            lock (x)
+            {
                 return x._bytes.Compare(y) <= 0;
             }
         }
 
-        public object this[int index] {
-            get {
-                lock (this) {
+        public object this[int index]
+        {
+            get
+            {
+                lock (this)
+                {
                     return ScriptingRuntimeHelpers.Int32ToObject((int)_bytes[PythonOps.FixIndex(index, _bytes.Count)]);
                 }
             }
-            set {
-                lock (this) {
+            set
+            {
+                lock (this)
+                {
                     _bytes[PythonOps.FixIndex(index, _bytes.Count)] = GetByte(value);
                 }
             }
         }
 
-        public object this[BigInteger index] {
-            get {
+        public object this[BigInteger index]
+        {
+            get
+            {
                 int iVal;
-                if (index.AsInt32(out iVal)) {
+                if (index.AsInt32(out iVal))
+                {
                     return this[iVal];
                 }
 
                 throw PythonOps.IndexError("cannot fit long in index");
             }
-            set {
+            set
+            {
                 int iVal;
-                if (index.AsInt32(out iVal)) {
+                if (index.AsInt32(out iVal))
+                {
                     this[iVal] = value;
                     return;
                 }
@@ -1032,62 +1307,85 @@ namespace IronPython.Runtime {
             }
         }
 
-        public object this[Slice/*!*/ slice] {
-            get {
-                lock (this) {
+        public object this[Slice/*!*/ slice]
+        {
+            get
+            {
+                lock (this)
+                {
                     List<byte> res = _bytes.Slice(slice);
-                    if (res == null) {
+                    if (res == null)
+                    {
                         return new ByteArray();
                     }
 
                     return new ByteArray(res);
                 }
             }
-            set {
-                if (slice == null) {
+            set
+            {
+                if (slice == null)
+                {
                     throw PythonOps.TypeError("bytearray indices must be integer or slice, not None");
                 }
-                
+
                 // get a list of the bytes we're going to assign into the slice.  We accept:
                 //      integers, longs, etc... - fill in an array of 0 bytes
                 //      list of bytes, indexables, etc...
 
                 IList<byte> list = value as IList<byte>;
-                if (list == null) {
+                if (list == null)
+                {
                     int? iVal = null;
-                    if (value is int) {
+                    if (value is int)
+                    {
                         iVal = (int)value;
-                    } else if (value is Extensible<int>) {
+                    }
+                    else if (value is Extensible<int>)
+                    {
                         iVal = ((Extensible<int>)value).Value;
-                    } else if (value is BigInteger) {
+                    }
+                    else if (value is BigInteger)
+                    {
                         int intval;
-                        if (((BigInteger)value).AsInt32(out intval)) {
+                        if (((BigInteger)value).AsInt32(out intval))
+                        {
                             iVal = intval;
                         }
                     }
 
-                    if (iVal != null) {
+                    if (iVal != null)
+                    {
                         List<byte> newlist = new List<byte>();
                         newlist.Capacity = iVal.Value;
-                        for (int i = 0; i < iVal; i++) {
+                        for (int i = 0; i < iVal; i++)
+                        {
                             newlist.Add(0);
                         }
                         list = newlist;
-                    } else {
+                    }
+                    else
+                    {
                         IEnumerator ie = PythonOps.GetEnumerator(value);
                         list = new List<byte>();
-                        while (ie.MoveNext()) {
+                        while (ie.MoveNext())
+                        {
                             list.Add(GetByte(ie.Current));
                         }
                     }
                 }
 
-                lock (this) {
-                    if (slice.step != null) {
+                lock (this)
+                {
+                    if (slice.step != null)
+                    {
                         // try to assign back to self: make a copy first
-                        if (this == list) {
+                        if (this == list)
+                        {
                             value = CopyThis();
-                        } else if (list.Count == 0) {
+                        }
+                        else if (list.Count == 0)
+                        {
                             DeleteItem(slice);
                             return;
                         }
@@ -1098,46 +1396,60 @@ namespace IronPython.Runtime {
                         slice.indices(_bytes.Count, out start, out stop, out step);
 
                         int n = (step > 0 ? (stop - start + step - 1) : (stop - start + step + 1)) / step;
-                        
+
                         // we don't use slice.Assign* helpers here because bytearray has different assignment semantics.
 
-                        if (list.Count < n) {
+                        if (list.Count < n)
+                        {
                             throw PythonOps.ValueError("too few items in the enumerator. need {0} have {1}", n, castedVal.Count);
                         }
 
-                        for (int i = 0, index = start; i < castedVal.Count; i++, index += step) {
-                            if (i >= n) {
-                                if (index == _bytes.Count) {
+                        for (int i = 0, index = start; i < castedVal.Count; i++, index += step)
+                        {
+                            if (i >= n)
+                            {
+                                if (index == _bytes.Count)
+                                {
                                     _bytes.Add(castedVal[i]);
-                                } else {
+                                }
+                                else
+                                {
                                     _bytes.Insert(index, castedVal[i]);
                                 }
-                            } else {
+                            }
+                            else
+                            {
                                 _bytes[index] = castedVal[i];
                             }
                         }
-                    } else {
+                    }
+                    else
+                    {
                         int start, stop, step;
                         slice.indices(_bytes.Count, out start, out stop, out step);
-                        
+
                         SliceNoStep(start, stop, list);
                     }
                 }
             }
         }
-        
+
         [SpecialName]
-        public void DeleteItem(int index) {
+        public void DeleteItem(int index)
+        {
             _bytes.RemoveAt(PythonOps.FixIndex(index, _bytes.Count));
         }
 
         [SpecialName]
-        public void DeleteItem(Slice/*!*/ slice) {
-            if (slice == null) {
+        public void DeleteItem(Slice/*!*/ slice)
+        {
+            if (slice == null)
+            {
                 throw PythonOps.TypeError("list indices must be integers or slices");
             }
 
-            lock (this) {
+            lock (this)
+            {
                 int start, stop, step;
                 // slice is sealed, indices can't be user code...
                 slice.indices(_bytes.Count, out start, out stop, out step);
@@ -1145,24 +1457,32 @@ namespace IronPython.Runtime {
                 if (step > 0 && (start >= stop)) return;
                 if (step < 0 && (start <= stop)) return;
 
-                if (step == 1) {
+                if (step == 1)
+                {
                     int i = start;
-                    for (int j = stop; j < _bytes.Count; j++, i++) {
+                    for (int j = stop; j < _bytes.Count; j++, i++)
+                    {
                         _bytes[i] = _bytes[j];
                     }
                     _bytes.RemoveRange(i, stop - start);
                     return;
-                } else if (step == -1) {
+                }
+                else if (step == -1)
+                {
                     int i = stop + 1;
-                    for (int j = start + 1; j < _bytes.Count; j++, i++) {
+                    for (int j = start + 1; j < _bytes.Count; j++, i++)
+                    {
                         _bytes[i] = _bytes[j];
                     }
                     _bytes.RemoveRange(i, start - stop);
                     return;
-                } else if (step < 0) {
+                }
+                else if (step < 0)
+                {
                     // find "start" we will skip in the 1,2,3,... order
                     int i = start;
-                    while (i > stop) {
+                    while (i > stop)
+                    {
                         i += step;
                     }
                     i -= step;
@@ -1179,14 +1499,18 @@ namespace IronPython.Runtime {
                 // move: the next position we will check
                 curr = skip = move = start;
 
-                while (curr < stop && move < stop) {
-                    if (move != skip) {
+                while (curr < stop && move < stop)
+                {
+                    if (move != skip)
+                    {
                         _bytes[curr++] = _bytes[move];
-                    } else
+                    }
+                    else
                         skip += step;
                     move++;
                 }
-                while (stop < _bytes.Count) {
+                while (stop < _bytes.Count)
+                {
                     _bytes[curr++] = _bytes[stop++];
                 }
                 _bytes.RemoveRange(curr, _bytes.Count - curr);
@@ -1197,62 +1521,79 @@ namespace IronPython.Runtime {
 
         #region Implementation Details
 
-        private static ByteArray/*!*/ JoinOne(object/*!*/ curVal) {
-            if (!(curVal is IList<byte>)) {
+        private static ByteArray/*!*/ JoinOne(object/*!*/ curVal)
+        {
+            if (!(curVal is IList<byte>))
+            {
                 throw PythonOps.TypeError("can only join an iterable of bytes");
             }
 
             return new ByteArray(new List<byte>(curVal as IList<byte>));
         }
 
-        private ByteArray/*!*/ CopyThis() {
+        private ByteArray/*!*/ CopyThis()
+        {
             return new ByteArray(new List<byte>(_bytes));
         }
 
-        private void SliceNoStep(int start, int stop, IList<byte>/*!*/ value) {
+        private void SliceNoStep(int start, int stop, IList<byte>/*!*/ value)
+        {
             // always copy from a List object, even if it's a copy of some user defined enumerator.  This
             // makes it easy to hold the lock for the duration fo the copy.
             IList<byte> other = GetBytes(value);
 
-            lock (this) {
-                if (start > stop) {
+            lock (this)
+            {
+                if (start > stop)
+                {
                     int newSize = Count + other.Count;
 
                     List<byte> newData = new List<byte>(newSize);
                     int reading = 0;
-                    for (reading = 0; reading < start; reading++) {
+                    for (reading = 0; reading < start; reading++)
+                    {
                         newData.Add(_bytes[reading]);
                     }
 
-                    for (int i = 0; i < other.Count; i++) {
+                    for (int i = 0; i < other.Count; i++)
+                    {
                         newData.Add(other[i]);
                     }
 
-                    for (; reading < Count; reading++) {
+                    for (; reading < Count; reading++)
+                    {
                         newData.Add(_bytes[reading]);
                     }
 
                     _bytes = newData;
-                } else if ((stop - start) == other.Count) {
+                }
+                else if ((stop - start) == other.Count)
+                {
                     // we are simply replacing values, this is fast...
-                    for (int i = 0; i < other.Count; i++) {
+                    for (int i = 0; i < other.Count; i++)
+                    {
                         _bytes[i + start] = other[i];
                     }
-                } else {
+                }
+                else
+                {
                     // we are resizing the array (either bigger or smaller), we 
                     // will copy the data array and replace it all at once.
                     int newSize = Count - (stop - start) + other.Count;
 
                     List<byte> newData = new List<byte>(newSize);
-                    for (int i = 0; i < start; i++) {
+                    for (int i = 0; i < start; i++)
+                    {
                         newData.Add(_bytes[i]);
                     }
 
-                    for (int i = 0; i < other.Count; i++) {
+                    for (int i = 0; i < other.Count; i++)
+                    {
                         newData.Add(other[i]);
                     }
 
-                    for (int i = stop; i < Count; i++) {
+                    for (int i = stop; i < Count; i++)
+                    {
                         newData.Add(_bytes[i]);
                     }
 
@@ -1261,32 +1602,39 @@ namespace IronPython.Runtime {
             }
         }
 
-        private static byte GetByte(object/*!*/ value) {
-            if (value is double || value is Extensible<double> || value is float) {
+        private static byte GetByte(object/*!*/ value)
+        {
+            if (value is double || value is Extensible<double> || value is float)
+            {
                 throw PythonOps.TypeError("an integer or string of size 1 is required");
             }
             return ByteOps.GetByteListOk(value);
         }
 
-        private static IList<byte>/*!*/ GetBytes(object/*!*/ value) {
+        private static IList<byte>/*!*/ GetBytes(object/*!*/ value)
+        {
             ListGenericWrapper<byte> genWrapper = value as ListGenericWrapper<byte>;
-            if (genWrapper == null && value is IList<byte>) {
+            if (genWrapper == null && value is IList<byte>)
+            {
                 return (IList<byte>)value;
             }
 
             var strValue = value as string;
-            if (strValue != null) {
+            if (strValue != null)
+            {
                 return strValue.MakeByteArray();
             }
 
             var esValue = value as Extensible<string>;
-            if (esValue != null) {
+            if (esValue != null)
+            {
                 return esValue.Value.MakeByteArray();
             }
 
             List<byte> ret = new List<byte>();
             IEnumerator ie = PythonOps.GetEnumerator(value);
-            while (ie.MoveNext()) {
+            while (ie.MoveNext())
+            {
                 ret.Add(GetByte(ie.Current));
             }
             return ret;
@@ -1297,27 +1645,34 @@ namespace IronPython.Runtime {
         #region IList<byte> Members
 
         [PythonHidden]
-        public int IndexOf(byte item) {
-            lock (this) {
+        public int IndexOf(byte item)
+        {
+            lock (this)
+            {
                 return _bytes.IndexOf(item);
             }
         }
 
         [PythonHidden]
-        public void Insert(int index, byte item) {
+        public void Insert(int index, byte item)
+        {
             _bytes.Insert(index, item);
         }
 
         [PythonHidden]
-        public void RemoveAt(int index) {
+        public void RemoveAt(int index)
+        {
             _bytes.RemoveAt(index);
         }
 
-        byte IList<byte>.this[int index] {
-            get {
+        byte IList<byte>.this[int index]
+        {
+            get
+            {
                 return _bytes[index];
             }
-            set {
+            set
+            {
                 _bytes[index] = value;
             }
         }
@@ -1327,64 +1682,80 @@ namespace IronPython.Runtime {
         #region ICollection<byte> Members
 
         [PythonHidden]
-        public void Add(byte item) {
-            lock (this) {
+        public void Add(byte item)
+        {
+            lock (this)
+            {
                 _bytes.Add(item);
             }
         }
 
         [PythonHidden]
-        public void Clear() {
-            lock (this) {
+        public void Clear()
+        {
+            lock (this)
+            {
                 _bytes.Clear();
             }
         }
 
         [PythonHidden]
-        public bool Contains(byte item) {
-            lock (this) {
+        public bool Contains(byte item)
+        {
+            lock (this)
+            {
                 return _bytes.Contains(item);
             }
         }
 
         [PythonHidden]
-        public void CopyTo(byte[]/*!*/ array, int arrayIndex) {
-            lock (this) {
+        public void CopyTo(byte[]/*!*/ array, int arrayIndex)
+        {
+            lock (this)
+            {
                 _bytes.CopyTo(array, arrayIndex);
             }
         }
 
-        public int Count {
+        public int Count
+        {
             [PythonHidden]
-            get { 
-                lock (this) { 
-                    return _bytes.Count; 
-                } 
+            get
+            {
+                lock (this)
+                {
+                    return _bytes.Count;
+                }
             }
         }
 
-        public bool IsReadOnly {
+        public bool IsReadOnly
+        {
             [PythonHidden]
             get { return false; }
         }
 
         [PythonHidden]
-        public bool Remove(byte item) {
-            lock (this) {
+        public bool Remove(byte item)
+        {
+            lock (this)
+            {
                 return _bytes.Remove(item);
             }
         }
 
         #endregion
 
-        public IEnumerator __iter__() {
+        public IEnumerator __iter__()
+        {
             return PythonOps.BytesIntEnumerator(this).Key;
         }
 
         #region IEnumerable<byte> Members
 
         [PythonHidden]
-        public IEnumerator<byte>/*!*/ GetEnumerator() {
+        public IEnumerator<byte>/*!*/ GetEnumerator()
+        {
             return _bytes.GetEnumerator();
         }
 
@@ -1392,31 +1763,39 @@ namespace IronPython.Runtime {
 
         #region IEnumerable Members
 
-        System.Collections.IEnumerator/*!*/ System.Collections.IEnumerable.GetEnumerator() {
-            return _bytes.GetEnumerator();
+        System.Collections.IEnumerator/*!*/ System.Collections.IEnumerable.GetEnumerator()
+        {
+            foreach (var _byte in _bytes)
+            {
+                yield return (int)_byte;
+            }
         }
 
         #endregion
 
         #region IValueEquality Members
 #if CLR2
-        int IValueEquality.GetValueHashCode() {
+        int IValueEquality.GetValueHashCode()
+        {
             throw PythonOps.TypeError("bytearray object is unhashable");
         }
 
-        bool IValueEquality.ValueEquals(object other) {
+        bool IValueEquality.ValueEquals(object other)
+        {
             return Equals(other);
         }
 #endif
 
         public const object __hash__ = null;
 
-        public override int GetHashCode() {
+        public override int GetHashCode()
+        {
             return (PythonTuple.MakeTuple(_bytes.ToArray())).GetHashCode();
         }
 
-        public override bool Equals(object other) {
-            IList<byte> bytes ;
+        public override bool Equals(object other)
+        {
+            IList<byte> bytes;
             if (other is string)
                 bytes = PythonOps.MakeBytes(((string)other).MakeByteArray());
             else if (other is Extensible<string>)
@@ -1424,16 +1803,22 @@ namespace IronPython.Runtime {
             else
                 bytes = other as IList<byte>;
 
-            if (bytes == null || Count != bytes.Count) {
+            if (bytes == null || Count != bytes.Count)
+            {
                 return false;
-            } else if (Count == 0) {
+            }
+            else if (Count == 0)
+            {
                 // 2 empty ByteArrays are equal
                 return true;
             }
 
-            using (new OrderedLocker(this, other)) {
-                for (int i = 0; i < Count; i++) {
-                    if (_bytes[i] != bytes[i]) {
+            using (new OrderedLocker(this, other))
+            {
+                for (int i = 0; i < Count; i++)
+                {
+                    if (_bytes[i] != bytes[i])
+                    {
                         return false;
                     }
                 }
@@ -1444,74 +1829,93 @@ namespace IronPython.Runtime {
 
         #endregion
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return _bytes.MakeString();
         }
 
         #region IBufferProtocol Members
 
-        Bytes IBufferProtocol.GetItem(int index) {
-            lock (this) {
+        Bytes IBufferProtocol.GetItem(int index)
+        {
+            lock (this)
+            {
                 return new Bytes(new[] { _bytes[PythonOps.FixIndex(index, _bytes.Count)] });
             }
         }
 
-        void IBufferProtocol.SetItem(int index, object value) {
+        void IBufferProtocol.SetItem(int index, object value)
+        {
             this[index] = value;
         }
 
-        void IBufferProtocol.SetSlice(Slice index, object value) {
+        void IBufferProtocol.SetSlice(Slice index, object value)
+        {
             this[index] = value;
         }
 
-        int IBufferProtocol.ItemCount {
-            get {
+        int IBufferProtocol.ItemCount
+        {
+            get
+            {
                 return _bytes.Count;
             }
         }
 
-        string IBufferProtocol.Format {
+        string IBufferProtocol.Format
+        {
             get { return "B"; }
         }
 
-        BigInteger IBufferProtocol.ItemSize {
+        BigInteger IBufferProtocol.ItemSize
+        {
             get { return 1; }
         }
 
-        BigInteger IBufferProtocol.NumberDimensions {
+        BigInteger IBufferProtocol.NumberDimensions
+        {
             get { return 1; }
         }
 
-        bool IBufferProtocol.ReadOnly {
+        bool IBufferProtocol.ReadOnly
+        {
             get { return false; }
         }
 
-        IList<BigInteger> IBufferProtocol.GetShape(int start, int? end) {
-            if (end != null) {
+        IList<BigInteger> IBufferProtocol.GetShape(int start, int? end)
+        {
+            if (end != null)
+            {
                 return new[] { (BigInteger)end - start };
             }
             return new[] { (BigInteger)this._bytes.Count - start };
         }
 
-        PythonTuple IBufferProtocol.Strides {
+        PythonTuple IBufferProtocol.Strides
+        {
             get { return PythonTuple.MakeTuple(1); }
         }
 
-        object IBufferProtocol.SubOffsets {
+        object IBufferProtocol.SubOffsets
+        {
             get { return null; }
         }
 
-        Bytes IBufferProtocol.ToBytes(int start, int? end) {
-            if (start == 0 && end == null) {
+        Bytes IBufferProtocol.ToBytes(int start, int? end)
+        {
+            if (start == 0 && end == null)
+            {
                 return new Bytes(this);
             }
 
             return new Bytes((ByteArray)this[new Slice(start, end)]);
         }
 
-        List IBufferProtocol.ToList(int start, int? end) {
+        List IBufferProtocol.ToList(int start, int? end)
+        {
             List<byte> res = _bytes.Slice(new Slice(start, end));
-            if (res == null) {
+            if (res == null)
+            {
                 return new List();
             }
 


### PR DESCRIPTION
Fixed the bug, that if iterating over a bytearray, a System.Byte instead of an integer was returned. Issue: https://github.com/IronLanguages/main/issues/1237 (ip2)