### PR TITLE
Fix issue when using dir on an instance of subclass of IOBase

### DIFF
--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -64,7 +64,7 @@ namespace IronPython.Modules {
             );
         }
 
-        [PythonType]
+        [PythonType, DontMapGetMemberNamesToDir]
         public class _IOBase : IDisposable, IEnumerator<object>, IEnumerable<object>, IWeakReferenceable, IDynamicMetaObjectProvider, IPythonExpandable {
             private bool _closed;
             internal CodeContext/*!*/ context;


### PR DESCRIPTION
Fixes the following which leads to a `StackOverflowException`
```Python
import io

class Test(io.IOBase):
    pass

dir(Test())
```