### PR TITLE
Don't raise syntax error when deleting variable references in nested scope

### DIFF
--- a/Src/IronPython/Compiler/Ast/ScopeStatement.cs
+++ b/Src/IronPython/Compiler/Ast/ScopeStatement.cs
@@ -374,21 +374,6 @@ namespace IronPython.Compiler.Ast {
                 foreach (var reference in _references.Values) {
                     PythonVariable variable;
                     reference.PythonVariable = variable = BindReference(binder, reference);
-
-                    // Accessing outer scope variable which is being deleted?
-                    if (variable != null) {
-                        if (variable.Deleted && variable.Scope != this && !variable.Scope.IsGlobal) {
-
-                            // report syntax error
-                            binder.ReportSyntaxError(
-                                String.Format(
-                                    System.Globalization.CultureInfo.InvariantCulture,
-                                    "can not delete variable '{0}' referenced in nested scope",
-                                    reference.Name
-                                    ),
-                                this);
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
Prevents test_scope from failing with a syntax error.