### PR TITLE
Properly implement hashing of complex numbers

### DIFF
--- a/Src/IronPython/Runtime/Operations/ComplexOps.cs
+++ b/Src/IronPython/Runtime/Operations/ComplexOps.cs
@@ -10,6 +10,7 @@ using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 
 using IronPython.Runtime.Types;
+using IronPython.Modules;
 
 namespace IronPython.Runtime.Operations {
     public class ExtensibleComplex : Extensible<Complex> {
@@ -180,7 +181,12 @@ namespace IronPython.Runtime.Operations {
             if (x.Imaginary() == 0) {
                 return DoubleOps.__hash__(x.Real);
             }
-            return x.GetHashCode();
+
+            int hash = (DoubleOps.__hash__(x.Real) + SysModule.hash_info.imag * DoubleOps.__hash__(x.Imaginary)) % SysModule.hash_info.modulus;
+            if (hash == -1) {
+                hash = -2;
+            }
+            return hash;
         }
 
         public static bool __bool__(Complex x) {

--- a/Tests/test_numberhash.py
+++ b/Tests/test_numberhash.py
@@ -58,6 +58,17 @@ class NumberHashTest(unittest.TestCase):
         h2 = hash(l2)
         self.assertTrue(h1 != h2)
 
+    def test_complex_hash_quality(self):
+        """Ensure that the complex hash function uses the complex term."""
+        c1 = complex(2323853, 2.1e67)
+        h1 = hash(c1)
+        self.assertTrue(h1 != hash(c1.real))
+        c2 = complex(2323853, 2.3e65)
+        h2 = hash(c2)
+        self.assertTrue(h1 != h2)
+        c3 = complex(1323852, 2.3e65)
+        self.assertTrue(h2 != hash(c3))
+
     def test_userhash_result(self):
         class x(object):
             def __init__(self, hash):
@@ -105,5 +116,7 @@ class NumberHashTest(unittest.TestCase):
         self.assertEqual(hash(9223372036854775807), 1) # long.MaxValue
         self.assertEqual(hash(-9223372036854775808), -2) # long.MinValue
         self.assertEqual(hash(-9223372036854775807), -2) # long.MinValue+1
+        # this checks that we handle the case where the hash results in -1
+        self.assertEqual(hash(complex(-1000004, 1)), -2) # sys.hash_info.imag-1 + 1j
 
 run_test(__name__)


### PR DESCRIPTION
Resolves #436.

Implement hashing of complex numbers that adheres to CPython's
standard. Add a unit test verifying that the hash uses both
the real and imaginary components to verify the quality of the
hash.

Some things I was unsure about:
- The code path when the complex's imaginary value is unnecessary (181-183), but I left it thinking that it makes clear that the value is essentially coerced to a double.
- Line 185 is excessively long, but it seems as though the convention for this repository is to keep statements on a single line, regardless the length.