### PR TITLE
Assignment unpacking from PEP 3132

### DIFF
--- a/Src/IronPython/Compiler/Ast/AssignmentStatement.cs
+++ b/Src/IronPython/Compiler/Ast/AssignmentStatement.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
@@ -110,7 +111,9 @@ namespace IronPython.Compiler.Ast {
             SequenceExpression seLeft = _left[0] as SequenceExpression;
             SequenceExpression seRight = _right as SequenceExpression;
 
-            if (seLeft != null && seRight != null && seLeft.Items.Count == seRight.Items.Count) {
+            bool isStarred = seLeft != null && seLeft.Items.OfType<StarredExpression>().Any();
+
+            if (!isStarred && seLeft != null && seRight != null && seLeft.Items.Count == seRight.Items.Count) {
                 int cnt = seLeft.Items.Count;
                 
                 // a, b = 1, 2, or [a,b] = 1,2 - not something like a, b = range(2)

--- a/Src/IronPython/Compiler/Ast/AstMethods.cs
+++ b/Src/IronPython/Compiler/Ast/AstMethods.cs
@@ -71,8 +71,9 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo ImportBottom = GetMethod((Func<CodeContext, string, int, object>)PythonOps.ImportBottom);
         public static readonly MethodInfo MakeList = GetMethod((Func<List>)PythonOps.MakeList);
         public static readonly MethodInfo MakeListNoCopy = GetMethod((Func<object[], List>)PythonOps.MakeListNoCopy);
-        public static readonly MethodInfo GetEnumeratorValues = GetMethod((Func<CodeContext, object, int, object>)PythonOps.GetEnumeratorValues);
-        public static readonly MethodInfo GetEnumeratorValuesNoComplexSets = GetMethod((Func<CodeContext, object, int, object>)PythonOps.GetEnumeratorValuesNoComplexSets);
+        public static readonly MethodInfo GetEnumeratorValues = GetMethod((Func<CodeContext, object, int, int, object>)PythonOps.GetEnumeratorValues);
+        public static readonly MethodInfo GetEnumeratorValuesNoComplexSets = GetMethod((Func<CodeContext, object, int, int, object>)PythonOps.GetEnumeratorValuesNoComplexSets);
+        public static readonly MethodInfo UnpackIterable = GetMethod((Func<CodeContext, object, int, int, object>)PythonOps.UnpackIterable);
         public static readonly MethodInfo GetGlobalContext = GetMethod((Func<CodeContext, CodeContext>)PythonOps.GetGlobalContext);
         public static readonly MethodInfo GetParentContextFromFunction = GetMethod((Func<PythonFunction, CodeContext>)PythonOps.GetParentContextFromFunction);
         public static readonly MethodInfo MakeFunction = GetMethod((Func<CodeContext, FunctionCode, object, object[], object>)PythonOps.MakeFunction);

--- a/Src/IronPython/Compiler/Ast/PythonWalker.Generated.cs
+++ b/Src/IronPython/Compiler/Ast/PythonWalker.Generated.cs
@@ -107,6 +107,10 @@ namespace IronPython.Compiler.Ast {
         public virtual bool Walk(SliceExpression node) { return true; }
         public virtual void PostWalk(SliceExpression node) { }
 
+        // StarredExpression
+        public virtual bool Walk(StarredExpression node) { return true; }
+        public virtual void PostWalk(StarredExpression node) { }
+
         // TupleExpression
         public virtual bool Walk(TupleExpression node) { return true; }
         public virtual void PostWalk(TupleExpression node) { }

--- a/Src/IronPython/Compiler/Ast/StarredExpression.cs
+++ b/Src/IronPython/Compiler/Ast/StarredExpression.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+using Microsoft.Scripting;
+using Microsoft.Scripting.Runtime;
+
+using IronPython.Runtime.Binding;
+
+using MSAst = System.Linq.Expressions;
+
+namespace IronPython.Compiler.Ast {
+
+    public class StarredExpression : Expression {
+        public StarredExpression(Expression value) {
+            Value = value;
+        }
+
+        public Expression Value { get; }
+
+        public override MSAst.Expression Reduce() {
+            return Value;
+        }
+
+        internal override MSAst.Expression TransformSet(SourceSpan span, MSAst.Expression right, PythonOperationKind op) {
+            return Value.TransformSet(span, right, op);
+        }
+
+        internal override string CheckAssign() {
+            return Value.CheckAssign();
+        }
+
+        internal override string CheckDelete() {
+            return Value.CheckDelete();
+        }
+
+        internal override MSAst.Expression TransformDelete() {
+            return Value.TransformDelete();
+        }
+
+        public override Type Type {
+            get {
+                return Value.Type;
+            }
+        }
+
+        public override void Walk(PythonWalker walker) {
+            if (walker.Walk(this)) {
+                if (Value != null) {
+                    Value.Walk(walker);
+                }
+            }
+            walker.PostWalk(this);
+        }
+
+        internal override bool CanThrow {
+            get {
+                return Value.CanThrow;
+            }
+        }
+    }
+}

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -685,7 +685,7 @@ namespace IronPython.Compiler {
                 if (MaybeEat(TokenKind.KeywordYield)) {
                     right = ParseYieldExpression();
                 } else {
-                    right = ParseTestListAsExpr();
+                    right = ParseTestListStarExpr();
                 }
             }
 
@@ -704,13 +704,14 @@ namespace IronPython.Compiler {
             }
         }
 
-        // expr_stmt: expression_list
-        // expression_list: expression ( "," expression )* [","] 
-        // assignment_stmt: (target_list "=")+ (expression_list | yield_expression) 
-        // augmented_assignment_stmt ::= target augop (expression_list | yield_expression) 
-        // augop: '+=' | '-=' | '*=' | '@=' | '/=' | '%=' | '**=' | '>>=' | '<<=' | '&=' | '^=' | '|=' | '//='
+        // expr_stmt: testlist_star_expr (augassign (yield_expr|testlist) | ('=' (yield_expr|testlist_star_expr))*)
+        // expr_stmt: testlist (augassign (yield_expr|testlist) | ('=' (yield_expr|testlist))*)
+        // testlist_star_expr: (test|star_expr) (',' (test|star_expr))* [',']
+        // augassign: ('+=' | '-=' | '*=' | '@=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=' | '**=' | '//=')
+        // testlist: test (',' test)* [',']
+        // star_expr: '*' expr
         private Statement ParseExprStmt() {
-            Expression ret = ParseTestListAsExpr();
+            Expression ret = ParseTestListStarExpr();
             if (ret is ErrorExpression) {
                 NextToken();
             }
@@ -2461,6 +2462,55 @@ namespace IronPython.Compiler {
             }
             return MakeTupleOrExpr(l, trailingComma);
         }
+
+
+        private Expression ParseTestListStarExpr() {
+            if (MaybeEat(TokenKind.Multiply)) {
+                var start = GetStart();
+                var expr = new StarredExpression(ParseExpression());
+                expr.SetLoc(_globalParent, start, GetEnd());
+                if (!MaybeEat(TokenKind.Comma)) {
+                    return expr;
+                }
+
+                return ParseTestListStarExpr(expr);
+            }
+            if (!NeverTestToken(PeekToken())) {
+                var expr = ParseExpression();
+                if (!MaybeEat(TokenKind.Comma)) {
+                    return expr;
+                }
+
+                return ParseTestListStarExpr(expr);
+            } else {
+                return ParseTestListAsExprError();
+            }
+        }
+
+        private Expression ParseTestListStarExpr(Expression expr) {
+            List<Expression> l = new List<Expression>();
+            l.Add(expr);
+
+            bool trailingComma = true;
+            while (true) {
+                if (MaybeEat(TokenKind.Multiply)) {
+                    var start = GetStart();
+                    var sExpr = new StarredExpression(ParseExpression());
+                    sExpr.SetLoc(_globalParent, start, GetEnd());
+                    l.Add(sExpr);
+                }
+                else {
+                    if (NeverTestToken(PeekToken())) break;
+                    l.Add(ParseExpression());
+                }
+                if (!MaybeEat(TokenKind.Comma)) {
+                    trailingComma = false;
+                    break;
+                }
+            }
+            return MakeTupleOrExpr(l, trailingComma);
+        }
+
 
         private Expression ParseTestListAsExprError() {
             if (MaybeEat(TokenKind.Indent)) {

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -30,6 +30,7 @@
     <Compile Include="Compiler\Ast\PythonConstantExpression.cs" />
     <Compile Include="Compiler\Ast\SerializedScopeStatement.cs" />
     <Compile Include="Compiler\Ast\SetExpression.cs" />
+    <Compile Include="Compiler\Ast\StarredExpression.cs" />
     <Compile Include="Compiler\CollectableCompilationMode.cs" />
     <Compile Include="Compiler\Ast\AssertStatement.cs" />
     <Compile Include="Compiler\Ast\AssignmentStatement.cs" />

--- a/Src/IronPython/Modules/_ast.cs
+++ b/Src/IronPython/Modules/_ast.cs
@@ -386,6 +386,8 @@ namespace IronPython.Modules
                     ast = new DictComp((DictionaryComprehension)expr);
                 else if (expr is SetComprehension)
                     ast = new SetComp((SetComprehension)expr);
+                else if (expr is StarredExpression)
+                    ast = new Starred((StarredExpression)expr, ctx);
                 else
                     throw new ArgumentTypeException("Unexpected expression type: " + expr.GetType());
 
@@ -3034,6 +3036,32 @@ namespace IronPython.Modules
                 get { return _step; }
                 set { _step = value; }
             }
+        }
+
+        [PythonType]
+        public class Starred : expr
+        {
+            public Starred() {
+                _fields = new PythonTuple(new[] { nameof(value), nameof(ctx) });
+            }
+
+            public Starred(expr value, expr_context ctx, [Optional]int? lineno, [Optional]int? col_offset)
+                : this() {
+                this.value = value;
+                this.ctx = ctx;
+                _lineno = lineno;
+                _col_offset = col_offset;
+            }
+
+            public Starred(expr value, expr_context ctx)
+                : this(value, ctx, null, null) { }
+
+            internal Starred(StarredExpression expr, expr_context ctx)
+                : this(Convert(expr.Value), ctx, null, null) { }
+
+            public expr_context ctx { get; set; }
+
+            public expr value { get; set; }
         }
 
         [PythonType]


### PR DESCRIPTION
Partial implementation of PEP 3132. This is for the assignment unpacking part of it (e.g. `a, *b = [1,2,3,4]`). There are more implicit unpacking cases that are not handled by this PR (e.g. `for a, *b in [(1, 2, 3), (4, 5, 6, 7)]: print(b)`).