### PR TITLE
Keyword only args

### DIFF
--- a/Src/IronPython/Compiler/Ast/Parameter.cs
+++ b/Src/IronPython/Compiler/Ast/Parameter.cs
@@ -27,10 +27,6 @@ namespace IronPython.Compiler.Ast {
     /// Parameter base class
     /// </summary>
     public class Parameter : Node {
-        /// <summary>
-        /// Position of the parameter: 0-based index
-        /// </summary>
-        private readonly string _name;
         protected readonly ParameterKind _kind;
         protected Expression _defaultValue;
 
@@ -42,16 +38,14 @@ namespace IronPython.Compiler.Ast {
         }
 
         public Parameter(string name, ParameterKind kind) {
-            _name = name;
+            Name = name;
             _kind = kind;
         }
 
         /// <summary>
         /// Parameter name
         /// </summary>
-        public string Name {
-            get { return _name; }
-        }
+        public string Name { get; }
 
         public Expression Annotation { get; set; }
 
@@ -60,23 +54,13 @@ namespace IronPython.Compiler.Ast {
             set { _defaultValue = value; }
         }
 
-        public bool IsList {
-            get {
-                return _kind == ParameterKind.List;
-            }
-        }
+        public bool IsList => _kind == ParameterKind.List;
 
-        public bool IsDictionary {
-            get {
-                return _kind == ParameterKind.Dictionary;
-            }
-        }
+        public bool IsDictionary => _kind == ParameterKind.Dictionary;
 
-        internal ParameterKind Kind {
-            get {
-                return _kind;
-            }
-        }
+        internal bool IsKeywordOnly => _kind == ParameterKind.KeywordOnly;
+
+        internal ParameterKind Kind => _kind;
 
         internal PythonVariable PythonVariable {
             get { return _variable; }

--- a/Src/IronPython/Compiler/PythonGlobal.cs
+++ b/Src/IronPython/Compiler/PythonGlobal.cs
@@ -29,8 +29,8 @@ namespace IronPython.Compiler {
         private string _name;
         private CodeContext/*!*/ _context;
 
-        internal static PropertyInfo/*!*/ CurrentValueProperty = typeof(PythonGlobal).GetProperty("CurrentValue");
-        internal static PropertyInfo/*!*/ RawValueProperty = typeof(PythonGlobal).GetProperty("RawValue");
+        internal static PropertyInfo/*!*/ CurrentValueProperty = typeof(PythonGlobal).GetProperty(nameof(CurrentValue));
+        internal static PropertyInfo/*!*/ RawValueProperty = typeof(PythonGlobal).GetProperty(nameof(RawValue));
 
         public PythonGlobal(CodeContext/*!*/ context, string name) {
             Assert.NotNull(context);
@@ -86,10 +86,11 @@ namespace IronPython.Compiler {
                 }
             }
 
+            var ex = PythonOps.NameError(_name);
             if (lightThrow) {
-                return LightExceptions.Throw(PythonOps.GlobalNameError(_name));
+                return LightExceptions.Throw(ex);
             }
-            throw PythonOps.GlobalNameError(_name);
+            throw ex;
         }
 
         public object RawValue {

--- a/Src/IronPython/Compiler/PythonGlobalVariableExpression.cs
+++ b/Src/IronPython/Compiler/PythonGlobalVariableExpression.cs
@@ -339,7 +339,7 @@ namespace IronPython.Compiler {
 
         public override Expression/*!*/ Reduce() {
             return Expression.Call(
-                typeof(PythonOps).GetMethod(_isLocal ? "GetLocal" : "GetGlobal"),
+                typeof(PythonOps).GetMethod(_isLocal ? nameof(PythonOps.GetLocal) : nameof(PythonOps.GetGlobal)),
                 _codeContextExpr,
                 Utils.Constant(_name)
             );

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2598,6 +2598,14 @@ namespace IronPython.Runtime.Operations {
             return function.Defaults[index];
         }
 
+        public static object GetFunctionKeywordOnlyParameterValue(PythonFunction function, string name, PythonDictionary dict) {
+            if (dict != null && dict.TryRemoveValue(name, out object val)) {
+                return val;
+            }
+
+            return function.__kwdefaults__[name];
+        }
+
         public static void CheckParamsZero(PythonFunction function, List extraArgs) {
             if (extraArgs.__len__() != 0) {
                 throw function.BadArgumentError(extraArgs.__len__() + function.NormalArgumentCount);
@@ -3024,6 +3032,11 @@ namespace IronPython.Runtime.Operations {
 
         public static object FunctionGetDefaultValue(PythonFunction func, int index) {
             return func.Defaults[index];
+        }
+
+        public static object FunctionGetKeywordOnlyDefaultValue(PythonFunction func, string name) {
+            func.__kwdefaults__.TryGetValue(name, out object res);
+            return res;
         }
 
         public static int FunctionGetCompatibility(PythonFunction func) {
@@ -3624,7 +3637,7 @@ namespace IronPython.Runtime.Operations {
                 return res;
             }
 
-            Exception ex = isGlobal ? GlobalNameError(name) : NameError(name);
+            var ex = NameError(name);
             if (lightThrow) {
                 return LightExceptions.Throw(ex);
             }

--- a/Src/IronPython/Runtime/PythonFunction.Generated.cs
+++ b/Src/IronPython/Runtime/PythonFunction.Generated.cs
@@ -174,13 +174,14 @@ namespace IronPython.Runtime {
                 }
             }
 
-            PerfTrack.NoteEvent(PerfTrack.Categories.BindingSlow, "PythonFunction " + _compat + " - " + ((Flags & FunctionAttributes.Generator) != 0) + ", " + binder.Signature);
+            PerfTrack.NoteEvent(PerfTrack.Categories.BindingSlow, "PythonFunction " + FunctionCompatibility + " - " + ((Flags & FunctionAttributes.Generator) != 0) + ", " + binder.Signature);
             return new Binding.FastBindResult<T>();
         }
 
         private bool CanOptimizeCall(Binding.PythonInvokeBinder binder, object[] args) {
             return args.Length >= (NormalArgumentCount - _defaults.Length) &&
                 args.Length <= NormalArgumentCount &&
+                KeywordOnlyArgumentCount == 0 && // don't optimize if we have keyword-only arguments
                 ArgNames.Length < FunctionCallerProperties.MaxGeneratedFunctionArgs &&
                 !binder.Signature.HasDictionaryArgument() &&
                 !binder.Signature.HasKeywordArgument() &&
@@ -240,9 +241,7 @@ namespace IronPython.Runtime {
         }
 
         public object Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object>)pyfunc.__code__.Target)(pyfunc);
             }
 
@@ -256,8 +255,7 @@ namespace IronPython.Runtime {
 
 
         public object Default1Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -266,8 +264,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -276,8 +273,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -286,8 +282,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -296,8 +291,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -306,8 +300,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -316,8 +309,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default7Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6]);
             }
@@ -326,8 +318,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default8Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7]);
             }
@@ -336,8 +327,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default9Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8]);
             }
@@ -346,8 +336,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default10Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9]);
             }
@@ -356,8 +345,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default11Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9], pyfunc.Defaults[defaultIndex + 10]);
             }
@@ -366,8 +354,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default12Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9], pyfunc.Defaults[defaultIndex + 10], pyfunc.Defaults[defaultIndex + 11]);
             }
@@ -376,8 +363,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default13Call0(CallSite site, CodeContext context, object func) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9], pyfunc.Defaults[defaultIndex + 10], pyfunc.Defaults[defaultIndex + 11], pyfunc.Defaults[defaultIndex + 12]);
             }
@@ -404,8 +390,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object>)pyfunc.__code__.Target)(pyfunc, arg0);
             }
 
@@ -413,8 +398,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -423,8 +407,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -433,8 +416,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -443,8 +425,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -453,8 +434,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -463,8 +443,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -473,8 +452,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default7Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6]);
             }
@@ -483,8 +461,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default8Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7]);
             }
@@ -493,8 +470,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default9Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8]);
             }
@@ -503,8 +479,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default10Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9]);
             }
@@ -513,8 +488,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default11Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9], pyfunc.Defaults[defaultIndex + 10]);
             }
@@ -523,8 +497,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default12Call1(CallSite site, CodeContext context, object func, T0 arg0) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 1;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9], pyfunc.Defaults[defaultIndex + 10], pyfunc.Defaults[defaultIndex + 11]);
             }
@@ -537,8 +510,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1);
             }
 
@@ -546,8 +518,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -556,8 +527,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -566,8 +536,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -576,8 +545,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -586,8 +554,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -596,8 +563,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -606,8 +572,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default7Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6]);
             }
@@ -616,8 +581,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default8Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7]);
             }
@@ -626,8 +590,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default9Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8]);
             }
@@ -636,8 +599,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default10Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9]);
             }
@@ -646,8 +608,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default11Call2(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 2;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9], pyfunc.Defaults[defaultIndex + 10]);
             }
@@ -660,8 +621,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2);
             }
 
@@ -669,8 +629,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -679,8 +638,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -689,8 +647,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -699,8 +656,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -709,8 +665,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -719,8 +674,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -729,8 +683,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default7Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6]);
             }
@@ -739,8 +692,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default8Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7]);
             }
@@ -749,8 +701,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default9Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8]);
             }
@@ -759,8 +710,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default10Call3(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 3;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8], pyfunc.Defaults[defaultIndex + 9]);
             }
@@ -773,8 +723,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3);
             }
 
@@ -782,8 +731,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -792,8 +740,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -802,8 +749,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -812,8 +758,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -822,8 +767,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -832,8 +776,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -842,8 +785,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default7Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6]);
             }
@@ -852,8 +794,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default8Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7]);
             }
@@ -862,8 +803,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default9Call4(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 4;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7], pyfunc.Defaults[defaultIndex + 8]);
             }
@@ -876,8 +816,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4);
             }
 
@@ -885,8 +824,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -895,8 +833,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -905,8 +842,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -915,8 +851,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -925,8 +860,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -935,8 +869,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -945,8 +878,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default7Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6]);
             }
@@ -955,8 +887,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default8Call5(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 5;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6], pyfunc.Defaults[defaultIndex + 7]);
             }
@@ -969,8 +900,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5);
             }
 
@@ -978,8 +908,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 6;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -988,8 +917,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 6;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -998,8 +926,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 6;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -1008,8 +935,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 6;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -1018,8 +944,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 6;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -1028,8 +953,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 6;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -1038,8 +962,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default7Call6(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 6;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5], pyfunc.Defaults[defaultIndex + 6]);
             }
@@ -1052,8 +975,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call7(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6);
             }
 
@@ -1061,8 +983,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call7(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 7;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -1071,8 +992,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call7(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 7;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -1081,8 +1001,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call7(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 7;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -1091,8 +1010,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call7(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 7;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -1101,8 +1019,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call7(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 7;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -1111,8 +1028,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default6Call7(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 7;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4], pyfunc.Defaults[defaultIndex + 5]);
             }
@@ -1125,8 +1041,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call8(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
             }
 
@@ -1134,8 +1049,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call8(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 8;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -1144,8 +1058,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call8(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 8;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -1154,8 +1067,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call8(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 8;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -1164,8 +1076,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call8(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 8;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -1174,8 +1085,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default5Call8(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 8;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3], pyfunc.Defaults[defaultIndex + 4]);
             }
@@ -1188,8 +1098,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call9(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
             }
 
@@ -1197,8 +1106,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call9(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 9;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -1207,8 +1115,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call9(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 9;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -1217,8 +1124,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call9(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 9;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -1227,8 +1133,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default4Call9(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 9;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2], pyfunc.Defaults[defaultIndex + 3]);
             }
@@ -1241,8 +1146,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call10(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
             }
 
@@ -1250,8 +1154,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call10(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 10;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -1260,8 +1163,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call10(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 10;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -1270,8 +1172,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default3Call10(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 10;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1], pyfunc.Defaults[defaultIndex + 2]);
             }
@@ -1284,8 +1185,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call11(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
             }
 
@@ -1293,8 +1193,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call11(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 11;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -1303,8 +1202,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default2Call11(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 11;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, pyfunc.Defaults[defaultIndex + 0], pyfunc.Defaults[defaultIndex + 1]);
             }
@@ -1317,8 +1215,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call12(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
             }
 
@@ -1326,8 +1223,7 @@ namespace IronPython.Runtime {
         }
 
         public object Default1Call12(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + 12;
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, pyfunc.Defaults[defaultIndex + 0]);
             }
@@ -1340,8 +1236,7 @@ namespace IronPython.Runtime {
         public FunctionCaller(int compat) : base(compat) { }
 
         public object Call13(CallSite site, CodeContext context, object func, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12) {
-            PythonFunction pyfunc = func as PythonFunction;
-            if (pyfunc != null && pyfunc._compat == _compat) {
+            if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
                 return ((Func<PythonFunction, object, object, object, object, object, object, object, object, object, object, object, object, object, object>)pyfunc.__code__.Target)(pyfunc, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
             }
 

--- a/Src/Scripts/generate_calls.py
+++ b/Src/Scripts/generate_calls.py
@@ -130,8 +130,7 @@ public sealed class FunctionCaller<%(typeParams)s> : FunctionCaller {
     public FunctionCaller(int compat) : base(compat) { }
     
     public object Call%(argCount)d(CallSite site, CodeContext context, object func, %(callParams)s) {
-        PythonFunction pyfunc = func as PythonFunction;
-        if (pyfunc != null && pyfunc._compat == _compat) {
+        if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
             return ((Func<%(genFuncArgs)s>)pyfunc.__code__.Target)(pyfunc, %(callArgs)s);
         }
 
@@ -140,8 +139,7 @@ public sealed class FunctionCaller<%(typeParams)s> : FunctionCaller {
     
 defaults_template = """
     public object Default%(defaultCount)dCall%(argCount)d(CallSite site, CodeContext context, object func, %(callParams)s) {
-        PythonFunction pyfunc = func as PythonFunction;
-        if (pyfunc != null && pyfunc._compat == _compat) {
+        if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
             int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount + %(argCount)d;
             return ((Func<%(genFuncArgs)s>)pyfunc.__code__.Target)(pyfunc, %(callArgs)s, %(defaultArgs)s);
         }
@@ -151,8 +149,7 @@ defaults_template = """
 
 defaults_template_0 = """
 public object Default%(argCount)dCall0(CallSite site, CodeContext context, object func) {
-    PythonFunction pyfunc = func as PythonFunction;
-    if (pyfunc != null && pyfunc._compat == _compat) {
+    if (func is PythonFunction pyfunc && pyfunc.FunctionCompatibility == _compat) {
         int defaultIndex = pyfunc.Defaults.Length - pyfunc.NormalArgumentCount;
         return ((Func<%(genFuncArgs)s>)pyfunc.__code__.Target)(pyfunc, %(defaultArgs)s);
     }

--- a/Src/StdLib/Lib/inspect.py
+++ b/Src/StdLib/Lib/inspect.py
@@ -2072,8 +2072,8 @@ class _empty:
 
 
 class _ParameterKind(int):
-    def __new__(self, val, name):
-        obj = int.__new__(self, val)
+    def __new__(self, *args, name):
+        obj = int.__new__(self, *args)
         obj._name = name
         return obj
 

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1254,4 +1254,10 @@ class C:
         self.assertEqual(a, [(__file__, 1+lineno, 'C', 'raise Exception')])
         self.assertEqual([x[2] for x in b], ['A', 'B', 'C']) # only check that we're in the proper function, the rest does not work properly
 
+    def test_ipy3_gh412(self):
+        def test(a, *args, b=None, **kwargs):
+            return (a, args, b, kwargs)
+
+        self.assertEqual(test(1, 2, 3, b=4, c=5, d=6), (1, (2, 3), 4, {'c': 5, 'd': 6}))
+
 run_test(__name__)


### PR DESCRIPTION
- Most of `AllCPython.test_keywordonlyarg` is passing except for stuff related to error messages, and SyntaxError for too many arguments.
- We probably need to add some sort of mechanism so that a C# defined method can have keyword-only arguments. Perhaps a `KeywordOnlyAttribute`?
