### PR TITLE
Fix iter of str and bytes

### DIFF
--- a/Src/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/Src/IronPython/Runtime/Operations/InstanceOps.cs
@@ -199,12 +199,12 @@ namespace IronPython.Runtime.Operations {
 
         // 3.0-only
         public static object IterMethodForString(string self) {
-            return PythonOps.StringEnumerator(self);
+            return StringOps.StringEnumerator(self);
         }
 
         // 3.0-only
         public static object IterMethodForBytes(Bytes self) {
-            return PythonOps.BytesIntEnumerator(self);
+            return IListOfByteOps.BytesIntEnumerator(self);
         }
 
         public static object IterMethodForEnumerator(IEnumerator self) {

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -1003,12 +1003,12 @@ namespace IronPython.Runtime.Types {
         private static MemberGroup/*!*/ IterResolver(MemberBinder/*!*/ binder, Type/*!*/ type) {
             if (type == typeof(string)) {
                 // __iter__ is only exposed in 3.0
-                return GetInstanceOpsMethod(type, "IterMethodForString");
+                return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForString));
             }
 
             if (typeof(Bytes).IsAssignableFrom(type)) {
                 // __iter__ is only exposed in 3.0
-                return GetInstanceOpsMethod(type, "IterMethodForBytes");
+                return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForBytes));
             }
 
             foreach (Type t in binder.GetContributingTypes(type)) {
@@ -1022,13 +1022,13 @@ namespace IronPython.Runtime.Types {
             if (!type.GetTypeInfo().IsDefined(typeof(DontMapIEnumerableToIterAttribute), true)) {
                 // no special __iter__, use the default.
                 if (typeof(IEnumerable<>).IsAssignableFrom(type)) {
-                    return GetInstanceOpsMethod(type, "IterMethodForGenericEnumerable");
+                    return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForGenericEnumerable));
                 } else if (typeof(IEnumerable).IsAssignableFrom(type)) {
-                    return GetInstanceOpsMethod(type, "IterMethodForEnumerable");
+                    return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForEnumerable));
                 } else if (typeof(IEnumerator<>).IsAssignableFrom(type)) {
-                    return GetInstanceOpsMethod(type, "IterMethodForGenericEnumerator");
+                    return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForGenericEnumerator));
                 } else if (typeof(IEnumerator).IsAssignableFrom(type)) {
-                    return GetInstanceOpsMethod(type, "IterMethodForEnumerator");
+                    return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForEnumerator));
                 }
             }
             


### PR DESCRIPTION
Fixes the following:
```
list(iter("123"))
list(iter(b"123"))
```
which were returning key/value pairs.

Note that the same code appears in the ipy2.7 branch however it does not appear to get called...