### PR TITLE
Fix #395

### DIFF
--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -42,10 +42,10 @@ namespace IronPython.Runtime.Operations {
             return StringOps.Quote(Value);
         }
 
-        #endregion        
+        #endregion
 
         [return: MaybeNotImplemented]
-        public object __eq__(object other) {
+        public virtual object __eq__(object other) {
             if (other is string || other is ExtensibleString || other is Bytes) {
                 return ScriptingRuntimeHelpers.BooleanToObject(EqualsWorker(other));
             }
@@ -54,7 +54,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         [return: MaybeNotImplemented]
-        public object __ne__(object other) {
+        public virtual object __ne__(object other) {
             if (other is string || other is ExtensibleString || other is Bytes) {
                 return ScriptingRuntimeHelpers.BooleanToObject(!EqualsWorker(other));
             }


### PR DESCRIPTION
```
IronPython 3.4.0a0 (3.4.0.0) on .NET 4.0.30319.42000 (64-bit)
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> assert sys.platform =="win32"
>>> assert sys.platform == "cli"
>>> assert not sys.platform != "win32"
>>> assert not sys.platform != "cli"
>>> assert not sys.platform == "bla"
>>> assert sys.platform != "bla"
```