### PR TITLE
Dictionary views

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,8 @@ indent_size = 4
 [*.cs]
 csharp_new_line_before_open_brace = none
 csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
 
 # disable default VS2017 naming rule
 dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity = none

--- a/Build/Common.proj
+++ b/Build/Common.proj
@@ -87,7 +87,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <DefineConstants>$(Features);$(SignedSym);$(PlatformSymbols);TRACE</DefineConstants>
+    <DefineConstants>$(Features);$(SignedSym);$(PlatformSymbols);IPY3;TRACE</DefineConstants>
   </PropertyGroup>
 
   <!-- Debug -->
@@ -97,7 +97,6 @@
     <Optimize>false</Optimize>
     <!-- TODO: Python & zlib.net need some work -->
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <DefineConstants>$(Features);$(SignedSym);$(PlatformSymbols);DEBUG;TRACE</DefineConstants>
+    <DefineConstants>$(Features);$(SignedSym);$(PlatformSymbols);IPY3;DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
- 
 </Project>

--- a/Src/IronPython.Modules/_collections.cs
+++ b/Src/IronPython.Modules/_collections.cs
@@ -982,13 +982,17 @@ namespace IronPython.Modules {
                 return String.Format("defaultdict({0}, {1})", PythonOps.Repr(context, default_factory), base.__repr__(context));
             }
 
-            public PythonTuple __reduce__() {
+            public PythonTuple __reduce__(CodeContext context) {
                 return PythonTuple.MakeTuple(
                     DynamicHelpers.GetPythonType(this),
                     PythonTuple.MakeTuple(default_factory),
                     null,
                     null,
+#if IPY3
+                    Builtin.iter(context, PythonOps.Invoke(context, this, nameof(PythonDictionary.items)))
+#else
                     iteritems()
+#endif
                 );
             }
         }

--- a/Src/IronPython/Runtime/Types/MappingProxy.cs
+++ b/Src/IronPython/Runtime/Types/MappingProxy.cs
@@ -25,7 +25,7 @@ using Microsoft.Scripting.Utils;
 
 namespace IronPython.Runtime.Types {
     [PythonType("mappingproxy")]
-    public class MappingProxy : IDictionary, IEnumerable, IDictionary<object, object> {
+    public class MappingProxy : IDictionary<object, object>, IDictionary {
         internal PythonDictionary Dictionary { get; }
 
         internal MappingProxy(CodeContext context, PythonType/*!*/ dt) {
@@ -69,24 +69,12 @@ namespace IronPython.Runtime.Types {
             return Dictionary.values();
         }
 
-        public List items(CodeContext context) {
+        public object items(CodeContext context) {
             return Dictionary.items();
         }
 
         public PythonDictionary copy(CodeContext/*!*/ context) {
             return new PythonDictionary(context, this);
-        }
-
-        public IEnumerator iteritems(CodeContext/*!*/ context) {
-            return new DictionaryItemEnumerator(Dictionary._storage);
-        }
-
-        public IEnumerator iterkeys(CodeContext/*!*/ context) {
-            return new DictionaryKeyEnumerator(Dictionary._storage);
-        }
-
-        public IEnumerator itervalues(CodeContext/*!*/ context) {
-            return new DictionaryValueEnumerator(Dictionary._storage);
         }
 
         #endregion
@@ -126,8 +114,8 @@ namespace IronPython.Runtime.Types {
 
         #region IEnumerable Members
 
-        System.Collections.IEnumerator IEnumerable.GetEnumerator() {
-            return DictionaryOps.iterkeys(Dictionary);
+        IEnumerator IEnumerable.GetEnumerator() {
+            return Dictionary.keys().GetEnumerator();
         }
 
         #endregion
@@ -145,7 +133,7 @@ namespace IronPython.Runtime.Types {
         }
 
         IDictionaryEnumerator IDictionary.GetEnumerator() {
-            return new PythonDictionary.DictEnumerator(Dictionary.GetEnumerator());
+            return ((IDictionary)Dictionary).GetEnumerator();
         }
 
         bool IDictionary.IsFixedSize {

--- a/Src/IronPythonConsoleAny/IronPythonConsoleAny.csproj
+++ b/Src/IronPythonConsoleAny/IronPythonConsoleAny.csproj
@@ -15,6 +15,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\IronPython\IronPython.csproj" />
+    <ProjectReference Include="..\IronPython.Modules\IronPython.Modules.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\IronPythonConsole\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
@@ -22,7 +25,7 @@
     <Compile Include="..\IronPythonConsole\Console.cs" Link="Console.cs" />
   </ItemGroup>
   <Import Project="$(BeforeTargetFiles)" />
-  <Target Name="BeforeBuildStarts" BeforeTargets="BeforeBuild" DependsOnTargets="$(BeforeTargets);GenerateCurrentVersion"/>
+  <Target Name="BeforeBuildStarts" BeforeTargets="BeforeBuild" DependsOnTargets="$(BeforeTargets);GenerateCurrentVersion" />
   <ItemGroup>
     <!-- if the file does not exist it's not picked up automatically -->
     <Compile Remove="Properties\CurrentVersion.Generated.cs" />

--- a/WhatsNewInPython30.md
+++ b/WhatsNewInPython30.md
@@ -4,8 +4,8 @@ https://docs.python.org/3/whatsnew/3.0.html
 
 Views And Iterators Instead Of Lists
 =======================
-- [ ] dict methods dict.keys(), dict.items() and dict.values() return "views" instead of lists. For example, this no longer works: k = d.keys(); k.sort(). Use k = sorted(d) instead (this works in Python 2.5 too and is just as efficient).
-- [ ] Also, the dict.iterkeys(), dict.iteritems() and dict.itervalues() methods are no longer supported.
+- [x] dict methods dict.keys(), dict.items() and dict.values() return "views" instead of lists. For example, this no longer works: k = d.keys(); k.sort(). Use k = sorted(d) instead (this works in Python 2.5 too and is just as efficient).
+- [x] Also, the dict.iterkeys(), dict.iteritems() and dict.itervalues() methods are no longer supported.
 - [x] map() and filter() return iterators. If you really need a list, a quick fix is e.g. list(map(...)), but a better fix is often to use a list comprehension (especially when the original code uses lambda), or rewriting the code so it doesn't need a list at all. Particularly tricky is map() invoked for the side effects of the function; the correct transformation is to use a regular for loop (since creating a list would just be wasteful).
 - [x] zip() now returns an iterator.
 


### PR DESCRIPTION
Changes dictionary `keys`, `values` and `items` methods to return views instead of lists. Also eliminated the `iterkeys`, `itervalues` and `iteritems` methods.

This is a somewhat experimental PR in that it also makes `PythonDictionary.cs` IPY2/IPY3 compatible using preprocessor directived (meaning that the exact same file should work in both code bases).

Edit: `test_dictviews` should be passing all tests except for pickling related stuff.