### PR TITLE
Remove mandatory future features

### DIFF
--- a/Src/IronPython/Compiler/Ast/FromImportStatement.cs
+++ b/Src/IronPython/Compiler/Ast/FromImportStatement.cs
@@ -30,7 +30,6 @@ namespace IronPython.Compiler.Ast {
         private readonly string[] _names;
         private readonly string[] _asNames;
         private readonly bool _fromFuture;
-        private readonly bool _forceAbsolute;
 
         private PythonVariable[] _variables;
 
@@ -59,12 +58,11 @@ namespace IronPython.Compiler.Ast {
             set { _variables = value; }
         }
 
-        public FromImportStatement(ModuleName root, string[] names, string[] asNames, bool fromFuture, bool forceAbsolute) {
+        public FromImportStatement(ModuleName root, string[] names, string[] asNames, bool fromFuture) {
             _root = root;
             _names = names;
             _asNames = asNames;
             _fromFuture = fromFuture;
-            _forceAbsolute = forceAbsolute;
         }
 
         public override MSAst.Expression Reduce() {
@@ -139,11 +137,7 @@ namespace IronPython.Compiler.Ast {
                 return rmn.DotCount;
             }
 
-            if (_forceAbsolute) {
-                return 0;
-            }
-
-            return -1;
+            return 0;
         }
 
         public override void Walk(PythonWalker walker) {

--- a/Src/IronPython/Compiler/Ast/ImportStatement.cs
+++ b/Src/IronPython/Compiler/Ast/ImportStatement.cs
@@ -28,14 +28,12 @@ namespace IronPython.Compiler.Ast {
     public class ImportStatement : Statement {
         private readonly ModuleName[] _names;
         private readonly string[] _asNames;
-        private readonly bool _forceAbsolute;
 
         private PythonVariable[] _variables;
 
-        public ImportStatement(ModuleName[] names, string[] asNames, bool forceAbsolute) {
+        public ImportStatement(ModuleName[] names, string[] asNames) {
             _names = names;
             _asNames = asNames;
-            _forceAbsolute = forceAbsolute;
         }
 
         internal PythonVariable[] Variables {
@@ -63,9 +61,9 @@ namespace IronPython.Compiler.Ast {
                             LightExceptions.CheckAndThrow(
                                 Expression.Call(
                                     _asNames[i] == null ? AstMethods.ImportTop : AstMethods.ImportBottom,
-                                    Parent.LocalContext,                                     // 1st arg - code context
-                                    AstUtils.Constant(_names[i].MakeString()),                   // 2nd arg - module name
-                                    AstUtils.Constant(_forceAbsolute ? 0 : -1)                   // 3rd arg - absolute or relative imports
+                                    Parent.LocalContext,                                    // 1st arg - code context
+                                    AstUtils.Constant(_names[i].MakeString()),              // 2nd arg - module name
+                                    AstUtils.Constant(0)                                    // 3rd arg - absolute imports
                                 )
                             )
                         ),

--- a/Src/IronPython/Compiler/Ast/PythonAst.cs
+++ b/Src/IronPython/Compiler/Ast/PythonAst.cs
@@ -335,24 +335,6 @@ namespace IronPython.Compiler.Ast {
 
         #region Public API
 
-        /// <summary>
-        /// True if the with statement is enabled in this AST.
-        /// </summary>
-        public bool AllowWithStatement {
-            get {
-                return (_languageFeatures & ModuleOptions.WithStatement) != 0;
-            }
-        }
-
-        /// <summary>
-        /// True if absolute imports are enabled
-        /// </summary>
-        public bool AbsoluteImports {
-            get {
-                return (_languageFeatures & ModuleOptions.AbsoluteImports) != 0;
-            }
-        }
-
         public Statement Body {
             get { return _body; }
         }

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -773,7 +773,7 @@ namespace IronPython.Compiler {
             ModuleName[] names = l.ToArray();
             var asNames = las.ToArray();
 
-            ImportStatement ret = new ImportStatement(names, asNames, AbsoluteImports);
+            ImportStatement ret = new ImportStatement(names, asNames);
             ret.SetLoc(_globalParent, start, GetEnd());
             return ret;
         }
@@ -871,14 +871,13 @@ namespace IronPython.Compiler {
                     if (name == "division") {
                         // Ignored in Python 3
                     } else if (name == "with_statement") {
-                        _languageFeatures |= ModuleOptions.WithStatement;
+                        // Ignored in Python 2.7
                     } else if (name == "absolute_import") {
-                        _languageFeatures |= ModuleOptions.AbsoluteImports;
+                        // Ignored in Python 3
                     } else if (name == "print_function") {
                         // Ignored in Python 3
                     } else if (name == "unicode_literals") {
-                        _tokenizer.UnicodeLiterals = true;
-                        _languageFeatures |= ModuleOptions.UnicodeLiterals;
+                        // Ignored in Python 3
                     } else if (name == "nested_scopes") {
                     } else if (name == "generators") {
                     } else {
@@ -899,7 +898,7 @@ namespace IronPython.Compiler {
                 Eat(TokenKind.RightParenthesis);
             }
 
-            FromImportStatement ret = new FromImportStatement(dname, (string[])names, asNames, fromFuture, AbsoluteImports);
+            FromImportStatement ret = new FromImportStatement(dname, (string[])names, asNames, fromFuture);
             ret.SetLoc(_globalParent, start, GetEnd());
             return ret;
         }
@@ -3288,10 +3287,6 @@ namespace IronPython.Compiler {
                 new SourceSpan(_tokenizer.CurrentPosition, _tokenizer.CurrentPosition),
                 _sourceUnit.Path
             );
-        }
-
-        private bool AbsoluteImports {
-            get { return (_languageFeatures & ModuleOptions.AbsoluteImports) == ModuleOptions.AbsoluteImports; }
         }
 
         private void StartParsing() {

--- a/Src/IronPython/Compiler/PythonCompilerOptions.cs
+++ b/Src/IronPython/Compiler/PythonCompilerOptions.cs
@@ -66,26 +66,6 @@ namespace IronPython.Compiler {
             }
         }
 
-        public bool AllowWithStatement {
-            get {
-                return (_module & ModuleOptions.WithStatement) != 0;
-            }
-            set {
-                if (value) _module |= ModuleOptions.WithStatement;
-                else _module &= ~ModuleOptions.WithStatement;
-            }
-        }
-
-        public bool AbsoluteImports {
-            get {
-                return (_module & ModuleOptions.AbsoluteImports) != 0;
-            }
-            set {
-                if (value) _module |= ModuleOptions.AbsoluteImports;
-                else _module &= ~ModuleOptions.AbsoluteImports;
-            }
-        }
-
         public bool Verbatim {
             get {
                 return (_module & ModuleOptions.Verbatim) != 0;
@@ -93,16 +73,6 @@ namespace IronPython.Compiler {
             set {
                 if (value) _module |= ModuleOptions.Verbatim;
                 else _module &= ~ModuleOptions.Verbatim;
-            }
-        }
-
-        public bool UnicodeLiterals {
-            get {
-                return (_module & ModuleOptions.UnicodeLiterals) != 0;
-            }
-            set {
-                if (value) _module |= ModuleOptions.UnicodeLiterals;
-                else _module &= ~ModuleOptions.UnicodeLiterals;
             }
         }
 

--- a/Src/IronPython/Compiler/Tokenizer.cs
+++ b/Src/IronPython/Compiler/Tokenizer.cs
@@ -44,7 +44,7 @@ namespace IronPython.Compiler {
         private SourceUnit _sourceUnit;
         private ErrorSink _errors;
         private Severity _indentationInconsistencySeverity;
-        private bool _endContinues, _unicodeLiterals;
+        private bool _endContinues;
         private List<int> _newLineLocations;
         private SourceLocation _initialLocation;
         private TextReader _reader;
@@ -81,7 +81,6 @@ namespace IronPython.Compiler {
             _verbatim = options.Verbatim;
             _state = new State(null);
             _dontImplyDedent = options.DontImplyDedent;
-            _unicodeLiterals = options.UnicodeLiterals;
             _names = new Dictionary<object, NameToken>(128, new TokenEqualityComparer(this));
         }
 
@@ -307,15 +306,6 @@ namespace IronPython.Compiler {
             }
             tokenString = GetTokenString();
             return true;
-        }
-
-        internal bool UnicodeLiterals {
-            get {
-                return _unicodeLiterals;
-            }
-            set {
-                _unicodeLiterals = value;
-            }
         }
 
         public Token GetNextToken() {

--- a/Src/IronPython/Hosting/PythonCommandLine.cs
+++ b/Src/IronPython/Hosting/PythonCommandLine.cs
@@ -301,7 +301,7 @@ namespace IronPython.Hosting {
                 return;
 
             try {
-                Importer.ImportModule(PythonContext.SharedContext, null, "site", false, -1);
+                Importer.ImportModule(PythonContext.SharedContext, null, "site", false, 0);
             } catch (Exception e) {
                 Console.Write(Language.FormatException(e), Style.Error);
             }

--- a/Src/IronPython/Hosting/PythonService.cs
+++ b/Src/IronPython/Hosting/PythonService.cs
@@ -92,7 +92,7 @@ namespace IronPython.Hosting {
         }
 
         public ScriptScope/*!*/ ImportModule(ScriptEngine/*!*/ engine, string/*!*/ name) {
-            PythonModule module = Importer.ImportModule(_context.SharedClsContext, _context.SharedClsContext.GlobalDict, name, false, -1) as PythonModule;
+            PythonModule module = Importer.ImportModule(_context.SharedClsContext, _context.SharedClsContext.GlobalDict, name, false, 0) as PythonModule;
             if (module != null) {
                 return HostingHelpers.CreateScriptScope(engine, module.Scope);
             }

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -72,15 +72,9 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             }
         }
 
-        [Documentation("__import__(name) -> module\n\nImport a module.")]
-        [LightThrowing]
-        public static object __import__(CodeContext/*!*/ context, string name) {
-            return __import__(context, name, null, null, null, -1);
-        }
-
         [Documentation("__import__(name, globals, locals, fromlist, level) -> module\n\nImport a module.")]
         [LightThrowing]
-        public static object __import__(CodeContext/*!*/ context, string name, object globals=null, object locals=null, object fromlist=null, int level=-1) {
+        public static object __import__(CodeContext/*!*/ context, string name, object globals=null, object locals=null, object fromlist=null, int level=0) {
             if (fromlist is string || fromlist is Extensible<string>) {
                 fromlist = new List<object> { fromlist };
             }
@@ -1728,16 +1722,16 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             
             ModuleOptions langFeat = ModuleOptions.None;
             if ((cflags & CompileFlags.CO_FUTURE_WITH_STATEMENT) != 0) {
-                langFeat |= ModuleOptions.WithStatement;
+                // Ignored in Python 2.7
             }
             if ((cflags & CompileFlags.CO_FUTURE_ABSOLUTE_IMPORT) != 0) {
-                langFeat |= ModuleOptions.AbsoluteImports;
+                // Ignored in Python 3
             }
             if ((cflags & CompileFlags.CO_FUTURE_PRINT_FUNCTION) != 0) {
                 // Ignored in Python 3
             }
             if ((cflags & CompileFlags.CO_FUTURE_UNICODE_LITERALS) != 0) {
-                langFeat |= ModuleOptions.UnicodeLiterals;
+                // Ignored in Python 3
             }
             pco.Module |= langFeat;
 

--- a/Src/IronPython/Modules/_ast.cs
+++ b/Src/IronPython/Modules/_ast.cs
@@ -1962,7 +1962,7 @@ namespace IronPython.Modules
                     moduleNames[i] = new ModuleName(alias.name.Split(MODULE_NAME_SPLITTER));
                     asNames[i] = alias.asname;
                 }
-                return new ImportStatement(moduleNames, asNames, false);  // TODO: not so sure about the relative/absolute argument here
+                return new ImportStatement(moduleNames, asNames);
             }
 
             public PythonList names { get; set; }
@@ -1996,17 +1996,15 @@ namespace IronPython.Modules
 
             internal override Statement Revert() {
                 ModuleName root = null;
-                bool absolute = false; // TODO: absolute import appears in ModuleOptions, not sure how it should work together
                 if (module != null)
                     if (module[0] == '.') // relative module
                         root = new RelativeModuleName(module.Split(MODULE_NAME_SPLITTER), level);
                     else {
                         root = new ModuleName(module.Split(MODULE_NAME_SPLITTER));
-                        absolute = true;
                     }
 
                 if (names.Count == 1 && ((alias)names[0]).name == "*")
-                    return new FromImportStatement(root, (string[])FromImportStatement.Star, null, false, absolute);
+                    return new FromImportStatement(root, (string[])FromImportStatement.Star, null, false);
 
                 String[] newNames = new String[names.Count];
                 String[] asNames = new String[names.Count];
@@ -2015,7 +2013,7 @@ namespace IronPython.Modules
                     newNames[i] = alias.name;
                     asNames[i] = alias.asname;
                 }
-                return new FromImportStatement(root, newNames, asNames, false, absolute);
+                return new FromImportStatement(root, newNames, asNames, false);
             }
 
             public string module { get; set; }

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -777,7 +777,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
             try {
                 PythonModule zipimport = Importer.ImportModule(
                     context.SharedClsContext, context.SharedClsContext.GlobalDict,
-                    "zipimport", false, -1) as PythonModule;
+                    "zipimport", false, 0) as PythonModule;
                 if (zipimport != null) {
                     object zipimporter = PythonOps.GetBoundAttr(
                         context.SharedClsContext, zipimport, "zipimporter");

--- a/Src/IronPython/Runtime/Importer.cs
+++ b/Src/IronPython/Runtime/Importer.cs
@@ -47,6 +47,8 @@ namespace IronPython.Runtime {
         /// a module and returns the module.
         /// </summary>
         public static object Import(CodeContext/*!*/ context, string fullName, PythonTuple from, int level) {
+            if (level < 0) throw new ArgumentException("level must be >= 0", nameof(level));
+
             return LightExceptions.CheckAndThrow(ImportLightThrow(context, fullName, from, level));
         }
 
@@ -56,39 +58,21 @@ namespace IronPython.Runtime {
         /// </summary>
         [LightThrowing]
         internal static object ImportLightThrow(CodeContext/*!*/ context, string fullName, PythonTuple from, int level) {
+            Debug.Assert(level >= 0);
+
             PythonContext pc = context.LanguageContext;
 
-            if (level == -1) {
-                // no specific level provided, call the 4 param version so legacy code continues to work
-                var site = pc.OldImportSite;
-                return site.Target(
-                    site,
-                    context,
-                    FindImportFunction(context),
-                    fullName,
-                    Builtin.globals(context),
-                    context.Dict,
-                    from
-                );
-            } else {
-
-                // relative import or absolute import, in other words:
-                //
-                // from . import xyz
-                // or 
-                // from __future__ import absolute_import
-                var site = pc.ImportSite;
-                return site.Target(
-                    site,
-                    context,
-                    FindImportFunction(context),
-                    fullName,
-                    Builtin.globals(context),
-                    context.Dict,
-                    from,
-                    level
-                );
-            }
+            var site = pc.ImportSite;
+            return site.Target(
+                site,
+                context,
+                FindImportFunction(context),
+                fullName,
+                Builtin.globals(context),
+                context.Dict,
+                from,
+                level
+            );
         }
 
         /// <summary>
@@ -186,11 +170,12 @@ namespace IronPython.Runtime {
         /// Called by the __builtin__.__import__ functions (general importing) and ScriptEngine (for site.py)
         /// 
         /// level indiciates whether to perform absolute or relative imports.
-        ///     -1 indicates both should be performed
         ///     0 indicates only absolute imports should be performed
         ///     Positive numbers indicate the # of parent directories to search relative to the calling module
         /// </summary>        
         public static object ImportModule(CodeContext/*!*/ context, object globals, string/*!*/ modName, bool bottom, int level) {
+            if (level < 0) throw PythonOps.ValueError("level must be >= 0");
+
             if (modName.IndexOf(Path.DirectorySeparatorChar) != -1) {
                 throw PythonOps.ImportError("Import by filename is not supported.", modName);
             }
@@ -230,7 +215,7 @@ namespace IronPython.Runtime {
             }
             string finalName = null;
 
-            if (level != 0) {
+            if (level > 0) {
                 // try a relative import
 
                 // if importing a.b.c, import "a" first and then import b.c from a
@@ -262,7 +247,7 @@ namespace IronPython.Runtime {
                 }
             }
 
-            if (level <= 0) {
+            if (level == 0) {
                 // try an absolute import
                 if (newmod == null) {
                     object parentPkg;
@@ -333,7 +318,7 @@ namespace IronPython.Runtime {
         /// <param name="package">the global __package__ value</param>
         /// <returns></returns>
         private static bool TryGetNameAndPath(CodeContext/*!*/ context, object globals, string name, int level, string package, out string full, out List path, out PythonModule parentMod) {
-            Debug.Assert(level != 0);   // shouldn't be here for absolute imports
+            Debug.Assert(level > 0);   // shouldn't be here for absolute imports
 
             // Unless we can find enough information to perform relative import,
             // we are going to import the module whose name we got
@@ -363,14 +348,7 @@ namespace IronPython.Runtime {
                 if (pyGlobals._storage.TryGetPath(out attribute) && (path = attribute as List) != null) {
                     // found __path__, importing nested module. The actual name of the nested module
                     // is the name of the mod plus the name of the imported module
-                    if (level == -1) {
-                        // absolute import of some module
-                        full = modName + "." + name;
-                        object parentModule;
-                        if (context.LanguageContext.SystemStateModules.TryGetValue(modName, out parentModule)) {
-                            parentMod = parentModule as PythonModule;
-                        }
-                    } else if (String.IsNullOrEmpty(name)) {
+                    if (String.IsNullOrEmpty(name)) {
                         // relative import of ancestor
                         full = (StringOps.rsplit(modName, ".", level - 1)[0] as string);
                     } else {
@@ -432,9 +410,10 @@ namespace IronPython.Runtime {
         }
 
         private static string GetParentPackageName(int level, string[] names) {
+            Debug.Assert(level >= 0);
+
             StringBuilder parentName = new StringBuilder(names[0]);
 
-            if (level < 0) level = 1;
             for (int i = 1; i < names.Length - level; i++) {
                 parentName.Append('.');
                 parentName.Append(names[i]);

--- a/Src/IronPython/Runtime/ModuleOptions.cs
+++ b/Src/IronPython/Runtime/ModuleOptions.cs
@@ -35,14 +35,6 @@ namespace IronPython.Runtime {
         /// </summary>
         Initialize = 0x0008,
         /// <summary>
-        /// Enable usage of the with statement
-        /// </summary>
-        WithStatement = 0x0010,
-        /// <summary>
-        /// Enable absolute imports
-        /// </summary>
-        AbsoluteImports = 0x0020,
-        /// <summary>
         /// Indiciates that __builtins__ should not be set in the module
         /// </summary>
         NoBuiltins = 0x0040,
@@ -66,10 +58,6 @@ namespace IronPython.Runtime {
         /// </summary>
         Interpret = 0x1000,
         /// <summary>
-        /// String Literals should be parsed as Unicode strings
-        /// </summary>
-        UnicodeLiterals = 0x2000,
-        /// <summary>
         /// Include comments in the parse tree
         /// </summary>
         Verbatim = 0x4000,
@@ -78,5 +66,4 @@ namespace IronPython.Runtime {
         /// </summary>
         LightThrow = 0x8000
     }
-
 }

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -110,7 +110,6 @@ namespace IronPython.Runtime
         private CallSite<Func<CallSite, CodeContext, object, object[], IDictionary<object, object>, object>> _callDictSite;
         private CallSite<Func<CallSite, CodeContext, object, object, object, object>> _callDictSiteLooselyTyped;
         private CallSite<Func<CallSite, CodeContext, object, string, PythonDictionary, PythonDictionary, PythonTuple, int, object>> _importSite;
-        private CallSite<Func<CallSite, CodeContext, object, string, PythonDictionary, PythonDictionary, PythonTuple, object>> _oldImportSite;
         private CallSite<Func<CallSite, object, bool>> _isCallableSite;
         private CallSite<Func<CallSite, object, IList<string>>> _getSignaturesSite;
         private CallSite<Func<CallSite, object, object, object>> _addSite, _divModSite, _rdivModSite;
@@ -1230,7 +1229,7 @@ namespace IronPython.Runtime
             object warnings = null;
             try {
                 if (!_importWarningThrows) {
-                    warnings = Importer.ImportModule(SharedContext, new PythonDictionary(), "warnings", false, -1);
+                    warnings = Importer.ImportModule(SharedContext, new PythonDictionary(), "warnings", false, 0);
                 }
             } catch {
                 // don't repeatedly import after it fails
@@ -1242,7 +1241,7 @@ namespace IronPython.Runtime
         public void EnsureEncodings() {
             if (!_importedEncodings) {
                 try {
-                    Importer.ImportModule(SharedContext, new PythonDictionary(), "encodings", false, -1);
+                    Importer.ImportModule(SharedContext, new PythonDictionary(), "encodings", false, 0);
                 } catch (ImportException) {
                 }
                 _importedEncodings = true;
@@ -2904,24 +2903,6 @@ namespace IronPython.Runtime
                 }
 
                 return _importSite;
-            }
-        }
-
-        internal CallSite<Func<CallSite, CodeContext, object, string, PythonDictionary, PythonDictionary, PythonTuple, object>> OldImportSite {
-            get {
-                if (_oldImportSite == null) {
-                    Interlocked.CompareExchange(
-                        ref _oldImportSite,
-                        CallSite<Func<CallSite, CodeContext, object, string, PythonDictionary, PythonDictionary, PythonTuple, object>>.Create(
-                            Invoke(
-                                new CallSignature(4)
-                            ).GetLightExceptionBinder()
-                        ),
-                        null
-                    );
-                }
-
-                return _oldImportSite;
             }
         }
 

--- a/WhatsNewInPython30.md
+++ b/WhatsNewInPython30.md
@@ -73,7 +73,7 @@ Removed Syntax
 - [x] Integer literals no longer support a trailing l or L.
 - [x] ~~String literals no longer support a leading u or U.~~ (Readded in Python 3.3)
 - [ ] The from module import * syntax is only allowed at the module level, no longer inside functions.
-- [ ] The only acceptable syntax for relative imports is from .[module] import name. All import forms not starting with . are interpreted as absolute imports. (PEP 0328)
+- [x] The only acceptable syntax for relative imports is from .[module] import name. All import forms not starting with . are interpreted as absolute imports. (PEP 0328)
 - [x] Classic classes are gone.
 
 Library Changes


### PR DESCRIPTION
Makes absolute imports on by default. Removes code related to `with_statement` and `unicode_literals` which are already on by default.