### PR TITLE
Add re.fullmatch

### DIFF
--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -126,47 +126,47 @@ Ignore=true
 
 [AllCPython.test_codecencodings_cn]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=LookupError: unknown encoding
 
 [AllCPython.test_codecencodings_hk]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=LookupError: unknown encoding
 
 [AllCPython.test_codecencodings_iso2022]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=LookupError: unknown encoding
 
 [AllCPython.test_codecencodings_jp]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=LookupError: unknown encoding
 
 [AllCPython.test_codecencodings_kr]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=LookupError: unknown encoding
 
 [AllCPython.test_codecencodings_tw]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=LookupError: unknown encoding
 
 [AllCPython.test_codecmaps_cn]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490
 
 [AllCPython.test_codecmaps_hk]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490
 
 [AllCPython.test_codecmaps_jp]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490
 
 [AllCPython.test_codecmaps_kr]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490
 
 [AllCPython.test_codecmaps_tw]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490
 
 [AllCPython.test_codecs]
 Ignore=true
@@ -295,7 +295,6 @@ Ignore=true
 
 [AllCPython.test_docxmlrpc]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_dynamic]
 Ignore=true
@@ -383,6 +382,7 @@ Ignore=true
 
 [AllCPython.test_ftplib]
 Ignore=true
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490 (or related issue???)
 
 [AllCPython.test_funcattrs]
 Ignore=true
@@ -442,8 +442,8 @@ Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/414
 Ignore=true
 
 [AllCPython.test_http_cookiejar]
-Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+RunCondition=NOT $(IS_DEBUG)
+Reason=Raises an assertion error in Debug
 
 [AllCPython.test_http_cookies]
 Ignore=true
@@ -451,11 +451,11 @@ Reason=Blocked by pickling
 
 [AllCPython.test_httplib]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490 (or related issue???)
 
 [AllCPython.test_httpservers]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490 (or related issue???)
 
 [AllCPython.test_idle]
 Ignore=true
@@ -628,7 +628,7 @@ Reason=Blocked by surrogateescape
 
 [AllCPython.test_normalization]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490
 
 [AllCPython.test_ntpath]
 Ignore=true
@@ -732,6 +732,7 @@ Ignore=true
 
 [AllCPython.test_poplib]
 Ignore=true
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490 (or related issue???)
 
 [AllCPython.test_posix]
 RunCondition='$(OS)' == 'Unix'
@@ -761,7 +762,6 @@ Reason=unittest.case.SkipTest: No module named 'fcntl'
 
 [AllCPython.test_pulldom]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_pwd]
 RunCondition='$(OS)'=='Unix'
@@ -819,7 +819,6 @@ Reason=AssertionError: TypeError not raised by <lambda$1>
 
 [AllCPython.test_robotparser]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_runpy]
 Ignore=true
@@ -827,7 +826,6 @@ Reason=NotImplementedError: sys.implementation.cache_tag is None
 
 [AllCPython.test_sax]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_sched]
 Ignore=true
@@ -871,7 +869,6 @@ Ignore=true
 
 [AllCPython.test_site]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_smtpd]
 Ignore=true
@@ -907,7 +904,7 @@ Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/414
 
 [AllCPython.test_ssl]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/414
 
 [AllCPython.test_startfile]
 RunCondition='$(OS)' != 'Unix'
@@ -1077,7 +1074,6 @@ Ignore=true
 
 [AllCPython.test_ucn]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_unicode]
 Ignore=true
@@ -1100,7 +1096,7 @@ Ignore=true
 
 [AllCPython.test_urllib]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=ImportError: Cannot import name RAND_bytes
 #Reason=Intermittent StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/40
 
 [AllCPython.test_urllib_response]
@@ -1108,19 +1104,17 @@ Ignore=true
 
 [AllCPython.test_urllib2]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=ImportError: Cannot import name RAND_bytes
 
 [AllCPython.test_urllib2_localnet]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_urllib2net]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=ImportError: Cannot import name RAND_bytes
 
 [AllCPython.test_urllibnet]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_userlist]
 Ignore=true
@@ -1178,7 +1172,6 @@ Ignore=true
 
 [AllCPython.test_wsgiref]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_xml_dom_minicompat]
 Ignore=true
@@ -1194,11 +1187,10 @@ Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/414
 
 [AllCPython.test_xmlrpc]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
 
 [AllCPython.test_xmlrpc_net]
 Ignore=true
-Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/483
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/490 (or related issue???)
 
 [AllCPython.test_zipfile]
 Ignore=true

--- a/Tests/modules/io_related/test_re.py
+++ b/Tests/modules/io_related/test_re.py
@@ -819,4 +819,43 @@ class ReTest(IronPythonTestCase):
         self.assertRaisesMessage(re.error, "redefinition of group name 'hoge' as group 3; was group 2", re.compile, r'(abc)(?P<hoge>\w+):(?P<hoge>\w+)')
         self.assertRaisesMessage(re.error, "redefinition of group name 'hoge' as group 4; was group 2", re.compile, r'(abc)(?P<hoge>\w+):(abc)(?P<hoge>\w+)')
 
+    def test_re_fullmatch(self):
+        # test_re_fullmatch from the StdLib - can be removed once test_re is passing
+
+        class S(str):
+            def __getitem__(self, index):
+                return S(super().__getitem__(index))
+
+        class B(bytes):
+            def __getitem__(self, index):
+                return B(super().__getitem__(index))
+
+        self.assertEqual(re.fullmatch(r"a", "a").span(), (0, 1))
+        for string in "ab", S("ab"):
+            self.assertEqual(re.fullmatch(r"a|ab", string).span(), (0, 2))
+        for string in b"ab", B(b"ab"), bytearray(b"ab"):
+            self.assertEqual(re.fullmatch(br"a|ab", string).span(), (0, 2))
+        for a, b in "\xe0\xdf", "\u0430\u0431":
+            r = r"%s|%s" % (a, a + b)
+            self.assertEqual(re.fullmatch(r, a + b).span(), (0, 2))
+        self.assertEqual(re.fullmatch(r".*?$", "abc").span(), (0, 3))
+        self.assertEqual(re.fullmatch(r".*?", "abc").span(), (0, 3))
+        self.assertEqual(re.fullmatch(r"a.*?b", "ab").span(), (0, 2))
+        self.assertEqual(re.fullmatch(r"a.*?b", "abb").span(), (0, 3))
+        self.assertEqual(re.fullmatch(r"a.*?b", "axxb").span(), (0, 4))
+        self.assertIsNone(re.fullmatch(r"a+", "ab"))
+        self.assertIsNone(re.fullmatch(r"abc$", "abc\n"))
+        self.assertIsNone(re.fullmatch(r"abc\Z", "abc\n"))
+        self.assertIsNone(re.fullmatch(r"(?m)abc$", "abc\n"))
+        self.assertEqual(re.fullmatch(r"ab(?=c)cd", "abcd").span(), (0, 4))
+        self.assertEqual(re.fullmatch(r"ab(?<=b)cd", "abcd").span(), (0, 4))
+        self.assertEqual(re.fullmatch(r"(?=a|ab)ab", "ab").span(), (0, 2))
+
+        self.assertEqual(
+            re.compile(r"bc").fullmatch("abcd", pos=1, endpos=3).span(), (1, 3))
+        self.assertEqual(
+            re.compile(r".*?$").fullmatch("abcd", pos=1, endpos=3).span(), (1, 3))
+        self.assertEqual(
+            re.compile(r".*?").fullmatch("abcd", pos=1, endpos=3).span(), (1, 3))
+
 run_test(__name__)


### PR DESCRIPTION
Adds `re.fullmatch` and cleans up `re.cs`. The implementation basically lazily generates a second `Regex` to use with `fullmatch` which wraps the original pattern `(?:{pattern})\Z`.