### PR TITLE
make.cmd: output labels as tests run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - git submodule update --init --recursive
   - make $FLAVOUR
   - pushd bin/$CONFIGURATION
-  - mono ./IronPythonTest.exe --result:all-result.xml
+  - mono ./IronPythonTest.exe --labels=All --result:all-result.xml
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 
 
 test-smoke:
-	(cd bin/Debug && mono ./IronPythonTest.exe --where:Category==StandardCPython --result=smoke-result-net40.xml) || true
-	(cd bin/v45Debug && mono ./IronPythonTest.exe --where:Category==StandardCPython --result=smoke-result-net45.xml) || true
+	(cd bin/Debug && mono ./IronPythonTest.exe --labels=All --where:Category==StandardCPython --result=smoke-result-net40.xml) || true
+	(cd bin/v45Debug && mono ./IronPythonTest.exe --labels=All --where:Category==StandardCPython --result=smoke-result-net45.xml) || true

--- a/make.cmd
+++ b/make.cmd
@@ -62,35 +62,35 @@ goto :exit
 
 :test-smoke
 pushd bin\Debug
-IronPythonTest.exe --where:Category==StandardCPython --result:smoke-result-net40.xml
+IronPythonTest.exe --labels=All --where:Category==StandardCPython --result:smoke-result-net40.xml
 popd
 pushd bin\v45Debug
-IronPythonTest.exe --where:Category==StandardCPython --result:smoke-result-net45.xml
+IronPythonTest.exe --labels=All --where:Category==StandardCPython --result:smoke-result-net45.xml
 popd
 goto :exit
 
 :test-ironpython
 pushd bin\Debug
-IronPythonTest.exe --where:Category==IronPython --result:ironpython-result.xml
+IronPythonTest.exe --labels=All --where:Category==IronPython --result:ironpython-result.xml
 popd
 goto :exit
 
 :test-cpython
 pushd bin\Debug
-IronPythonTest.exe --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-result.xml
+IronPythonTest.exe --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-result.xml
 popd
 goto :exit
 
 :test-all
 pushd bin\Debug
-IronPythonTest.exe --result:all-result.xml
+IronPythonTest.exe --labels=All --result:all-result.xml
 popd
 goto :exit
 
 :test-custom
 pushd bin\Debug
 shift
-IronPythonTest.exe --result:custom-result.xml %1 %2 %3 %4 %5 %6 %7 %8 %9
+IronPythonTest.exe --labels=All --result:custom-result.xml %1 %2 %3 %4 %5 %6 %7 %8 %9
 popd
 goto :exit
 


### PR DESCRIPTION
Since NUnit 3.4, the ```--labels=All``` flag outputs the name of
each test case as it is run.

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>