### PR TITLE
Fix bug with argument unpacking

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1552,7 +1552,7 @@ namespace IronPython.Runtime.Operations {
                 }
             }
             else {
-                if (list._size > expected + argcntafter) {
+                if (list._size >= expected + argcntafter) {
                     return list._data;
                 }
             }

--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -52,9 +52,6 @@ Ignore=true ; timeout
 [test_socketserver]
 Ignore=true ; timeout
 
-[test_string]
-Ignore=true ; assertion failed
-
 [test_subprocess]
 Ignore=true ; kills the testing process
 


### PR DESCRIPTION
Would fail the following:
```Python
a, *b = [1]
```

Also removes a test from the ignore list (it was raising an assertion error due to this bug).