### PR TITLE
Implement List.copy, cmath.isfinite, array.typecodes

### DIFF
--- a/Src/IronPython.Modules/cmath.cs
+++ b/Src/IronPython.Modules/cmath.cs
@@ -362,6 +362,12 @@ namespace IronPython.Modules {
             return IsNaN(num);
         }
 
+        public static bool isfinite(object x) {
+            Complex num = GetComplexNum(x);
+
+            return IsFinite(num);
+        }
+
         #region Helpers
 
         private static bool IsInfinity(Complex num) {
@@ -370,6 +376,12 @@ namespace IronPython.Modules {
 
         private static bool IsNaN(Complex num) {
             return double.IsNaN(num.Real) || double.IsNaN(num.Imaginary());
+        }
+
+        private static bool IsFinite(Complex num) {
+            // double.IsFinite is not available in .NET Framework 4.5 and was added to .NET Core in 2.1
+            return !double.IsInfinity(num.Real) && !double.IsNaN(num.Real)
+                && !double.IsInfinity(num.Imaginary) && !double.IsNaN(num.Imaginary);
         }
 
         private static double GetAngle(Complex num) {

--- a/Src/IronPython/Modules/array.cs
+++ b/Src/IronPython/Modules/array.cs
@@ -28,6 +28,8 @@ namespace IronPython.Modules {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         public static readonly PythonType/*!*/ ArrayType = DynamicHelpers.GetPythonTypeFromType(typeof(array));
 
+        public static readonly string typecodes = "cbBuHhiIlLfd";
+
         [PythonType]
         public class array : IPythonArray, IEnumerable, IWeakReferenceable, ICollection, ICodeFormattable, IList<object>, IStructuralEquatable
         {

--- a/Src/IronPython/Runtime/List.cs
+++ b/Src/IronPython/Runtime/List.cs
@@ -1108,6 +1108,10 @@ namespace IronPython.Runtime {
             return true;
         }
 
+        public List copy() {
+            return new List(this);
+        }
+
         #region IList Members
 
         bool IList.IsReadOnly {


### PR DESCRIPTION
These methods/constants were added prior to Python 3.4.