### PR TITLE
Prevent incorrect argument from being added to exceptions

### DIFF
--- a/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
+++ b/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
@@ -941,8 +941,10 @@ for k, v in toError.items():
                 pyEx = PythonOps.CallWithArgsTuple(type, ArrayUtils.EmptyObjects, value);
             } else if (value != null) {
                 pyEx = PythonCalls.Call(context, type, value, cause);
-            } else {
+            } else if (cause != null) {
                 pyEx = PythonCalls.Call(context, type, cause);
+            } else {
+                pyEx = PythonCalls.Call(context, type);
             }
 
             if (PythonOps.IsInstance(pyEx, type)) {


### PR DESCRIPTION
An incorrect argument was being added to exceptions raised without a value.
```Python
try:
    raise Exception
except Exception as e:
    assert len(e.args) == 0
```