### PR TITLE
Turn off debug mode when running tests

### DIFF
--- a/Src/IronPythonTest/Cases/CaseExecuter.cs
+++ b/Src/IronPythonTest/Cases/CaseExecuter.cs
@@ -52,7 +52,7 @@ namespace IronPythonTest.Cases {
 
         public CaseExecuter() {
             this.defaultEngine = Python.CreateEngine(new Dictionary<string, object> {
-                {"Debug", true },
+                {"Debug", false},
                 {"Frames", true},
                 {"FullFrames", true}
             });


### PR DESCRIPTION
Also, as a side effect of turning off debug mode, the tests run in a fraction of the time (e.g. 18 seconds on my machine!)