### PR TITLE
Add sys.hash_info and update number hashing

### DIFF
--- a/Src/IronPython/Lib/iptest/type_util.py
+++ b/Src/IronPython/Lib/iptest/type_util.py
@@ -5,7 +5,7 @@
 # types derived from built-in types
 
 class myint(int): pass
-class mylong(long): pass
+class mylong(int): pass
 class myfloat(float): pass
 class mycomplex(complex): pass
 

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -469,7 +469,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         }
 
         public static int hash(CodeContext/*!*/ context, int o) {
-            return o;
+            return Int32Ops.__hash__(o);
         }
 
         public static int hash(CodeContext/*!*/ context, [NotNull]string o) {

--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -2933,7 +2933,7 @@ namespace IronPython.Modules {
                     output = PythonOps.CallWithKeywordArgs(
                         context,
                         PythonOps.GetBoundAttr(context, _decoder, "decode"),
-                        new object[] { input, true },
+                        new object[] { input, final },
                         new string[] { "final" }
                     );
                 }

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -706,7 +706,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
             2,                  // FLT_RADIX
             1);                 // FLT_ROUNDS
 
-        [PythonType("sys.float_info"), PythonHidden]
+        [PythonType("float_info"), PythonHidden]
         public class floatinfo : PythonTuple {
             internal floatinfo(double max, int max_exp, int max_10_exp,
                                double min, int min_exp, int min_10_exp,
@@ -754,6 +754,42 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
             }
         }
 
+        public static hashinfo hash_info = new hashinfo(width: 32, modulus: int.MaxValue, inf: 314159, nan: 0, imag: 1000003, algorithm: "dotnet", hash_bits: 0, seed_bits:0, cutoff: 0);
+
+        [PythonType("hash_info"), PythonHidden]
+        public class hashinfo : PythonTuple {
+            internal hashinfo(int width, int modulus, int inf, int nan, int imag, string algorithm, int hash_bits, int seed_bits, int cutoff)
+                : base(new object[] { width, modulus, inf, nan, imag, algorithm, hash_bits, seed_bits, cutoff }) {
+
+                this.width = width;
+                this.modulus = modulus;
+                this.inf = inf;
+                this.nan = nan;
+                this.imag = imag;
+                this.algorithm = algorithm;
+                this.hash_bits = hash_bits;
+                this.seed_bits = seed_bits;
+                this.cutoff = cutoff;
+            }
+
+            public readonly int width;
+            public readonly int modulus;
+            public readonly int inf;
+            public readonly int nan;
+            public readonly int imag;
+            public readonly string algorithm;
+            public readonly int hash_bits;
+            public readonly int seed_bits;
+            public readonly int cutoff;
+
+            public const int n_fields = 11;
+            public const int n_sequence_fields = 11;
+            public const int n_unnamed_fields = 0;
+
+            public override string __repr__(CodeContext context) {
+                return $"sys.hash_info(width={width}, modulus={modulus}, inf={inf}, nan={nan}, imag={imag}, algorithm='{algorithm}', hash_bits={hash_bits}, seed_bits={seed_bits}, cutoff={cutoff})";
+            }
+        }
 
         [SpecialName]
         public static void PerformModuleReload(PythonContext/*!*/ context, PythonDictionary/*!*/ dict) {

--- a/Src/IronPython/Runtime/Operations/DecimalOps.cs
+++ b/Src/IronPython/Runtime/Operations/DecimalOps.cs
@@ -78,9 +78,9 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static int __hash__(decimal x) {
-            return ((BigInteger)x).GetHashCode();   
+            // TODO: This should be made consistent with Python number hashing
+            return ((BigInteger)x).GetHashCode();
         }
-
 
         public static string __format__(CodeContext/*!*/ context, decimal self, [NotNull]string/*!*/ formatSpec) {
             StringFormatSpec spec = StringFormatSpec.FromString(formatSpec);

--- a/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
@@ -92,6 +92,7 @@ namespace IronPython.Runtime.Operations {
             return x;
         }
         public static int __hash__(SByte x) {
+            if (x == -1) return -2;
             return unchecked((int)x);
         }
         public static int __index__(SByte x) {
@@ -635,6 +636,7 @@ namespace IronPython.Runtime.Operations {
             return x;
         }
         public static int __hash__(Int16 x) {
+            if (x == -1) return -2;
             return unchecked((int)x);
         }
         public static int __index__(Int16 x) {
@@ -1151,6 +1153,8 @@ namespace IronPython.Runtime.Operations {
             return x;
         }
         public static int __hash__(Int32 x) {
+            if (x == -1 || x == int.MinValue) return -2;
+            if (x == int.MaxValue || x == int.MinValue + 1) return 0;
             return unchecked((int)x);
         }
         public static int __index__(Int32 x) {
@@ -1361,7 +1365,7 @@ namespace IronPython.Runtime.Operations {
             return x;
         }
         public static int __hash__(UInt32 x) {
-            return unchecked((int)x);
+            return unchecked((int)((x >= int.MaxValue) ? (x % int.MaxValue) : x));
         }
         public static int __index__(UInt32 x) {
             return unchecked((int)x);
@@ -1677,15 +1681,14 @@ namespace IronPython.Runtime.Operations {
             return x;
         }
         public static int __hash__(Int64 x) {
-            Int64 tmp = x;
-            if (tmp < 0) {
-                tmp *= -1;
-            }
-            int total = unchecked((int) (((uint)tmp) + (uint)(tmp >> 32)));
             if (x < 0) {
-                return unchecked(-total);
+                if (x == long.MinValue) return -2;
+                x = -x;
+                var h = unchecked(-(int)((x >= int.MaxValue) ? (x % int.MaxValue) : x));
+                if (h == -1) return -2;
+                return h;
             }
-            return total;
+            return unchecked((int)((x >= int.MaxValue) ? (x % int.MaxValue) : x));
         }
 
         public static BigInteger __index__(Int64 x) {
@@ -1915,11 +1918,7 @@ namespace IronPython.Runtime.Operations {
             return x;
         }
         public static int __hash__(UInt64 x) {
-            int total = unchecked((int) (((uint)x) + (uint)(x >> 32)));
-            if (x < 0) {
-                return unchecked(-total);
-            }
-            return total;
+            return unchecked((int)((x >= int.MaxValue) ? (x % int.MaxValue) : x));
         }
 
         public static BigInteger __index__(UInt64 x) {

--- a/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
@@ -1153,6 +1153,7 @@ namespace IronPython.Runtime.Operations {
             return x;
         }
         public static int __hash__(Int32 x) {
+            // for perf we use an if for the 3 int values with abs(x) >= int.MaxValue
             if (x == -1 || x == int.MinValue) return -2;
             if (x == int.MaxValue || x == int.MinValue + 1) return 0;
             return unchecked((int)x);
@@ -1164,26 +1165,26 @@ namespace IronPython.Runtime.Operations {
         // Binary Operations - Arithmetic
         [SpecialName]
         public static object Add(Int32 x, Int32 y) {
-            long result = (long) x + y;
+            long result = (long)x + y;
             if (Int32.MinValue <= result && result <= Int32.MaxValue) {
                 return Microsoft.Scripting.Runtime.ScriptingRuntimeHelpers.Int32ToObject((Int32)(result));
-            } 
+            }
             return BigIntegerOps.Add((BigInteger)x, (BigInteger)y);
         }
         [SpecialName]
         public static object Subtract(Int32 x, Int32 y) {
-            long result = (long) x - y;
+            long result = (long)x - y;
             if (Int32.MinValue <= result && result <= Int32.MaxValue) {
                 return Microsoft.Scripting.Runtime.ScriptingRuntimeHelpers.Int32ToObject((Int32)(result));
-            } 
+            }
             return BigIntegerOps.Subtract((BigInteger)x, (BigInteger)y);
         }
         [SpecialName]
         public static object Multiply(Int32 x, Int32 y) {
-            long result = (long) x * y;
+            long result = (long)x * y;
             if (Int32.MinValue <= result && result <= Int32.MaxValue) {
                 return Microsoft.Scripting.Runtime.ScriptingRuntimeHelpers.Int32ToObject((Int32)(result));
-            } 
+            }
             return BigIntegerOps.Multiply((BigInteger)x, (BigInteger)y);
         }
         [SpecialName]
@@ -1367,8 +1368,8 @@ namespace IronPython.Runtime.Operations {
         public static int __hash__(UInt32 x) {
             return unchecked((int)((x >= int.MaxValue) ? (x % int.MaxValue) : x));
         }
-        public static int __index__(UInt32 x) {
-            return unchecked((int)x);
+        public static BigInteger __index__(UInt32 x) {
+            return unchecked((BigInteger)x);
         }
 
         // Binary Operations - Arithmetic
@@ -1690,7 +1691,6 @@ namespace IronPython.Runtime.Operations {
             }
             return unchecked((int)((x >= int.MaxValue) ? (x % int.MaxValue) : x));
         }
-
         public static BigInteger __index__(Int64 x) {
             return unchecked((BigInteger)x);
         }
@@ -1920,7 +1920,6 @@ namespace IronPython.Runtime.Operations {
         public static int __hash__(UInt64 x) {
             return unchecked((int)((x >= int.MaxValue) ? (x % int.MaxValue) : x));
         }
-
         public static BigInteger __index__(UInt64 x) {
             return unchecked((BigInteger)x);
         }

--- a/Src/StdLib/Lib/test/test_hash.py
+++ b/Src/StdLib/Lib/test/test_hash.py
@@ -166,6 +166,7 @@ class HashBuiltinsTestCase(unittest.TestCase):
         for obj in self.hashes_to_check:
             self.assertEqual(hash(obj), _default_hash(obj))
 
+@unittest.skipIf(sys.implementation.name == "ironpython", "TODO")
 class HashRandomizationTests:
 
     # Each subclass should define a field "repr_", containing the repr() of

--- a/Tests/test_numberhash.py
+++ b/Tests/test_numberhash.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 # Test that hash and equality operations cooperate for numbers.
 #  cmp(x,y)==0 --> hash(x) == hash(y).
 #
@@ -10,25 +9,25 @@
 
 import unittest
 
-from iptest import run_test, skipUnlessIronPython
+from iptest import is_32, is_cli, run_test, skipUnlessIronPython
 
 class NumberHashTest(unittest.TestCase):
 
     def check(self,x,y):
         """Check the hash invariant for equal objects."""
-        self.assertTrue(cmp(x,y)==0)
+        self.assertEqual(x, y)
         self.assertTrue(hash(x) == hash(y))
 
     def test_integer(self):
         i = 123456
-        self.check(i, long(i))
+        self.check(i, int(i))
         self.check(i, float(i))
         self.check(i, complex(i,0))
 
     def test_float_long(self):
         """bug 315746"""
         f=float(1.23e300)
-        l=long(f)
+        l=int(f)
         self.check(f,l)
 
     def test_complex_float(self):
@@ -51,7 +50,7 @@ class NumberHashTest(unittest.TestCase):
 
     def test_bigint_hash_quality(self):
         """Ensure that we have a decent hash function that doesn't just map everything to zero - bug 320659"""
-        l1=long(1.23e300)
+        l1=int(1.23e300)
         h1 = hash(l1)
         self.assertTrue(h1 != 0)
         l2 = l1 + 1
@@ -59,32 +58,33 @@ class NumberHashTest(unittest.TestCase):
         h2 = hash(l2)
         self.assertTrue(h1 != h2)
 
-
     def test_userhash_result(self):
         class x(object):
-            def __hash__(self): return 1L
+            def __init__(self, hash):
+                self.__hash = hash
+            def __hash__(self):
+                return self.__hash
         
-        self.assertEqual(hash(x()), 1)
-
-        class x(object):
-            def __hash__(self): return 1<<33L
-        
-        #if not is_net40: #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=25894
-        self.assertEqual(hash(x()), 2)
+        self.assertEqual(hash(x(1)), 1)
+        if is_cli or is_32:
+            self.assertEqual(hash(x(1<<32)), 2)
+        else:
+            self.assertEqual(hash(x(1<<63)), 4)
 
     @skipUnlessIronPython()
     def test_cli_number_hash(self):
         from iptest.type_util import clr_numbers
         
-        for name, value in clr_numbers.iteritems():
-            if name.find('Single') != -1:
+        for name, value in clr_numbers.items():
+            if "Decimal" in name: continue # https://github.com/IronLanguages/ironpython2/issues/527
+            if "Single" in name:
                 self.assertEqual(hash(value), hash(float(value)))
             else:
-                self.assertEqual(hash(value), hash(long(value)))
+                self.assertEqual(hash(value), hash(int(value)))
 
-
+    @unittest.skipIf(is_cli, "https://github.com/IronLanguages/ironpython2/issues/528")
     def test_bigint_hash_subclass(self):
-        class x(long):
+        class x(int):
             def __hash__(self): return 42
             
         self.assertEqual(hash(x()), 42)


### PR DESCRIPTION
The hashing is made to match the 32-bit implementation of CPython so we can keep using `int` as the return type.

Issues:
- Hashing of complex number doesn't match CPython (for non-real numbers).
- Hashing of `System.Decimal` is incorrect (https://github.com/IronLanguages/ironpython2/issues/527).

Resolves https://github.com/IronLanguages/ironpython3/issues/268