### PR TITLE
Fix several tests in test_abc.py

### DIFF
--- a/Src/IronPython/Runtime/Descriptors.cs
+++ b/Src/IronPython/Runtime/Descriptors.cs
@@ -35,11 +35,8 @@ namespace IronPython.Runtime {
         }
 
         public void __init__(CodeContext/*!*/ context, object func) {
-            if (!PythonOps.IsCallable(context, func))
-                throw PythonOps.TypeError("{0} object is not callable", PythonTypeOps.GetName(func));
             _func = func;
-        }
-            
+        }            
 
         internal override bool TryGetValue(CodeContext context, object instance, PythonType owner, out object value) {
             value = __get__(instance, PythonOps.ToPythonType(owner));
@@ -84,8 +81,6 @@ namespace IronPython.Runtime {
         internal object _func;
 
         public void __init__(CodeContext/*!*/ context, object func) {
-            if (!PythonOps.IsCallable(context, func))
-                throw PythonOps.TypeError("{0} object is not callable", PythonTypeOps.GetName(func));
             _func = func;
         }
 
@@ -105,7 +100,6 @@ namespace IronPython.Runtime {
                 return _func;
             }
         }
-
         public bool __isabstractmethod__ {
             get {
                 object isabstract;

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -2188,7 +2188,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 
             PythonTypeSlot val;
             if (_dict.TryGetValue("__new__", out val) && val is PythonFunction) {
-                AddSlot("__new__", new staticmethod(val));
+                AddSlot("__new__", new staticmethod(context, val));
             }
         }
 


### PR DESCRIPTION
Add \_\_init__ methods to avoid object.\_\_init__ deprecation warnings. Add \_\_isabstractmethod__ implementations.