### PR TITLE
Fix blocking test in test_syntax

### DIFF
--- a/Src/StdLib/Lib/test/test_syntax.py
+++ b/Src/StdLib/Lib/test/test_syntax.py
@@ -364,7 +364,7 @@ build.  The number of blocks must be greater than CO_MAXBLOCKS.  SF #1565514
    ...                   while 20:
    ...                    while 21:
    ...                     while 22:
-   ...                      break
+   ...                      assert False
    Traceback (most recent call last):
      ...
    SystemError: too many statically nested blocks


### PR DESCRIPTION
Prevents an infinite loop if the test doesn't fail as expected. Might be worth making a PR to CPython for this one.