### PR TITLE
Clean up tests

### DIFF
--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -9,19 +9,13 @@ Timeout=600000 ; 10 minute timeout
 IsolationLevel=PROCESS
 Ignore=true
 
-[AllCPython.test_aepack]
+[AllCPython.test__locale]
+Ignore=true
+
+[AllCPython.test_abc]
 Ignore=true
 
 [AllCPython.test_aifc]
-Ignore=true
-
-[AllCPython.test_al]
-Ignore=true
-
-[AllCPython.test_anydbm]
-IsolationLevel=ENGINE
-
-[AllCPython.test_applesingle]
 Ignore=true
 
 [AllCPython.test_argparse]
@@ -30,9 +24,6 @@ Reason=This fails on Linux for some reason, needs debug
 Ignore=true
 
 [AllCPython.test_array]
-Ignore=true
-
-[AllCPython.test_ascii_formatd]
 Ignore=true
 
 [AllCPython.test_ast]
@@ -44,7 +35,13 @@ Reason=failing for some reason, needs debug
 IsolationLevel=PROCESS
 RunCondition='$(OS)' != 'Unix'
 
+[AllCPython.test_asyncio]
+Ignore=true
+
 [AllCPython.test_asyncore]
+Ignore=true
+
+[AllCPython.test_atexit]
 Ignore=true
 
 [AllCPython.test_audioop]
@@ -66,13 +63,7 @@ Ignore=true
 FullFrames=true
 Ignore=true
 
-[AllCPython.test_bsddb3]
-Ignore=true
-
-[AllCPython.test_bsddb]
-Ignore=true
-
-[AllCPython.test_bsddb185]
+[AllCPython.test_bool]
 Ignore=true
 
 [AllCPython.test_buffer]
@@ -97,16 +88,13 @@ Ignore=true
 [AllCPython.test_capi]
 Ignore=true
 
-[AllCPython.test_cd]
-Ignore=true
-
-[AllCPython.test_cfgparser]
-Ignore=true
-
 [AllCPython.test_cgi]
 Ignore=true
 
-[AllCPython.test_cl]
+[AllCPython.test_cgitb]
+Ignore=true
+
+[AllCPython.test_charmapcodec]
 Ignore=true
 
 [AllCPython.test_class]
@@ -130,13 +118,13 @@ Ignore=true
 [AllCPython.test_codeccallbacks]
 Ignore=true
 
-[AllCPython.test_codecencodings_iso2022]
-Ignore=true
-
 [AllCPython.test_codecencodings_cn]
 Ignore=true
 
 [AllCPython.test_codecencodings_hk]
+Ignore=true
+
+[AllCPython.test_codecencodings_iso2022]
 Ignore=true
 
 [AllCPython.test_codecencodings_jp]
@@ -169,18 +157,10 @@ Ignore=true
 [AllCPython.test_codeop]
 Ignore=true
 
-[AllCPython.test_coercion]
-Ignore=true
-
 [AllCPython.test_collections]
 Ignore=true
 
-[AllCPython.test_commands]
-Ignore=true
-Reason=Relies on popen, which is not functional on POSIX
-RunCondition='$(OS)' == 'Unix'
-
-[AllCPython.test_compiler]
+[AllCPython.test_compare]
 Ignore=true
 
 [AllCPython.test_compile]
@@ -192,16 +172,15 @@ Ignore=true
 [AllCPython.test_complex]
 Ignore=true
 
+[AllCPython.test_concurrent_futures]
+Ignore=true
+
+[AllCPython.test_configparser]
+Ignore=true
+
 [AllCPython.test_contextlib]
 Ignore=true
 Reason=Hangs
-
-[AllCPython.test_cookielib]
-Ignore=true
-
-[AllCPython.test_cookie]
-FullFrames=true
-Ignore=true
 
 [AllCPython.test_copy]
 Ignore=true
@@ -209,13 +188,13 @@ Ignore=true
 [AllCPython.test_copyreg]
 Ignore=true
 
-[AllCPython.test_cpickle]
-Ignore=true
-
 [AllCPython.test_cprofile]
 Ignore=true
 
 [AllCPython.test_crypt]
+Ignore=true
+
+[AllCPython.test_csv]
 Ignore=true
 
 [AllCPython.test_ctypes]
@@ -230,6 +209,15 @@ Ignore=true
 [AllCPython.test_dbm]
 Ignore=true
 
+[AllCPython.test_dbm_dumb]
+Ignore=true
+
+[AllCPython.test_dbm_gnu]
+Ignore=true
+
+[AllCPython.test_dbm_ndbm]
+Ignore=true
+
 [AllCPython.test_decimal]
 FullFrames=true
 Ignore=true
@@ -241,11 +229,14 @@ Ignore=true
 FullFrames=true
 Ignore=true
 
+[AllCPython.test_descr]
+Ignore=true
+
 [AllCPython.test_descrtut]
 FullFrames=true
 Ignore=true
 
-[AllCPython.test_descr]
+[AllCPython.test_devpoll]
 Ignore=true
 
 [AllCPython.test_dictcomps]
@@ -266,29 +257,35 @@ Ignore=true
 [AllCPython.test_distutils]
 Ignore=true
 
-[AllCPython.test_dl]
+[AllCPython.test_doctest]
+FullFrames=true
 Ignore=true
 
 [AllCPython.test_doctest2]
 FullFrames=true
 
-[AllCPython.test_doctest]
-FullFrames=true
-Ignore=true
-
 [AllCPython.test_docxmlrpc]
 Ignore=true
 
+[AllCPython.test_dynamic]
+Ignore=true
+
+[AllCPython.test_dynamicclassattribute]
+Ignore=true
+
 [AllCPython.test_email]
+Ignore=true
+
+[AllCPython.test_ensurepip]
+Ignore=true
+
+[AllCPython.test_enum]
 Ignore=true
 
 [AllCPython.test_enumerate]
 Ignore=true
 Reason=Causes StackOverflowException
 IsolationLevel=ENGINE
-
-[AllCPython.test_ensurepip]
-Ignore=true
 
 [AllCPython.test_eof]
 Ignore=true
@@ -303,24 +300,36 @@ Ignore=true
 FullFrames=true
 Ignore=true
 
+[AllCPython.test_faulthandler]
+Ignore=true
+
 [AllCPython.test_fcntl]
 Ignore=true
 
-[AllCPython.test_fileio]
-Ignore=true
-IsolationLevel=ENGINE
-
 [AllCPython.test_file]
-Ignore=true
-
-[AllCPython.test_file2k]
 Ignore=true
 
 [AllCPython.test_file_eintr]
 Ignore=true
 Reason=We do not implement all the necessary stuff for this yet
 
+[AllCPython.test_fileinput]
+Ignore=true
+
+[AllCPython.test_fileio]
+Ignore=true
+IsolationLevel=ENGINE
+
+[AllCPython.test_finalization]
+Ignore=true
+
 [AllCPython.test_float]
+Ignore=true
+
+[AllCPython.test_flufl]
+Ignore=true
+
+[AllCPython.test_fnmatch]
 Ignore=true
 
 [AllCPython.test_fork1]
@@ -332,7 +341,7 @@ Ignore=true
 [AllCPython.test_fractions]
 Ignore=true
 
-[AllCPython.test_frozen]
+[AllCPython.test_frame]
 Ignore=true
 
 [AllCPython.test_ftplib]
@@ -344,13 +353,13 @@ Ignore=true
 [AllCPython.test_functools]
 Ignore=true
 
+[AllCPython.test_future]
+Ignore=true
+
 [AllCPython.test_future4]
 Ignore=true
 
 [AllCPython.test_future5]
-Ignore=true
-
-[AllCPython.test_future]
 Ignore=true
 
 [AllCPython.test_gc]
@@ -359,32 +368,26 @@ Ignore=true
 [AllCPython.test_gdb]
 Ignore=true
 
-[AllCPython.test_gdbm]
-Ignore=true
-
 [AllCPython.test_generators]
 Ignore=true
 
+[AllCPython.test_genericpath]
+Ignore=true
+
 [AllCPython.test_genexps]
-Ignore=true
-
-[AllCPython.test_gestalt]
-Ignore=true
-
-[AllCPython.test_getargs]
 Ignore=true
 
 [AllCPython.test_getargs2]
 Ignore=true
 
 [AllCPython.test_getopt]
-FullFrames=truet
+FullFrames=true
+
+[AllCPython.test_getpass]
+Ignore=true
 
 [AllCPython.test_gettext]
 IsolationLevel=ENGINE
-Ignore=true
-
-[AllCPython.test_gl]
 Ignore=true
 
 [AllCPython.test_glob]
@@ -409,10 +412,16 @@ RunCondition=NOT $(IS_NETCOREAPP)
 Reason=TODO: figure out
 Ignore=true
 
+[AllCPython.test_heapq]
+Ignore=true
+
 [AllCPython.test_hmac]
 Ignore=true
 
-[AllCPython.test_hotshot]
+[AllCPython.test_http_cookiejar]
+Ignore=true
+
+[AllCPython.test_http_cookies]
 Ignore=true
 
 [AllCPython.test_httplib]
@@ -424,25 +433,21 @@ Ignore=true
 [AllCPython.test_idle]
 Ignore=true
 
-[AllCPython.test_imageop]
-Ignore=true
-
 [AllCPython.test_imaplib]
 Ignore=true
 
-[AllCPython.test_imgfile]
+[AllCPython.test_imghdr]
 Ignore=true
 
-[AllCPython.test_imghdr]
+[AllCPython.test_imp]
 Ignore=true
 
 [AllCPython.test_import]
 IsolationLevel=ENGINE
 Ignore=true
 
-[AllCPython.test_import_magic]
+[AllCPython.test_importlib]
 Ignore=true
-Reason=IronPython doesn't implement get_magic
 
 [AllCPython.test_index]
 Ignore=true
@@ -460,17 +465,26 @@ IsolationLevel=ENGINE
 [AllCPython.test_ioctl]
 Ignore=true
 
-[AllCPython.test_iterlen]
-Ignore=true
-
-[AllCPython.test_itertools]
+[AllCPython.test_ipaddress]
 Ignore=true
 
 [AllCPython.test_iter]
 Ignore=true
 IsolationLevel=ENGINE
 
+[AllCPython.test_iterlen]
+Ignore=true
+
+[AllCPython.test_itertools]
+Ignore=true
+
 [AllCPython.test_json]
+Ignore=true
+
+[AllCPython.test_keyword]
+Ignore=true
+
+[AllCPython.test_keywordonlyarg]
 Ignore=true
 
 [AllCPython.test_kqueue]
@@ -482,10 +496,10 @@ Ignore=true
 [AllCPython.test_lib2to3]
 Ignore=true
 
-[AllCPython.test_linuxaudiodev]
+[AllCPython.test_list]
 Ignore=true
 
-[AllCPython.test_list]
+[AllCPython.test_listcomps]
 Ignore=true
 
 [AllCPython.test_locale]
@@ -499,21 +513,24 @@ Ignore=true
 Ignore=true
 IsolationLevel=ENGINE
 
-[AllCPython.test_long_future]
+[AllCPython.test_lzma]
 Ignore=true
 
-[AllCPython.test_macos]
-Ignore=true
-
-[AllCPython.test_macostools]
+[AllCPython.test_macpath]
 Ignore=true
 
 [AllCPython.test_mailbox]
 Ignore=true
 
+[AllCPython.test_mailcap]
+Ignore=true
+
 [AllCPython.test_marshal]
 Ignore=true
 IsolationLevel=ENGINE
+
+[AllCPython.test_math]
+Ignore=true
 
 [AllCPython.test_memoryio]
 Ignore=true
@@ -522,13 +539,13 @@ Ignore=true
 Ignore=true
 Reason=kills the testing process (on appveyor)
 
-[AllCPython.test_mhlib]
-Ignore=true
-
-[AllCPython.test_mimetools]
+[AllCPython.test_metaclass]
 Ignore=true
 
 [AllCPython.test_mimetypes]
+Ignore=true
+
+[AllCPython.test_minidom]
 Ignore=true
 
 [AllCPython.test_mmap]
@@ -538,10 +555,10 @@ IsolationLevel=PROCESS
 Arguments=-m test.regrtest -v -uall,-largefile test_mmap
 Ignore=true
 
-[AllCPython.test_modulefinder]
+[AllCPython.test_module]
 Ignore=true
 
-[AllCPython.test_module]
+[AllCPython.test_modulefinder]
 Ignore=true
 
 [AllCPython.test_msilib]
@@ -550,16 +567,19 @@ Ignore=true
 [AllCPython.test_multibytecodec]
 Ignore=true
 
-[AllCPython.test_multiprocessing]
+[AllCPython.test_multiprocessing_fork]
 Ignore=true
 
-[AllCPython.test_mutants]
+[AllCPython.test_multiprocessing_forkserver]
+Ignore=true
+
+[AllCPython.test_multiprocessing_main_handling]
+Ignore=true
+
+[AllCPython.test_multiprocessing_spawn]
 Ignore=true
 
 [AllCPython.test_netrc]
-Ignore=true
-
-[AllCPython.test_new]
 Ignore=true
 
 [AllCPython.test_nis]
@@ -576,7 +596,13 @@ Ignore=true
 IsolationLevel=PROCESS
 Ignore=true
 
+[AllCPython.test_numeric_tower]
+Ignore=true
+
 [AllCPython.test_openpty]
+Ignore=true
+
+[AllCPython.test_operator]
 Ignore=true
 
 [AllCPython.test_ordered_dict]
@@ -593,13 +619,16 @@ Ignore=true
 Ignore=true
 IsolationLevel=ENGINE
 
+[AllCPython.test_pathlib]
+Ignore=true
+
 [AllCPython.test_pdb]
 Ignore=true
 
-[AllCPython.test_pep247]
+[AllCPython.test_peepholer]
 Ignore=true
 
-[AllCPython.test_pep263]
+[AllCPython.test_pep247]
 Ignore=true
 
 [AllCPython.test_pep277]
@@ -608,11 +637,20 @@ Ignore=true
 [AllCPython.test_pep352]
 Ignore=true
 
-[AllCPython.test_pickletools]
-FullFrames=true
+[AllCPython.test_pep3120]
+Ignore=true
+
+[AllCPython.test_pep3131]
+Ignore=true
+
+[AllCPython.test_pep3151]
 Ignore=true
 
 [AllCPython.test_pickle]
+FullFrames=true
+Ignore=true
+
+[AllCPython.test_pickletools]
 FullFrames=true
 Ignore=true
 
@@ -621,19 +659,22 @@ Ignore=true
 Reason=Currently failing, was not being run in IronLanguages/main
 ;RunCondition='$(OS)' == 'Unix'
 
-[AllCPython.test_pkgutil]
+[AllCPython.test_pkg]
 Ignore=true
 
-[AllCPython.test_pkg]
+[AllCPython.test_pkgimport]
+Ignore=true
+
+[AllCPython.test_pkgutil]
 Ignore=true
 
 [AllCPython.test_platform]
 Ignore=true
 
-[AllCPython.test_poll]
+[AllCPython.test_plistlib]
 Ignore=true
 
-[AllCPython.test_popen2]
+[AllCPython.test_poll]
 Ignore=true
 
 [AllCPython.test_popen]
@@ -653,26 +694,35 @@ Ignore=true
 [AllCPython.test_pprint]
 Ignore=true
 
-[AllCPython.test_profilehooks]
+[AllCPython.test_print]
 Ignore=true
 
 [AllCPython.test_profile]
 Ignore=true
 
+[AllCPython.test_pstats]
+Ignore=true
+
 [AllCPython.test_pty]
+Ignore=true
+
+[AllCPython.test_pulldom]
 Ignore=true
 
 [AllCPython.test_pwd]
 RunCondition='$(OS)'=='Unix'
 Reason=Only valid for Unix
 
-[AllCPython.test_py3kwarn]
-Ignore=true
-
 [AllCPython.test_py_compile]
 Ignore=true
 
+[AllCPython.test_pyclbr]
+Ignore=true
+
 [AllCPython.test_pydoc]
+Ignore=true
+
+[AllCPython.test_pyexpat]
 Ignore=true
 
 [AllCPython.test_queue]
@@ -683,10 +733,13 @@ Reason=Causes hang
 Ignore=true
 IsolationLevel=ENGINE
 
+[AllCPython.test_raise]
+Ignore=true
+
 [AllCPython.test_random]
 Ignore=true
 
-[AllCPython.test_repr]
+[AllCPython.test_range]
 Ignore=true
 
 [AllCPython.test_re]
@@ -699,7 +752,13 @@ Ignore=true
 Ignore=true
 Reason=kills the testing process (on appveyor)
 
+[AllCPython.test_reprlib]
+Ignore=true
+
 [AllCPython.test_resource]
+Ignore=true
+
+[AllCPython.test_richcmp]
 Ignore=true
 
 [AllCPython.test_robotparser]
@@ -718,14 +777,14 @@ Reason=Causes hang
 [AllCPython.test_scope]
 Ignore=true
 
-[AllCPython.test_scriptpackages]
+[AllCPython.test_script_helper]
 Ignore=true
 
 [AllCPython.test_select]
 Ignore=true
 
-[AllCPython.test_sets]
-FullFrames=true
+[AllCPython.test_selectors]
+Ignore=true
 
 [AllCPython.test_set]
 Ignore=true
@@ -733,13 +792,12 @@ Ignore=true
 [AllCPython.test_setcomps]
 Ignore=true
 
-[AllCPython.test_sha]
-RunCondition=NOT $(IS_NETCOREAPP)
-Reason=TODO: figure out
-
 [AllCPython.test_shelve]
 Ignore=true
 Reason=Causes hang
+
+[AllCPython.test_shlex]
+Ignore=true
 
 [AllCPython.test_shutil]
 Ignore=true
@@ -747,16 +805,19 @@ Ignore=true
 [AllCPython.test_signal]
 Ignore=true
 
-[AllCPython.test_SimpleHTTPServer]
-Ignore=true
-
 [AllCPython.test_site]
 Ignore=true
 
-[AllCPython.test_slice]
+[AllCPython.test_smtpd]
 Ignore=true
 
 [AllCPython.test_smtplib]
+Ignore=true
+
+[AllCPython.test_smtpnet]
+Ignore=true
+
+[AllCPython.test_sndhdr]
 Ignore=true
 
 [AllCPython.test_socket]
@@ -788,16 +849,19 @@ RunCondition='$(OS)' != 'Unix'
 Reason=Currently failing, was not being run in IronLanguages/main
 Ignore=true
 
+[AllCPython.test_statistics]
+Ignore=true
+
 [AllCPython.test_strftime]
 Ignore=true
 
-[AllCPython.test_stringio]
+[AllCPython.test_string]
 Ignore=true
 
 [AllCPython.test_stringprep]
 Ignore=true
 
-[AllCPython.test_strop]
+[AllCPython.test_strlit]
 Ignore=true
 
 [AllCPython.test_strptime]
@@ -806,13 +870,13 @@ Ignore=true
 [AllCPython.test_strtod]
 Ignore=true
 
-[AllCPython.test_structmembers]
-Ignore=true
-
 [AllCPython.test_struct]
 Ignore=true
 
-[AllCPython.test_str]
+[AllCPython.test_structmembers]
+Ignore=true
+
+[AllCPython.test_structseq]
 Ignore=true
 
 [AllCPython.test_subprocess]
@@ -825,10 +889,10 @@ Ignore=true
 [AllCPython.test_sunau]
 Ignore=true
 
-[AllCPython.test_sunaudiodev]
+[AllCPython.test_sundry]
 Ignore=true
 
-[AllCPython.test_sundry]
+[AllCPython.test_super]
 Ignore=true
 
 [AllCPython.test_symtable]
@@ -853,6 +917,9 @@ Ignore=true
 [AllCPython.test_sysconfig]
 Ignore=true
 
+[AllCPython.test_syslog]
+Ignore=true
+
 [AllCPython.test_tarfile]
 Ignore=true
 
@@ -865,20 +932,20 @@ Ignore=true
 [AllCPython.test_tempfile]
 Ignore=true
 
-[AllCPython.test_threadedtempfile]
+[AllCPython.test_thread]
 Ignore=true
-Reason=Causes hang
 
 [AllCPython.test_threaded_import]
 Ignore=true
+
+[AllCPython.test_threadedtempfile]
+Ignore=true
+Reason=Causes hang
 
 [AllCPython.test_threading]
 Ignore=true
 
 [AllCPython.test_threading_local]
-Ignore=true
-
-[AllCPython.test_thread]
 Ignore=true
 
 [AllCPython.test_threadsignals]
@@ -903,25 +970,22 @@ Ignore=true
 [AllCPython.test_tools]
 Ignore=true
 
+[AllCPython.test_trace]
+Ignore=true
+
+[AllCPython.test_traceback]
+Ignore=true
+
+[AllCPython.test_tracemalloc]
+Ignore=true
+
 [AllCPython.test_ttk_guionly]
 Ignore=true
 
 [AllCPython.test_ttk_textonly]
 Ignore=true
 
-[AllCPython.test_traceback]
-Ignore=true
-
-[AllCPython.test_trace]
-Ignore=true
-
-[AllCPython.test_transformer]
-Ignore=true
-
 [AllCPython.test_tuple]
-Ignore=true
-
-[AllCPython.test_turtle]
 Ignore=true
 
 [AllCPython.test_types]
@@ -930,16 +994,13 @@ Ignore=true
 [AllCPython.test_ucn]
 Ignore=true
 
-[AllCPython.test_undocumented_details]
-Ignore=true
-
-[AllCPython.test_unicodedata]
-Ignore=true
-
 [AllCPython.test_unicode]
 Ignore=true
 
 [AllCPython.test_unicode_file]
+Ignore=true
+
+[AllCPython.test_unicodedata]
 Ignore=true
 
 [AllCPython.test_unittest]
@@ -952,24 +1013,27 @@ IsolationLevel=ENGINE
 [AllCPython.test_unpack]
 FullFrames=true
 
+[AllCPython.test_unpack_ex]
+Ignore=true
+
 [AllCPython.test_urllib]
 Ignore=true
 Reason=Intermittent StackOverFlowException - https://github.com/IronLanguages/ironpython2/issues/40
 
+[AllCPython.test_urllib_response]
+Ignore=true
+
 [AllCPython.test_urllib2]
+Ignore=true
+
+[AllCPython.test_urllib2_localnet]
 Ignore=true
 
 [AllCPython.test_urllib2net]
 FullFrames=true
 Ignore=true
 
-[AllCPython.test_urllib2_localnet]
-Ignore=true
-
 [AllCPython.test_urllibnet]
-Ignore=true
-
-[AllCPython.test_userdict]
 Ignore=true
 
 [AllCPython.test_userlist]
@@ -979,6 +1043,12 @@ Ignore=true
 Ignore=true
 
 [AllCPython.test_uu]
+Ignore=true
+
+[AllCPython.test_uuid]
+Ignore=true
+
+[AllCPython.test_venv]
 Ignore=true
 
 [AllCPython.test_wait3]
@@ -1000,6 +1070,9 @@ IsolationLevel=ENGINE
 [AllCPython.test_weakset]
 Ignore=true
 
+[AllCPython.test_webbrowser]
+Ignore=true
+
 [AllCPython.test_winreg]
 RunCondition='$(OS)' != 'Unix'
 Ignore=true
@@ -1018,6 +1091,9 @@ Ignore=true
 [AllCPython.test_xdrlib]
 Ignore=true
 
+[AllCPython.test_xml_dom_minicompat]
+Ignore=true
+
 [AllCPython.test_xml_etree]
 Ignore=true
 
@@ -1027,10 +1103,7 @@ Ignore=true
 [AllCPython.test_xmlrpc]
 Ignore=true
 
-[AllCPython.test_xpickle]
-Ignore=true
-
-[AllCPython.test_xrange]
+[AllCPython.test_xmlrpc_net]
 Ignore=true
 
 [AllCPython.test_zipfile]
@@ -1041,501 +1114,11 @@ IsolationLevel=ENGINE
 Ignore=true
 IsolationLevel=ENGINE
 
+[AllCPython.test_zipimport]
+Ignore=true
+
 [AllCPython.test_zipimport_support]
 Ignore=true
 
 [AllCPython.test_zlib]
 Ignore=true
-
-[AllCPython.test_listcomps]
-Ignore=true
-
-[AllCPython.test_json.test_fail]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test_relative_imports]
-Ignore=true
-
-[AllCPython.test_importlib.frozen.test_loader]
-Ignore=true
-
-[AllCPython.test_urllib_response]
-Ignore=true
-
-[AllCPython.test_smtpnet]
-Ignore=true
-
-[AllCPython.test_selectors]
-Ignore=true
-
-[AllCPython.test_tools.test_unparse]
-Ignore=true
-
-[AllCPython.test_email.test_parser]
-Ignore=true
-
-[AllCPython.test_email.test_contentmanager]
-Ignore=true
-
-[AllCPython.test_asyncio.test_events]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test_api]
-Ignore=true
-
-[AllCPython.test_pep3151]
-Ignore=true
-
-[AllCPython.test_asyncio.test_windows_utils]
-Ignore=true
-
-[AllCPython.test_email.test_generator]
-Ignore=true
-
-[AllCPython.test_pyexpat]
-Ignore=true
-
-[AllCPython.test_importlib.source.test_finder]
-Ignore=true
-
-[AllCPython.test_email.test__header_value_parser]
-Ignore=true
-
-[AllCPython.test_json.test_unicode]
-Ignore=true
-
-[AllCPython.test_csv]
-Ignore=true
-
-[AllCPython.test_binop]
-Ignore=true
-
-[AllCPython.test_super]
-Ignore=true
-
-[AllCPython.test_importlib.source.test_file_loader]
-Ignore=true
-
-[AllCPython.test_abc]
-Ignore=true
-
-[AllCPython.test_minidom]
-Ignore=true
-
-[AllCPython.test_getpass]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test___package__]
-Ignore=true
-
-[AllCPython.test_json.test_enum]
-Ignore=true
-
-[AllCPython.test_json.test_recursion]
-Ignore=true
-
-[AllCPython.test_ipaddress]
-Ignore=true
-
-[AllCPython.test_email.test_headerregistry]
-Ignore=true
-
-[AllCPython.test_strlit]
-Ignore=true
-
-[AllCPython.test_metaclass]
-Ignore=true
-
-[AllCPython.test_asyncio.test_sslproto]
-Ignore=true
-
-[AllCPython.test_raise]
-Ignore=true
-
-[AllCPython.test_devpoll]
-Ignore=true
-
-[AllCPython.test_asyncio.test_locks]
-Ignore=true
-
-[AllCPython.test_multiprocessing_spawn]
-Ignore=true
-
-[AllCPython.test_numeric_tower]
-Ignore=true
-
-[AllCPython.test_richcmp]
-Ignore=true
-
-[AllCPython.test_tools.test_md5sum]
-Ignore=true
-
-[AllCPython.test_pulldom]
-Ignore=true
-
-[AllCPython.test_json.test_speedups]
-Ignore=true
-
-[AllCPython.test_importlib.source.test_source_encoding]
-Ignore=true
-
-[AllCPython.test_asyncio.test_streams]
-Ignore=true
-
-[AllCPython.test_dbm_ndbm]
-Ignore=true
-
-[AllCPython.test_json.test_pass1]
-Ignore=true
-
-[AllCPython.test_smtpd]
-Ignore=true
-
-[AllCPython.test_json.test_pass2]
-Ignore=true
-
-[AllCPython.test_statistics]
-Ignore=true
-
-[AllCPython.test_importlib.test_windows]
-Ignore=true
-
-[AllCPython.test_asyncio.test_queues]
-Ignore=true
-
-[AllCPython.test_faulthandler]
-Ignore=true
-
-[AllCPython.test_importlib.test_api]
-Ignore=true
-
-[AllCPython.test_plistlib]
-Ignore=true
-
-[AllCPython.test_importlib.extension.test_case_sensitivity]
-Ignore=true
-
-[AllCPython.test_importlib.source.test_path_hook]
-Ignore=true
-
-[AllCPython.test_asyncio.test_base_events]
-Ignore=true
-
-[AllCPython.test_http_cookiejar]
-Ignore=true
-
-[AllCPython.test_asyncio.test_unix_events]
-Ignore=true
-
-[AllCPython.test_genericpath]
-Ignore=true
-
-[AllCPython.test_pyclbr]
-Ignore=true
-
-[AllCPython.test_finalization]
-Ignore=true
-
-[AllCPython.test_importlib.extension.test_loader]
-Ignore=true
-
-[AllCPython.test_venv]
-Ignore=true
-
-[AllCPython.test_print]
-Ignore=true
-
-[AllCPython.test_email.test__encoded_words]
-Ignore=true
-
-[AllCPython.test_email.test_policy]
-Ignore=true
-
-[AllCPython.test_range]
-Ignore=true
-
-[AllCPython.test_asyncio.test_selector_events]
-Ignore=true
-
-[AllCPython.test_dbm_gnu]
-Ignore=true
-
-[AllCPython.test_asyncio.test_proactor_events]
-Ignore=true
-
-[AllCPython.test_importlib.frozen.test_finder]
-Ignore=true
-
-[AllCPython.test_fileinput]
-Ignore=true
-
-[AllCPython.test_json.test_pass3]
-Ignore=true
-
-[AllCPython.test_dbm_dumb]
-Ignore=true
-
-[AllCPython.test_lzma]
-Ignore=true
-
-[AllCPython.test_importlib.test_locks]
-Ignore=true
-
-[AllCPython.test_json.test_float]
-Ignore=true
-
-[AllCPython.test_concurrent_futures]
-Ignore=true
-
-[AllCPython.test_script_helper]
-Ignore=true
-
-[AllCPython.test_importlib.test_util]
-Ignore=true
-
-[AllCPython.test_mailcap]
-Ignore=true
-
-[AllCPython.test_email.test_utils]
-Ignore=true
-
-[AllCPython.test_pkgimport]
-Ignore=true
-
-[AllCPython.test_frame]
-Ignore=true
-
-[AllCPython.test_bool]
-Ignore=true
-
-[AllCPython.test_dynamic]
-Ignore=true
-
-[AllCPython.test_tools.test_reindent]
-Ignore=true
-
-[AllCPython.test_importlib.extension.test_finder]
-Ignore=true
-
-[AllCPython.test_importlib.builtin.test_loader]
-Ignore=true
-
-[AllCPython.test_asyncio.test_transports]
-Ignore=true
-
-[AllCPython.test_json.test_encode_basestring_ascii]
-Ignore=true
-
-[AllCPython.test_http_cookies]
-Ignore=true
-
-[AllCPython.test_fnmatch]
-Ignore=true
-
-[AllCPython.test_multiprocessing_main_handling]
-Ignore=true
-
-[AllCPython.test_pstats]
-Ignore=true
-
-[AllCPython.test_compare]
-Ignore=true
-
-[AllCPython.test_enum]
-Ignore=true
-
-[AllCPython.test_imp]
-Ignore=true
-
-[AllCPython.test_webbrowser]
-Ignore=true
-
-[AllCPython.test_unpack_ex]
-Ignore=true
-
-[AllCPython.test_peepholer]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test_caching]
-Ignore=true
-
-[AllCPython.test_json.test_indent]
-Ignore=true
-
-[AllCPython.test_xmlrpc_net]
-Ignore=true
-
-[AllCPython.test_importlib.test_spec]
-Ignore=true
-
-[AllCPython.test_importlib.test_abc]
-Ignore=true
-
-[AllCPython.test_dynamicclassattribute]
-Ignore=true
-
-[AllCPython.test_tracemalloc]
-Ignore=true
-
-[AllCPython.test_asyncio.test_windows_events]
-Ignore=true
-
-[AllCPython.test_json.test_separators]
-Ignore=true
-
-[AllCPython.test_string]
-Ignore=true
-
-[AllCPython.test_math]
-Ignore=true
-
-[AllCPython.test_asyncio.test_futures]
-Ignore=true
-
-[AllCPython.test_heapq]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test_fromlist]
-Ignore=true
-
-[AllCPython.test_xml_dom_minicompat]
-Ignore=true
-
-[AllCPython.test_importlib.source.test_case_sensitivity]
-Ignore=true
-
-[AllCPython.test_structseq]
-Ignore=true
-
-[AllCPython.test_macpath]
-Ignore=true
-
-[AllCPython.test_importlib.test_namespace_pkgs]
-Ignore=true
-
-[AllCPython.test_json.test_decode]
-Ignore=true
-
-[AllCPython.test_keyword]
-Ignore=true
-
-[AllCPython.test_reprlib]
-Ignore=true
-
-[AllCPython.test__locale]
-Ignore=true
-
-[AllCPython.test_json.test_default]
-Ignore=true
-
-[AllCPython.test_pep3120]
-Ignore=true
-
-[AllCPython.test_tools.test_gprof2html]
-Ignore=true
-
-[AllCPython.test_configparser]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test_path]
-Ignore=true
-
-[AllCPython.test_tools.test_pdeps]
-Ignore=true
-
-[AllCPython.test_importlib.extension.test_path_hook]
-Ignore=true
-
-[AllCPython.test_email.test_pickleable]
-Ignore=true
-
-[AllCPython.test_tools.test_sundry]
-Ignore=true
-
-[AllCPython.test_cgitb]
-Ignore=true
-
-[AllCPython.test_multiprocessing_forkserver]
-Ignore=true
-
-[AllCPython.test_keywordonlyarg]
-Ignore=true
-
-[AllCPython.test_html]
-Ignore=true
-
-[AllCPython.test_atexit]
-Ignore=true
-
-[AllCPython.test_json.test_dump]
-Ignore=true
-
-[AllCPython.test_email.test_asian_codecs]
-Ignore=true
-
-[AllCPython.test_uuid]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test_packages]
-Ignore=true
-
-[AllCPython.test_flufl]
-Ignore=true
-
-[AllCPython.test_pathlib]
-Ignore=true
-
-[AllCPython.test_syslog]
-Ignore=true
-
-[AllCPython.test_shlex]
-Ignore=true
-
-[AllCPython.test_zipimport]
-Ignore=true
-
-[AllCPython.test_asyncio.test_subprocess]
-Ignore=true
-
-[AllCPython.test_pep3131]
-Ignore=true
-
-[AllCPython.test_sndhdr]
-Ignore=true
-
-[AllCPython.test_multiprocessing_fork]
-Ignore=true
-
-[AllCPython.test_asyncio.test_tasks]
-Ignore=true
-
-[AllCPython.test_json.test_scanstring]
-Ignore=true
-
-[AllCPython.test_email.test_defect_handling]
-Ignore=true
-
-[AllCPython.test_email.test_message]
-Ignore=true
-
-[AllCPython.test_importlib.builtin.test_finder]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test_meta_path]
-Ignore=true
-
-[AllCPython.test_importlib.import_.test___loader__]
-Ignore=true
-
-[AllCPython.test_email.test_email]
-Ignore=true
-
-[AllCPython.test_operator]
-Ignore=true
-
-[AllCPython.test_tools.test_pindent]
-Ignore=true
-
-[AllCPython.test_charmapcodec]
-Ignore=true
-

--- a/Src/StdLib/Lib/numbers.py
+++ b/Src/StdLib/Lib/numbers.py
@@ -387,3 +387,4 @@ class Integral(Rational):
         return 1
 
 Integral.register(int)
+Integral.register(long) # TODO: remove me

--- a/Src/StdLib/Lib/xml/dom/xmlbuilder.py
+++ b/Src/StdLib/Lib/xml/dom/xmlbuilder.py
@@ -334,12 +334,13 @@ del NodeFilter
 class DocumentLS:
     """Mixin to create documents that conform to the load/save spec."""
 
-    async = False
+    async_ = False
 
     def _get_async(self):
         return False
-    def _set_async(self, async):
-        if async:
+
+    def _set_async(self, flag):
+        if flag:
             raise xml.dom.NotSupportedErr(
                 "asynchronous document loading is not supported")
 


### PR DESCRIPTION
- Removes non-existent tests and orders alphabetically
- Changes `xml/dom/xmlbuilder.py` to not raise a syntax error (async keyword)
- Temporarily adds `long` to integer types to get more stuff working