### PR TITLE
Add __set__ to getset_descriptor types

### DIFF
--- a/Src/IronPython/Runtime/Types/PythonTypeDictSlot.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeDictSlot.cs
@@ -93,6 +93,10 @@ namespace IronPython.Runtime.Types {
             return false;
         }
 
+        public void __set__(CodeContext context, object instance, object value) {
+            TrySetValue(context, instance, DynamicHelpers.GetPythonType(instance), value);
+        }
+
         #region ICodeFormattable Members
 
         public string/*!*/ __repr__(CodeContext/*!*/ context) {

--- a/Src/IronPython/Runtime/Types/PythonTypeWeakRefSlot.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeWeakRefSlot.cs
@@ -63,6 +63,10 @@ namespace IronPython.Runtime.Types {
             return String.Format("<attribute '__weakref__' of '{0}' objects>", _type.Name);
         }
 
+        public void __set__(CodeContext context, object instance, object value) {
+            TrySetValue(context, instance, DynamicHelpers.GetPythonType(instance), value);
+        }
+
         #region ICodeFormattable Members
 
         public string/*!*/ __repr__(CodeContext/*!*/ context) {


### PR DESCRIPTION
Adds `__set__` to `getset_descriptor` types to resolve the following issues:
```Python
import inspect
class test(object): pass

assert not inspect.ismethoddescriptor(test.__weakref__)
assert not inspect.ismethoddescriptor(test.__dict__["__dict__"])
```