### PR TITLE
AllCPythonCasesManifest.ini: ignore test_ast

### DIFF
--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -1,6 +1,9 @@
 ﻿[DEFAULT]
 Ignore=false
 
+[test_ast]
+Ignore=true ; assertion failed
+
 [test_asynchat]
 Ignore=true ; timeout
 


### PR DESCRIPTION
Assertion Failure causes dialog which stalls AppVeyor tests

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>