### PR TITLE
Temporarily avoid use of keyword only argument until properly implemented

### DIFF
--- a/Src/StdLib/Lib/inspect.py
+++ b/Src/StdLib/Lib/inspect.py
@@ -2072,8 +2072,8 @@ class _empty:
 
 
 class _ParameterKind(int):
-    def __new__(self, *args, name):
-        obj = int.__new__(self, *args)
+    def __new__(self, val, name):
+        obj = int.__new__(self, val)
         obj._name = name
         return obj
 


### PR DESCRIPTION
This should be reverted once keyword only arguments are properly implemented.