### PR TITLE
Update to new image and job format

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,26 +1,36 @@
-phases:
-- phase: Windows
-  queue: 
-    name: Hosted VS2017
-    timeoutInMinutes: 120
+jobs:
+
+################################################################################
+- job: Windows
+################################################################################
+  displayName: Windows
+  timeoutInMinutes: 180
+  pool:
+    vmImage: vs2017-win2016
   steps:
   - template: Build/steps.yml
     parameters:
       os: 'Windows'
 
-- phase: Linux
-  queue: 
-    name: Hosted Linux Preview
-    timeoutInMinutes: 120
+################################################################################
+- job: Linux
+################################################################################
+  displayName: Linux (Ubuntu)
+  timeoutInMinutes: 180
+  pool:
+    vmImage: 'ubuntu-16.04'    
   steps:
   - template: Build/steps.yml
     parameters:
       os: 'Linux'
 
-- phase: macOS
-  queue: 
-    name: Hosted macOS Preview
-    timeoutInMinutes: 120
+################################################################################
+- job: macOS
+################################################################################
+  displayName: macOS
+  timeoutInMinutes: 180
+  pool: 
+    vmImage: 'macOS-10.13'    
   steps:
   - template: Build/steps.yml
     parameters:


### PR DESCRIPTION
The current Ubuntu image we are using will be deprecated on December 1, 2018, this moves to the "new" VM image