### PR TITLE
README: clarify cloning with submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ strings, and all of the other new features.
 Builds of IronPython 3 are not yet provided.
 
 ## Build
+Make sure you **clone the Git repository recursively** (with `--recurse`) to clone all submodules.
+
 On Windows machines, start a Visual Studio command prompt and type:
 
     > make


### PR DESCRIPTION
Hi,

I don't know how critical this is, but I ran into it twice, so I thought I'd updated the `README` to explicitly mention cloning this repository recursively. (Without this, you run `make` and wonder why the DLR project files are missing.)