### PR TITLE
[WIP] Make classes for map/filter/zip

### DIFF
--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -802,43 +802,10 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             );
         }
 
-        [PythonType("map")]
-        public class mapobject : IEnumerable {
-            private CodeContext _context;
-            private object _func;
-            private object[] _iters;
-
-            public mapobject(CodeContext context, object func, params object[] iters) {
-                _context = context;
-                _func = func;
-                _iters = iters;
+        public static PythonType map {
+            get {
+                return DynamicHelpers.GetPythonTypeFromType(typeof(Map));
             }
-
-            IEnumerator IEnumerable.GetEnumerator() {
-                IEnumerator[] enumerators = _iters.Select(x => PythonOps.GetEnumerator(x)).ToArray();
-                while (enumerators.All(x => x.MoveNext())) {
-                    yield return PythonOps.CallWithContext(_context, _func, enumerators.Select(x => x.Current).ToArray());
-                }
-            }            
-        }
-
-        public static object map(CodeContext/*!*/ context, object func, params object[] iters) {
-            if(iters.Length == 0) {
-                throw PythonOps.TypeError("map() must have at least two arguments.");
-            }
-
-            if(!PythonOps.IsCallable(context, func)) {
-                throw PythonOps.TypeError("'{0}' object is not callable", PythonOps.GetPythonTypeName(func));
-            }
-
-            foreach(object o in iters) {
-                IEnumerator e;
-                if(!PythonOps.TryGetEnumerator(context, o, out e)) {
-                    throw PythonOps.TypeError("'{0}' object is not iterable", PythonOps.GetPythonTypeName(o));
-                }
-            }
-
-            return new mapobject(context, func, iters);
         }
 
         private static object UndefinedKeywordArgument = new object();

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -361,43 +361,10 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             }
         }
 
-        [PythonType("filter")]
-        public class filterobj : IEnumerable {
-            private CodeContext _context;
-            private object _function;
-            private object _list;
-
-            public filterobj(CodeContext context, object function, object list) {
-                _context = context;
-                _function = function;
-                _list = list;
+        public static PythonType filter {
+            get {
+                return DynamicHelpers.GetPythonTypeFromType(typeof(Filter));
             }
-
-            public IEnumerator GetEnumerator() {
-                if (_function != null && !PythonOps.IsCallable(_context, _function)) {
-                    throw PythonOps.TypeError("'{0}' object is not callable", PythonOps.GetPythonTypeName(_function));
-                }
-
-                IEnumerator e = PythonOps.GetEnumerator(_context, _list);
-                while(e.MoveNext()) {
-                    object o = e.Current;
-                    object t = (_function != null) ? PythonCalls.Call(_context, _function, o) : o;
-
-                    if (PythonOps.IsTrue(t)) {
-                        yield return o;
-                    }
-                }
-            }
-        }
-
-        public static object filter(CodeContext/*!*/ context, object function, object list) {
-            if (list == null) throw PythonOps.TypeError("NoneType is not iterable");
-
-            IEnumerator e;
-            if(!PythonOps.TryGetEnumerator(context, list, out e)) {
-                throw PythonOps.TypeError("'{0}' object is not iterable", PythonOps.GetPythonTypeName(list));
-            }
-            return new filterobj(context, function, list);
         }
 
         public static PythonType @float {

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1618,55 +1618,10 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             return value;
         }
 
-        [PythonType("zip")]
-        public class zipobject : IEnumerator {
-            private readonly IEnumerator[] enumerators;
-            private object current;
-
-            public zipobject(CodeContext context, object[] iters) {
-                if (iters == null) throw PythonOps.TypeError("zip argument #{0} must support iteration", 1);
-
-                enumerators = new IEnumerator[iters.Length];
-                for (var i = 0; i < iters.Length; i++) {
-                    if (!PythonOps.TryGetEnumerator(context, iters[i], out enumerators[i]))
-                        throw PythonOps.TypeError("zip argument #{0} must support iteration", i + 1);
-                }
+        public static PythonType zip {
+            get {
+                return DynamicHelpers.GetPythonTypeFromType(typeof(Zip));
             }
-
-            public object Current {
-                get {
-                    if (current == null) throw new InvalidOperationException();
-                    return current;
-                }
-            }
-
-            public bool MoveNext() {
-                if (enumerators.Length > 0 && enumerators[0].MoveNext()) {
-                    var res = new object[enumerators.Length];
-                    res[0] = enumerators[0].Current;
-
-                    for (var i = 1; i < enumerators.Length; i++) {
-                        var enumerator = enumerators[i];
-                        if (!enumerator.MoveNext()) {
-                            current = null;
-                            return false;
-                        }
-
-                        res[i] = enumerator.Current;
-                    }
-
-                    current = PythonTuple.MakeTuple(res);
-                    return true;
-                }
-                current = null;
-                return false;
-            }
-
-            public void Reset() { throw new NotSupportedException(); }
-        }
-
-        public static object zip(CodeContext context, params object[] seqs) {
-            return new zipobject(context, seqs);
         }
 
         public static PythonType BaseException {

--- a/Src/IronPython/Runtime/Filter.cs
+++ b/Src/IronPython/Runtime/Filter.cs
@@ -35,7 +35,7 @@ or string, return the same type, else return a list.")]
         IEnumerator IEnumerable.GetEnumerator() {
 
             if (_function != null && !PythonOps.IsCallable(_context, _function)) {
-                throw PythonOps.TypeError("'{0}' object is not callable", PythonOps.GetPythonTypeName(_function));
+                throw PythonOps.UncallableError(_function);
             }
 
             IEnumerator e = PythonOps.GetEnumerator(_context, _iterable);

--- a/Src/IronPython/Runtime/Filter.cs
+++ b/Src/IronPython/Runtime/Filter.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+using Microsoft.Scripting.Runtime;
+using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
+
+namespace IronPython.Runtime {
+
+    [PythonType("filter")]
+    [Documentation(@"filter(function or None, sequence) -> list, tuple, or string
+
+Return those items of sequence for which function(item) is true.  If
+function is None, return the items that are true.  If sequence is a tuple
+or string, return the same type, else return a list.")]
+    public class Filter : IEnumerable {
+        private CodeContext _context;
+        private object _function;
+        private object _iterable;
+
+        public Filter(CodeContext context, object function, object iterable) {
+            _context = context;
+            _function = function;
+            _iterable = iterable;
+
+            IEnumerator e;
+            if(!PythonOps.TryGetEnumerator(context, iterable, out e)) {
+                throw PythonOps.TypeErrorForNotIterable(iterable);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+
+            if (_function != null && !PythonOps.IsCallable(_context, _function)) {
+                throw PythonOps.TypeError("'{0}' object is not callable", PythonOps.GetPythonTypeName(_function));
+            }
+
+            IEnumerator e = PythonOps.GetEnumerator(_context, _iterable);
+            while(e.MoveNext()) {
+                object o = e.Current;
+                object t = (_function != null) ? PythonCalls.Call(_context, _function, o) : o;
+
+                if (PythonOps.IsTrue(t)) {
+                    yield return o;
+                }
+            }
+        }
+    }
+}

--- a/Src/IronPython/Runtime/Map.cs
+++ b/Src/IronPython/Runtime/Map.cs
@@ -31,7 +31,7 @@ each of the iterables.  Stops when the shortest iterable is exhausted.")]
             }
 
             if(!PythonOps.IsCallable(context, func)) {
-                throw PythonOps.TypeError("'{0}' object is not callable", PythonOps.GetPythonTypeName(func));
+                throw PythonOps.UncallableError(func);
             }
 
             foreach(object o in iters) {

--- a/Src/IronPython/Runtime/Map.cs
+++ b/Src/IronPython/Runtime/Map.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Linq;
+
+using Microsoft.Scripting.Runtime;
+using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
+
+namespace IronPython.Runtime {
+
+    [PythonType("map")]
+    [Documentation(@"map(func, *iterables) -> map object
+
+Make an iterator that computes the function using arguments from
+each of the iterables.  Stops when the shortest iterable is exhausted.")]
+    public class Map : IEnumerable {
+        private CodeContext _context;
+        private object _func;
+        private object[] _iters;
+
+        public Map(CodeContext context, object func,  params object[] iters){
+            _context = context;
+            _func = func;
+            _iters = iters;
+
+            if(iters.Length == 0) {
+                throw PythonOps.TypeError("map() must have at least two arguments.");
+            }
+
+            if(!PythonOps.IsCallable(context, func)) {
+                throw PythonOps.TypeError("'{0}' object is not callable", PythonOps.GetPythonTypeName(func));
+            }
+
+            foreach(object o in iters) {
+                IEnumerator e;
+                if(!PythonOps.TryGetEnumerator(context, o, out e)) {
+                    throw PythonOps.TypeErrorForNotIterable(o);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            IEnumerator[] enumerators = _iters.Select(x => PythonOps.GetEnumerator(x)).ToArray();
+            while (enumerators.All(x => x.MoveNext())) {
+                yield return PythonOps.CallWithContext(_context, _func, enumerators.Select(x => x.Current).ToArray());
+            }
+        }
+    }
+}

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2015,7 +2015,7 @@ namespace IronPython.Runtime.Operations {
         public static IEnumerator GetEnumerator(CodeContext/*!*/ context, object o) {
             IEnumerator ie;
             if (!TryGetEnumerator(context, o, out ie)) {
-                throw PythonOps.TypeError("{0} is not iterable", PythonTypeOps.GetName(o));
+                throw TypeErrorForNotIterable(o);
             }
             return ie;
         }
@@ -2028,7 +2028,7 @@ namespace IronPython.Runtime.Operations {
             if (o is PythonType) {
                 var pt = (PythonType)o;
                 if (!pt.IsIterable(context)) {
-                    throw PythonOps.TypeError("'{0}' object is not iterable", PythonTypeOps.GetName(o));
+                    throw TypeErrorForNotIterable(o);
                 }
             }
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -4035,7 +4035,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static Exception UncallableError(object func) {
-            return PythonOps.TypeError("{0} is not callable", PythonTypeOps.GetName(func));
+            return PythonOps.TypeError("'{0}' object is not callable", PythonTypeOps.GetName(func));
         }
 
         public static Exception TypeErrorForProtectedMember(Type/*!*/ type, string/*!*/ name) {

--- a/Src/IronPython/Runtime/Zip.cs
+++ b/Src/IronPython/Runtime/Zip.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using Microsoft.Scripting.Runtime;
+using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
+
+namespace IronPython.Runtime {
+
+    [PythonType("zip")]
+    [Documentation(@"zip(iter1 [,iter2 [...]]) --> zip object
+
+Return a zip object whose .__next__() method returns a tuple where
+the i-th element comes from the i-th iterable argument.  The .__next__()
+method continues until the shortest iterable in the argument sequence
+is exhausted and then it raises StopIteration.")]
+    public class Zip : IEnumerator {
+
+        private readonly IEnumerator[] enumerators;
+        private object current;
+
+        public Zip(CodeContext context, params object[] iters) {
+            if (iters == null) throw PythonOps.TypeError("zip argument #{0} must support iteration", 1);
+
+            enumerators = new IEnumerator[iters.Length];
+            for (var i = 0; i < iters.Length; i++) {
+                if (!PythonOps.TryGetEnumerator(context, iters[i], out enumerators[i]))
+                    throw PythonOps.TypeError("zip argument #{0} must support iteration", i + 1);
+            }
+        }
+
+        public object Current {
+            get {
+                if (current == null) throw new InvalidOperationException();
+                return current;
+            }
+        }
+
+        public bool MoveNext() {
+            if (enumerators.Length > 0 && enumerators[0].MoveNext()) {
+                var res = new object[enumerators.Length];
+                res[0] = enumerators[0].Current;
+
+                for (var i = 1; i < enumerators.Length; i++) {
+                    var enumerator = enumerators[i];
+                    if (!enumerator.MoveNext()) {
+                        current = null;
+                        return false;
+                    }
+
+                    res[i] = enumerator.Current;
+                }
+
+                current = PythonTuple.MakeTuple(res);
+                return true;
+            }
+            current = null;
+            return false;
+        }
+
+        public void Reset() { throw new NotSupportedException(); }
+    }
+}


### PR DESCRIPTION
Resolves #503

This is just a direct copying of the map / filter / zip builtins from the Builtin.cs file into their own classes.

However it appears that the (CPython) 3 implementation of these classes differs from the current ones in more fundamental ways, returning stateful iterators instead of an enumerable.

``` python

x = map(lambda x:x+5, [10, 20 , 30])

print(list(x)) # => [15, 25, 35]
print(list(x)) # => []

```

Should these classes be rewritten to implement the `IEnumerator` interface instead of `IEnumerable`?