### PR TITLE
Disable some tests in test_sort

### DIFF
--- a/Src/StdLib/Lib/test/test_sort.py
+++ b/Src/StdLib/Lib/test/test_sort.py
@@ -206,6 +206,7 @@ class TestDecorateSortUndecorate(unittest.TestCase):
             return x
         self.assertRaises(ValueError, data.sort, key=k)
 
+    @unittest.skipIf(sys.platform == "cli", "__del__ is only invoked when the GC runs")
     def test_key_with_mutating_del(self):
         data = list(range(10))
         class SortKiller(object):
@@ -218,6 +219,7 @@ class TestDecorateSortUndecorate(unittest.TestCase):
                 return id(self) < id(other)
         self.assertRaises(ValueError, data.sort, key=SortKiller)
 
+    @unittest.skipIf(sys.platform == "cli", "__del__ is only invoked when the GC runs")
     def test_key_with_mutating_del_and_exception(self):
         data = list(range(10))
         ## dup = data[:]


### PR DESCRIPTION
Disables two tests which rely on reference counting in order to work properly.