### PR TITLE
Use nunit3 syntax for all test-* targets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,6 +72,9 @@ build_script:
 
 # to run your custom scripts instead of automatic tests
 test_script:
+  #- .\make.cmd test-smoke
+  #- .\make.cmd test-cpython
+  #- .\make.cmd test-ironpython
   - .\make.cmd test-all
   #- nunit3-console .\bin\Debug\IronPythonTest.dll
 

--- a/make.cmd
+++ b/make.cmd
@@ -1,6 +1,6 @@
 @echo off
 setlocal
-set PATH=%PATH%;%WINDIR%\Microsoft.NET\Framework\v4.0.30319;%WINDIR%\Microsoft.NET\Framework\v3.5
+set PATH=%PATH%;%WINDIR%\Microsoft.NET\Framework\v4.0.30319
 
 :getopts
 if "%1"=="" (goto :default) else (goto :%1)
@@ -61,39 +61,36 @@ echo No target 'test'. Try 'test-smoke', 'test-ironpython', 'test-cpython', or '
 goto :exit
 
 :test-smoke
-pushd bin\v2Debug
-IronPythonTest.exe -include:StandardCPython -result:smoke-result-net35.xml
-popd
 pushd bin\Debug
-IronPythonTest.exe -include:StandardCPython -result:smoke-result-net40.xml
+IronPythonTest.exe --where:Category==StandardCPython --result:smoke-result-net40.xml
 popd
 pushd bin\v45Debug
-IronPythonTest.exe -include:StandardCPython -result:smoke-result-net45.xml
+IronPythonTest.exe --where:Category==StandardCPython --result:smoke-result-net45.xml
 popd
 goto :exit
 
 :test-ironpython
 pushd bin\Debug
-IronPythonTest.exe -include:IronPython -result:ironpython-result.xml
+IronPythonTest.exe --where:Category==IronPython --result:ironpython-result.xml
 popd
 goto :exit
 
 :test-cpython
 pushd bin\Debug
-IronPythonTest.exe -include:StandardCPython,AllCPython -result:cpython-result.xml
+IronPythonTest.exe --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-result.xml
 popd
 goto :exit
 
 :test-all
 pushd bin\Debug
-IronPythonTest.exe -result:all-result.xml
+IronPythonTest.exe --result:all-result.xml
 popd
 goto :exit
 
 :test-custom
 pushd bin\Debug
 shift
-IronPythonTest.exe -result:custom-result.xml %1 %2 %3 %4 %5 %6 %7 %8 %9
+IronPythonTest.exe --result:custom-result.xml %1 %2 %3 %4 %5 %6 %7 %8 %9
 popd
 goto :exit
 


### PR DESCRIPTION
* Drop .NET 3.5 from make.cmd

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>