### PR TITLE
Fix the issue where the underlying file gets closed when it shouldn't

### DIFF
--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -235,9 +235,7 @@ namespace IronPython.Modules {
                     return;
                 }
 
-                if(_closefd)
-                    flush(context);
-
+                flush(context);
                 _closed = true;
 
                 if (_closefd) {
@@ -247,12 +245,12 @@ namespace IronPython.Modules {
                         _writeStream.Close();
                         _writeStream.Dispose();
                     }
-                }
 
-                PythonFileManager myManager = _context.RawFileManager;
-                if (myManager != null) {
-                    myManager.Remove(this);
-                }
+                    PythonFileManager myManager = _context.RawFileManager;
+                    if (myManager != null) {
+                        myManager.Remove(this);
+                    }
+                }                
             }
 
             [Documentation("True if the file is closed")]

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -12,17 +12,8 @@
  *
  *
  * ***************************************************************************/
-#if FEATURE_CORE_DLR
 using System.Linq.Expressions;
-#else
-using Microsoft.Scripting.Ast;
-#endif
-
-#if FEATURE_NUMERICS
 using System.Numerics;
-#else
-using Microsoft.Scripting.Math;
-#endif
 
 using System;
 using System.Collections;
@@ -244,15 +235,19 @@ namespace IronPython.Modules {
                     return;
                 }
 
-                flush(context);
-                _closed = true;
-                _readStream.Close();
-                _readStream.Dispose();
-                if (!object.ReferenceEquals(_readStream, _writeStream)) {
-                    _writeStream.Close();
-                    _writeStream.Dispose();
-                }
+                if(_closefd)
+                    flush(context);
 
+                _closed = true;
+
+                if (_closefd) {
+                    _readStream.Close();
+                    _readStream.Dispose();
+                    if (!object.ReferenceEquals(_readStream, _writeStream)) {
+                        _writeStream.Close();
+                        _writeStream.Dispose();
+                    }
+                }
 
                 PythonFileManager myManager = _context.RawFileManager;
                 if (myManager != null) {


### PR DESCRIPTION
The underlying file should not get closed if closefd is False. There are some corner cases that I am missing for sure, so please review.