### PR TITLE
Fix bug with assigning to a sequence

### DIFF
--- a/Src/IronPython/Compiler/Ast/SequenceExpression.cs
+++ b/Src/IronPython/Compiler/Ast/SequenceExpression.cs
@@ -153,6 +153,10 @@ namespace IronPython.Compiler.Ast {
         }
 
         internal override string CheckAssign() {
+            foreach (var item in _items) {
+                var res = item.CheckAssign();
+                if (res != null) return res;
+            }
             return null;
         }
 


### PR DESCRIPTION
The following two statements should raise `SyntaxError`:
```Python
["a"] = [1]
[a + 1] = [1]
```
They currently raise a `SystemError` (or an assertion failure in Debug mode).