### PR TITLE
Enable errors on mbcs encode/decode

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -334,17 +334,15 @@ namespace IronPython.Modules {
         #region MBCS Functions
 
         public static PythonTuple mbcs_decode(CodeContext/*!*/ context, string input, [DefaultParameterValue("strict")]string errors, [DefaultParameterValue(false)]bool ignored) {
-            // CPython ignores the errors parameter
             return PythonTuple.MakeTuple(
-                StringOps.decode(context, input, Encoding.Default, "replace"),
+                StringOps.decode(context, input, Encoding.Default, errors),
                 Builtin.len(input)
             );
         }
 
         public static PythonTuple mbcs_encode(CodeContext/*!*/ context, string input, [DefaultParameterValue("strict")]string errors) {
-            // CPython ignores the errors parameter
             return PythonTuple.MakeTuple(
-                StringOps.encode(context, input, Encoding.Default, "replace"),
+                StringOps.encode(context, input, Encoding.Default, errors),
                 Builtin.len(input)
             );
         }

--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -37,6 +37,9 @@ Ignore=true ; timeout
 [test_mimetypes]
 Ignore=true ; timeout
 
+[test_pdb]
+Ignore=true ; timeout
+
 [test_poplib]
 Ignore=true ; timeout
 


### PR DESCRIPTION
In Python 3, mbcs encode/decode no longer ignores the errors parameter. This is currently causing a lot of tests to fail.