### PR TITLE
Replace PythonFile with FileIO for standard streams

### DIFF
--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -246,39 +246,20 @@ namespace IronPython.Modules {
             PythonContext.GetContext(context).DomainManager.Platform.TerminateScriptExecution(code);
         }
 
-        public static object fdopen(CodeContext/*!*/ context, int fd) {
-            return fdopen(context, fd, "r");
-        }
-
-        public static object fdopen(CodeContext/*!*/ context, int fd, string mode) {
-            return fdopen(context, fd, mode, 0);
-        }
-
-        public static object fdopen(CodeContext/*!*/ context, int fd, string mode, int bufsize) {
-            // check for a valid file mode...
-            PythonFile.ValidateMode(mode);
-
-            PythonContext pythonContext = PythonContext.GetContext(context);
-            PythonFile pf;
-            if (pythonContext.FileManager.TryGetFileFromId(pythonContext, fd, out pf)) {
-                return pf;
-            }
-
-            Stream stream = pythonContext.FileManager.GetObjectFromId(fd) as Stream;
-            if (stream == null) {
-                throw PythonExceptions.CreateThrowable(PythonExceptions.OSError, 9, "Bad file descriptor");
-            }
-
-            return PythonFile.Create(context, stream, stream.ToString(), mode);
+        public static object fdopen(CodeContext/*!*/ context, int fd,
+            [DefaultParameterValue("r")]string mode,
+            [DefaultParameterValue(-1)]int buffering,
+            [DefaultParameterValue(null)]string encoding,
+            [DefaultParameterValue(null)]string errors,
+            [DefaultParameterValue(null)]string newline,
+            [DefaultParameterValue(true)]bool closefd) {
+            return Builtin.open(context, fd, mode, buffering, encoding, errors, newline, closefd);
         }
 
         [LightThrowing]
         public static object fstat(CodeContext/*!*/ context, int fd) {
             PythonContext pythonContext = PythonContext.GetContext(context);
             PythonFile pf = pythonContext.FileManager.GetFileFromId(pythonContext, fd);
-            if (pf.IsConsole) {
-                return new stat_result(8192);
-            }
             return lstat(pf.name);
         }
 

--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -2848,6 +2848,29 @@ namespace IronPython.Modules {
             return res;
         }
 
+        internal static _IOBase CreateConsole(PythonContext context, SharedIO io, ConsoleStreamType type, string name) {
+            var cc = context.SharedContext;
+            if (type == ConsoleStreamType.Input) {
+                var encoding = StringOps.GetEncodingName(io.InputEncoding);
+                var fio = new FileIO(cc, io.InputStream, type) { name = name };
+                var buffer = BufferedReader.Create(cc, fio, DEFAULT_BUFFER_SIZE);
+                return TextIOWrapper.Create(cc, buffer, encoding, null, null, true);
+            }
+            else if (type == ConsoleStreamType.Output) {
+                var encoding = StringOps.GetEncodingName(io.OutputEncoding);
+                var fio = new FileIO(cc, io.OutputStream, type) { name = name };
+                var buffer = BufferedWriter.Create(cc, fio, DEFAULT_BUFFER_SIZE, null);
+                return TextIOWrapper.Create(cc, buffer, encoding, null, null, true);
+            }
+            else {
+                Debug.Assert(type == ConsoleStreamType.ErrorOutput);
+                var encoding = StringOps.GetEncodingName(io.ErrorEncoding);
+                var fio = new FileIO(cc, io.ErrorStream, type) { name = name };
+                var buffer = BufferedWriter.Create(cc, fio, DEFAULT_BUFFER_SIZE, null);
+                return TextIOWrapper.Create(cc, buffer, encoding, "backslashreplace", null, true);
+            }
+        }
+
         [PythonType]
         public class IncrementalNewlineDecoder {
             [Flags]

--- a/Src/IronPython/Runtime/OutputWriter.cs
+++ b/Src/IronPython/Runtime/OutputWriter.cs
@@ -52,6 +52,7 @@ namespace IronPython.Runtime {
             } catch (Exception e) {
                 PythonOps.PrintWithDest(DefaultContext.Default, _context.SystemStandardOut, _context.FormatException(e));
             }
+            Flush(); // we're using a buffered writer so always flush after write
         }
 
         public override void Write(char value) {

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1492,7 +1492,6 @@ namespace IronPython.Runtime
 
             result.Append(FormatStackTraces(exception));
             result.Append(FormatPythonException(pythonEx));
-            result.AppendLine();
 
             if (Options.ShowClrExceptions) {
                 result.Append(FormatCLSException(exception));
@@ -2052,9 +2051,9 @@ namespace IronPython.Runtime
         private void SetStandardIO() {
             SharedIO io = DomainManager.SharedIO;
 
-            PythonFile stdin = PythonFile.CreateConsole(this, io, ConsoleStreamType.Input, "<stdin>");
-            PythonFile stdout = PythonFile.CreateConsole(this, io, ConsoleStreamType.Output, "<stdout>");
-            PythonFile stderr = PythonFile.CreateConsole(this, io, ConsoleStreamType.ErrorOutput, "<stderr>");
+            var stdin = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.Input, "<stdin>");
+            var stdout = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.Output, "<stdout>");
+            var stderr = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.ErrorOutput, "<stderr>");
 
             SetSystemStateValue("__stdin__", stdin);
             SetSystemStateValue("stdin", stdin);


### PR DESCRIPTION
Replaces `sys.stdout`, `sys.stdin` and `sys.stderr` to use `TextIOWrapper`.