### PR TITLE
Fix issue with metaclass assignment corrupting __doc__

### DIFF
--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -1696,14 +1696,17 @@ namespace IronPython.Compiler {
                     return ErrorStmt();
                 }
 
-                if (metaclass != null) {
-                    l.Add(new AssignmentStatement(new[] { new NameExpression("__metaclass__") }, metaclass));
-                }
-
+                bool addMetaclass = true;
                 while (true) {
                     Statement s = ParseStmt();
 
                     l.Add(s);
+
+                    if(addMetaclass && metaclass != null) {
+                        l.Add(new AssignmentStatement(new[] { new NameExpression("__metaclass__") }, metaclass));
+                        addMetaclass = false;
+                    }
+
                     if (MaybeEat(TokenKind.Dedent)) break;
                     if (PeekToken().Kind == TokenKind.EndOfFile) {
                         ReportSyntaxError("unexpected end of file");

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -1696,16 +1696,10 @@ namespace IronPython.Compiler {
                     return ErrorStmt();
                 }
 
-                bool addMetaclass = true;
                 while (true) {
                     Statement s = ParseStmt();
 
                     l.Add(s);
-
-                    if(addMetaclass && metaclass != null) {
-                        l.Add(new AssignmentStatement(new[] { new NameExpression("__metaclass__") }, metaclass));
-                        addMetaclass = false;
-                    }
 
                     if (MaybeEat(TokenKind.Dedent)) break;
                     if (PeekToken().Kind == TokenKind.EndOfFile) {
@@ -1713,6 +1707,11 @@ namespace IronPython.Compiler {
                         break; // error handling
                     }
                 }
+
+                if(metaclass != null) {
+                    l.Insert(1, new AssignmentStatement(new[] { new NameExpression("__metaclass__") }, metaclass));
+                }
+
                 Statement[] stmts = l.ToArray();
                 SuiteStatement ret = new SuiteStatement(stmts);
                 ret.SetLoc(_globalParent, stmts[0].StartIndex, stmts[stmts.Length - 1].EndIndex);


### PR DESCRIPTION
The IPy code looks at _statements[0].Documentation to get the documentation for a class. If the metaclass is present in the class definition, it becomes the the first statement and it's Documentation is null. This fixes this issue by making the metaclass assignment at a minimum the second statement in the class's suite.