### PR TITLE
Temporarily get metaclasses working with old infrastructure

### DIFF
--- a/Src/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -44,6 +44,7 @@ namespace IronPython.Compiler.Ast {
         private readonly string _name;
         private Statement _body;
         private readonly Expression[] _bases;
+        private readonly Expression[] _keywords;
         private IList<Expression> _decorators;
 
         private PythonVariable _variable;           // Variable corresponding to the class name
@@ -58,12 +59,14 @@ namespace IronPython.Compiler.Ast {
         private static MSAst.ParameterExpression _parentContextParam = Ast.Parameter(typeof(CodeContext), "$parentContext");
         private static MSAst.Expression _tupleExpression = MSAst.Expression.Call(AstMethods.GetClosureTupleFromContext, _parentContextParam);
 
-        public ClassDefinition(string name, Expression[] bases, Statement body) {
-            ContractUtils.RequiresNotNull(body, "body");
-            ContractUtils.RequiresNotNullItems(bases, "bases");
+        public ClassDefinition(string name, Expression[] bases, Expression[] keywords, Statement body) {
+            ContractUtils.RequiresNotNull(body, nameof(body));
+            ContractUtils.RequiresNotNullItems(bases, nameof(bases));
+            ContractUtils.RequiresNotNullItems(keywords, nameof(keywords));
 
             _name = name;
             _bases = bases;
+            _keywords = keywords;
             _body = body;
         }
 
@@ -82,6 +85,10 @@ namespace IronPython.Compiler.Ast {
 
         public IList<Expression> Bases {
             get { return _bases; }
+        }
+
+        public IList<Expression> Keywords {
+            get { return _keywords; }
         }
 
         public Statement Body {

--- a/Src/IronPython/Modules/_ast.cs
+++ b/Src/IronPython/Modules/_ast.cs
@@ -1343,18 +1343,20 @@ namespace IronPython.Modules
         {
             private string _name;
             private PythonList _bases;
+            private PythonList _keywords;
             private PythonList _body;
             private PythonList _decorator_list;
 
             public ClassDef() {
-                _fields = new PythonTuple(new[] { "name", "bases", "body", "decorator_list" });
+                _fields = new PythonTuple(new[] { "name", "bases", "keywords", "body", "decorator_list" });
             }
 
-            public ClassDef(string name, PythonList bases, PythonList body, PythonList decorator_list,
+            public ClassDef(string name, PythonList bases, PythonList keywords, PythonList body, PythonList decorator_list,
                 [Optional]int? lineno, [Optional]int? col_offset)
                 : this() {
                 _name = name;
                 _bases = bases;
+                _keywords = keywords;
                 _body = body;
                 _decorator_list = decorator_list;
                 _lineno = lineno;
@@ -1378,7 +1380,7 @@ namespace IronPython.Modules
             }
 
             internal override Statement Revert() {
-                ClassDefinition cd = new ClassDefinition(name, expr.RevertExprs(bases), RevertStmts(body));
+                ClassDefinition cd = new ClassDefinition(name, expr.RevertExprs(bases), expr.RevertExprs(keywords), RevertStmts(body));
                 if (decorator_list.Count != 0) 
                     cd.Decorators = expr.RevertExprs(decorator_list);
                 return cd;
@@ -1392,6 +1394,11 @@ namespace IronPython.Modules
             public PythonList bases {
                 get { return _bases; }
                 set { _bases = value; }
+            }
+
+            public PythonList keywords {
+                get { return _keywords; }
+                set { _keywords = value; }
             }
 
             public PythonList body {


### PR DESCRIPTION
Basically this reads the metaclass keyword and then injects `__metaclass__` into the class body.

Thought this would unblock some tests but it looks like we just end up running into other stuff (e.g. PEP3135).