### PR TITLE
Add ability to mark supported platforms for a PythonModule.

### DIFF
--- a/Src/IronPython.Modules/_winapi.cs
+++ b/Src/IronPython.Modules/_winapi.cs
@@ -33,7 +33,7 @@ using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
 
-[assembly: PythonModule("_winapi", typeof(IronPython.Modules.PythonWinApi))]
+[assembly: PythonModule("_winapi", typeof(IronPython.Modules.PythonWinApi), PythonModuleAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
     public static class PythonWinApi {
         public const string __doc__ = "_subprocess Module";

--- a/Src/IronPython.Modules/msvcrt.cs
+++ b/Src/IronPython.Modules/msvcrt.cs
@@ -32,7 +32,7 @@ using System.Numerics;
 using Microsoft.Scripting.Math;
 #endif
 
-[assembly: PythonModule("msvcrt", typeof(IronPython.Modules.PythonMsvcrt))]
+[assembly: PythonModule("msvcrt", typeof(IronPython.Modules.PythonMsvcrt), PythonModuleAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
     [PythonType("msvcrt")]
     public class PythonMsvcrt {

--- a/Src/IronPython.Modules/winsound.cs
+++ b/Src/IronPython.Modules/winsound.cs
@@ -17,7 +17,7 @@ using Microsoft.Scripting.Utils;
 
 
 #if FEATURE_NATIVE
-[assembly: PythonModule("winsound", typeof(IronPython.Modules.PythonWinsoundModule))]
+[assembly: PythonModule("winsound", typeof(IronPython.Modules.PythonWinsoundModule), PythonModuleAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
     public static class PythonWinsoundModule {
         public static readonly string __doc__ = @"PlaySound(sound, flags) - play a sound

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1890,8 +1890,10 @@ namespace IronPython.Runtime
             object[] attrs = assem.GetCustomAttributes(typeof(PythonModuleAttribute), false);
             if (attrs.Length > 0) {
                 foreach (PythonModuleAttribute pma in attrs) {
-                    builtinTable[pma.Name] = pma.Type;
-                    BuiltinModuleNames[pma.Type] = pma.Name;
+                    if (pma.IsPlatformValid) {
+                        builtinTable[pma.Name] = pma.Type;
+                        BuiltinModuleNames[pma.Type] = pma.Name;
+                    }
                 }
 
                 if (updateSys) {

--- a/Src/IronPython/Runtime/PythonModuleAttribute.cs
+++ b/Src/IronPython/Runtime/PythonModuleAttribute.cs
@@ -26,8 +26,14 @@ namespace IronPython.Runtime {
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class PythonModuleAttribute : Attribute {
-        private readonly string/*!*/ _name;
-        private readonly Type/*!*/ _type;
+ 
+        public enum PlatformFamily {
+            Windows,
+            Unix
+        }
+
+        private static readonly PlatformID[] Windows = { PlatformID.Win32NT, PlatformID.Win32S, PlatformID.Win32Windows, PlatformID.WinCE, PlatformID.Xbox };
+        private static readonly PlatformID[] Unix = { PlatformID.MacOSX, PlatformID.Unix };
 
         /// <summary>
         /// Creates a new PythonModuleAttribute that can be used to specify a built-in module that exists
@@ -35,26 +41,53 @@ namespace IronPython.Runtime {
         /// </summary>
         /// <param name="name">The built-in module name</param>
         /// <param name="type">The type that implements the built-in module.</param>
-        public PythonModuleAttribute(string/*!*/ name, Type/*!*/ type) {
-            ContractUtils.RequiresNotNull(name, "name");
-            ContractUtils.RequiresNotNull(type, "type");
+        public PythonModuleAttribute(string/*!*/ name, Type/*!*/ type, params PlatformID[] validPlatforms) {
+            ContractUtils.RequiresNotNull(name, nameof(name));
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
-            _name = name;
-            _type = type;
+            Name = name;
+            Type = type;
+            ValidPlatforms = validPlatforms;
+        }
+
+        public PythonModuleAttribute(string/*!*/ name, Type/*!*/ type, PlatformFamily validPlatformFamily) {
+            ContractUtils.RequiresNotNull(name, nameof(name));
+            ContractUtils.RequiresNotNull(type, nameof(type));
+
+            Name = name;
+            Type = type;
+            switch(validPlatformFamily) {
+                case PlatformFamily.Unix:
+                    ValidPlatforms = Unix;
+                    break;
+                default:
+                    ValidPlatforms = Windows;
+                    break;
+            }
         }
 
         /// <summary>
         /// The built-in module name
         /// </summary>
         public string/*!*/ Name {
-            get { return _name; }
+            get;
         }
 
         /// <summary>
         /// The type that implements the built-in module
         /// </summary>
         public Type/*!*/ Type {
-            get { return _type; }
+            get;
+        }
+
+        public PlatformID[] ValidPlatforms {
+            get;
+        }
+
+        public bool IsPlatformValid {
+            get {
+                return ValidPlatforms == null || ValidPlatforms.Length == 0 || Array.IndexOf(ValidPlatforms, Environment.OSVersion.Platform) >= 0;
+            }
         }
     }
 }


### PR DESCRIPTION
This is somewhat different than the implementation for IPy2.
This allows passing a list (params PlatformID[]) of supported platforms,
or an enum value for a predefined list of supported platforms.