### PR TITLE
String/bytes cleanup

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -48,11 +48,11 @@ namespace IronPython.Modules {
         /// <summary>
         /// Encodes the input string with the specified optimized encoding map.
         /// </summary>
-        public static PythonTuple charmap_encode(CodeContext context, [BytesConversion]string input, string errors, [NotNull]EncodingMap map) {
+        public static PythonTuple charmap_encode(CodeContext context, string input, string errors, [NotNull]EncodingMap map) {
             return CharmapEncodeWorker(context, input, errors, new EncodingMapEncoding(map, errors));
         }
 
-        public static PythonTuple charmap_encode(CodeContext context, [BytesConversion]string input, string errors = "strict", IDictionary<object, object> map = null) {
+        public static PythonTuple charmap_encode(CodeContext context, string input, string errors = "strict", IDictionary<object, object> map = null) {
             Encoding e = map != null ? new CharmapEncoding(map, errors) : null;
             return CharmapEncodeWorker(context, input, errors, e);
         }
@@ -266,9 +266,11 @@ namespace IronPython.Modules {
             );
         }
 
-        public static PythonTuple readbuffer_encode([BytesConversion]string input, string errors = null) {
-            return PythonTuple.MakeTuple(input, input.Length);
-        }
+        public static PythonTuple readbuffer_encode(string input, string errors = null)
+            => readbuffer_encode(DoEncode(Encoding.UTF8, input).Item1, errors);
+
+        public static PythonTuple readbuffer_encode([BytesConversion]IList<byte> input, string errors = null)
+            => PythonTuple.MakeTuple(new Bytes(input), input.Count);
 
         public static void register(CodeContext/*!*/ context, object search_function) => PythonOps.RegisterEncoding(context, search_function);
 

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -107,7 +107,7 @@ namespace IronPython.Modules {
                 encoding = "latin-1";
             }
 
-            var res = StringOps.DoDecode(context, input.MakeString(), errors, encoding, e);
+            var res = StringOps.DoDecode(context, input, errors, encoding, e);
             return PythonTuple.MakeTuple(res, res.Length);
         }
 
@@ -237,7 +237,7 @@ namespace IronPython.Modules {
         [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static PythonTuple mbcs_decode(CodeContext/*!*/ context, [BytesConversion]IList<byte> input, string errors = "strict", bool final = false) {
             return PythonTuple.MakeTuple(
-                StringOps.decode(context, input.MakeString(), Encoding.Default, errors),
+                StringOps.RawDecode(context, input, Encoding.Default, errors),
                 Builtin.len(input)
             );
         }
@@ -255,7 +255,7 @@ namespace IronPython.Modules {
 
         public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [BytesConversion]IList<byte> input, string errors = "strict") {
             return PythonTuple.MakeTuple(
-                StringOps.decode(context, input.MakeString(), "raw-unicode-escape", errors),
+                StringOps.RawDecode(context, input, "raw-unicode-escape", errors),
                 Builtin.len(input)
             );
         }
@@ -436,7 +436,7 @@ namespace IronPython.Modules {
         #region Private implementation
 
         private static PythonTuple DoDecode(CodeContext context, string encodingName, Encoding encoding, [BytesConversion]IList<byte> input, string errors, bool final) {
-            var decoded = StringOps.DoDecode(context, input.MakeString(), errors, encodingName, encoding, final, out int numBytes);
+            var decoded = StringOps.DoDecode(context, input, errors, encodingName, encoding, final, out int numBytes);
             return PythonTuple.MakeTuple(decoded, numBytes);
         }
 

--- a/Src/IronPython.Modules/_pickle.cs
+++ b/Src/IronPython.Modules/_pickle.cs
@@ -98,8 +98,8 @@ namespace IronPython.Modules {
             + "reconstructed object. Characters in the string beyond the end of the first\n"
             + "pickle are ignored."
             )]
-        public static object loads(CodeContext/*!*/ context, [BytesConversion]string @string) {
-            return new UnpicklerObject(context, new PythonStringInput(@string)).load(context);
+        public static object loads(CodeContext/*!*/ context, [BytesConversion]IList<byte> @string) {
+            return new UnpicklerObject(context, new PythonStringInput(PythonOps.MakeString(@string))).load(context);
         }
 
         #endregion

--- a/Src/IronPython.Modules/binascii.cs
+++ b/Src/IronPython.Modules/binascii.cs
@@ -50,9 +50,9 @@ namespace IronPython.Modules {
             }
         }
 
-        public static string a2b_uu(CodeContext/*!*/ context, string data) {
+        public static Bytes a2b_uu(CodeContext/*!*/ context, string data) {
             if (data == null) throw PythonOps.TypeError("expected string, got NoneType");
-            if (data.Length < 1) return new string(Char.MinValue, 32);
+            if (data.Length < 1) return Bytes.Make(new byte[32]);
 
             int lenDec = (data[0] + 32) % 64; // decoded length in bytes
             int lenEnc = (lenDec * 4 + 2) / 3; // encoded length in 6-bit chunks
@@ -71,21 +71,21 @@ namespace IronPython.Modules {
                 ProcessSuffix(context, suffix, UuDecFunc);
             }
             
-            return res.ToString();
+            return PythonOps.MakeBytes(res.ToString());
         }
 
-        public static string b2a_uu(CodeContext/*!*/ context, string data) {
+        public static Bytes b2a_uu(CodeContext/*!*/ context, [BytesConversion]IList<byte> data) {
             if (data == null) throw PythonOps.TypeError("expected string, got NoneType");
-            if (data.Length > 45) throw Error(context, "At most 45 bytes at once");
+            if (data.Count > 45) throw Error(context, "At most 45 bytes at once");
 
             StringBuilder res = EncodeWorker(data, ' ', delegate(int val) {
                 return (char)(32 + (val % 64));
             });
 
-            res.Insert(0, ((char)(32 + data.Length)).ToString());
+            res.Insert(0, ((char)(32 + data.Count)).ToString());
 
             res.Append('\n');
-            return res.ToString();
+            return PythonOps.MakeBytes(res.ToString());
         }
 
         private static int Base64DecFunc(char val) {
@@ -104,22 +104,25 @@ namespace IronPython.Modules {
             }
         }
 
-        public static object a2b_base64(CodeContext/*!*/ context, [BytesConversion]string data) {
+        public static Bytes a2b_base64(CodeContext/*!*/ context, string data) {
             if (data == null) throw PythonOps.TypeError("expected string, got NoneType");
             data = RemovePrefix(context, data, Base64DecFunc);
-            if (data.Length == 0) return String.Empty;
+            if (data.Length == 0) return Bytes.Empty;
 
             StringBuilder res = DecodeWorker(context, data, false, Base64DecFunc);
-            return res.ToString();
+            return PythonOps.MakeBytes(res.ToString());
         }
 
-        public static object b2a_base64([BytesConversion]string data) {
+        public static Bytes a2b_base64(CodeContext/*!*/ context, [BytesConversion]IList<byte> data)
+            => a2b_base64(context, PythonOps.MakeString(data));
+
+        public static Bytes b2a_base64([BytesConversion]IList<byte> data) {
             if (data == null) throw PythonOps.TypeError("expected string, got NoneType");
-            if (data.Length == 0) return String.Empty;
+            if (data.Count == 0) return Bytes.Empty;
 
             StringBuilder res = EncodeWorker(data, '=', EncodeValue);
             res.Append('\n');
-            return res.ToString();
+            return PythonOps.MakeBytes(res.ToString());
         }
 
         private static char EncodeValue(int val) {
@@ -132,7 +135,7 @@ namespace IronPython.Modules {
                 case 63:
                     return '/';
                 default:
-                    throw new InvalidOperationException(String.Format("Bad int val: {0}", val));
+                    throw new InvalidOperationException(string.Format("Bad int val: {0}", val));
             }
         }
 
@@ -295,7 +298,7 @@ both encoded.  When quotetabs is set, space and tabs are encoded.")]
             throw new NotImplementedException();
         }
 
-        private static ushort[] crctab_hqx = new ushort[] {
+        private static readonly ushort[] crctab_hqx = new ushort[] {
             0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
             0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
             0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6,
@@ -330,8 +333,8 @@ both encoded.  When quotetabs is set, space and tabs are encoded.")]
             0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0,
         };
 
-        public static object crc_hqx([BytesConversion]IList<byte> data, int crc) {
-            crc = crc & 0xffff;
+        public static int crc_hqx([BytesConversion]IList<byte> data, int crc) {
+            crc &= 0xffff;
             foreach (var b in data) {
                 crc = ((crc << 8) & 0xff00) ^ crctab_hqx[(crc >> 8) ^ b];
             }
@@ -367,7 +370,7 @@ both encoded.  When quotetabs is set, space and tabs are encoded.")]
         internal static uint crc32(byte[] buffer, int offset, int count, uint baseValue) {
             uint remainder = (baseValue ^ 0xffffffff);
             for (int i = offset; i < offset + count; i++) {
-                remainder = remainder ^ buffer[i];
+                remainder ^= buffer[i];
                 for (int j = 0; j < 8; j++) {
                     if ((remainder & 0x01) != 0) {
                         remainder = (remainder >> 1) ^ 0xEDB88320;
@@ -423,39 +426,44 @@ both encoded.  When quotetabs is set, space and tabs are encoded.")]
             return (byte)('0' + p);
         }
 
-        public static object a2b_hex(CodeContext/*!*/ context, [BytesConversion]string data) {
+
+        public static Bytes a2b_hex(CodeContext/*!*/ context, string data) {
             if (data == null) throw PythonOps.TypeError("expected string, got NoneType");
             if ((data.Length & 0x01) != 0) throw PythonOps.TypeError("Odd-length string");
             StringBuilder res = new StringBuilder(data.Length / 2);
 
             for (int i = 0; i < data.Length; i += 2) {
                 byte b1, b2;
-                if (Char.IsDigit(data[i])) b1 = (byte)(data[i] - '0');
-                else b1 = (byte)(Char.ToUpper(data[i]) - 'A' + 10);
+                if (char.IsDigit(data[i])) b1 = (byte)(data[i] - '0');
+                else b1 = (byte)(char.ToUpper(data[i]) - 'A' + 10);
 
-                if (Char.IsDigit(data[i + 1])) b2 = (byte)(data[i + 1] - '0');
-                else b2 = (byte)(Char.ToUpper(data[i + 1]) - 'A' + 10);
+                if (char.IsDigit(data[i + 1])) b2 = (byte)(data[i + 1] - '0');
+                else b2 = (byte)(char.ToUpper(data[i + 1]) - 'A' + 10);
 
                 res.Append((char)(b1 * 16 + b2));
             }
-            return res.ToString();
+            return PythonOps.MakeBytes(res.ToString());
         }
+        public static Bytes a2b_hex(CodeContext/*!*/ context, [BytesConversion]IList<byte> data)
+            => a2b_hex(context, PythonOps.MakeString(data));
 
-        public static object unhexlify(CodeContext/*!*/ context, [BytesConversion]string hexstr) {
-            return a2b_hex(context, hexstr);
-        }
+        public static Bytes unhexlify(CodeContext/*!*/ context, string hexstr)
+            => a2b_hex(context, hexstr);
+
+        public static Bytes unhexlify(CodeContext/*!*/ context, [BytesConversion]IList<byte> hexstr)
+            => a2b_hex(context, hexstr);
 
         #region Private implementation
 
         private delegate char EncodeChar(int val);
         private delegate int DecodeByte(char val);
 
-        private static StringBuilder EncodeWorker(string data, char empty, EncodeChar encFunc) {
+        private static StringBuilder EncodeWorker(IList<byte> data, char empty, EncodeChar encFunc) {
             StringBuilder res = new StringBuilder();
 
             int bits;
-            for (int i = 0; i < data.Length; i += 3) {
-                switch (data.Length - i) {
+            for (int i = 0; i < data.Count; i += 3) {
+                switch (data.Count - i) {
                     case 1:
                         // only one char, emit 2 bytes &
                         // padding

--- a/Src/IronPython.Modules/binascii.cs
+++ b/Src/IronPython.Modules/binascii.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -342,29 +344,17 @@ both encoded.  When quotetabs is set, space and tabs are encoded.")]
         }
 
         [Documentation("crc32(string[, value]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of string.")]
-        public static int crc32(string buffer, int baseValue=0) {
-            byte[] data = buffer.MakeByteArray();
+        public static BigInteger crc32([BytesConversion]IList<byte> buffer, int baseValue=0) {
+            byte[] data = buffer as byte[] ?? (buffer is Bytes b ? b.GetUnsafeByteArray() : buffer.ToArray());
             uint result = crc32(data, 0, data.Length, unchecked((uint)baseValue));
-            return unchecked((int)result);
+            return result;
         }
 
         [Documentation("crc32(string[, value]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of string.")]
-        public static int crc32(string buffer, uint baseValue) {
-            byte[] data = buffer.MakeByteArray();
+        public static BigInteger crc32([BytesConversion]IList<byte> buffer, uint baseValue) {
+            byte[] data = buffer as byte[] ?? (buffer is Bytes b ? b.GetUnsafeByteArray() : buffer.ToArray());
             uint result = crc32(data, 0, data.Length, baseValue);
-            return unchecked((int)result);
-        }
-
-        [Documentation("crc32(byte_array[, value]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of byte_array.")]
-        public static int crc32(byte[] buffer, int baseValue=0) {
-            uint result = crc32(buffer, 0, buffer.Length, unchecked((uint)baseValue));
-            return unchecked((int)result);
-        }
-
-        [Documentation("crc32(byte_array[, value]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of byte_array.")]
-        public static int crc32(byte[] buffer, uint baseValue) {
-            uint result = crc32(buffer, 0, buffer.Length, baseValue);
-            return unchecked((int)result);
+            return result;
         }
 
         internal static uint crc32(byte[] buffer, int offset, int count, uint baseValue) {

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -371,10 +371,15 @@ namespace IronPython.Modules {
         /// Like stat(path), but do not follow symbolic links.
         /// </summary>
         [LightThrowing]
-        public static object lstat([BytesConversion]string path) {
+        public static object lstat(string path) {
             // TODO: detect links
             return stat(path);
         }
+
+        [LightThrowing]
+        public static object lstat([BytesConversion]IList<byte> path)
+            => lstat(PythonOps.MakeString(path));
+
 
 #if FEATURE_NATIVE
         [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
@@ -1116,7 +1121,7 @@ namespace IronPython.Modules {
 
         [Documentation("stat(path) -> stat result\nGathers statistics about the specified file or directory")]
         [LightThrowing]
-        public static object stat([BytesConversion]string path) {
+        public static object stat(string path) {
             if (path == null) {
                 return LightExceptions.Throw(PythonOps.TypeError("expected string, got NoneType"));
             }
@@ -1169,6 +1174,10 @@ namespace IronPython.Modules {
                 return null;
             }
         }
+
+        [LightThrowing]
+        public static object stat([BytesConversion]IList<byte> path)
+            => stat(PythonOps.MakeString(path));
 
         public static string strerror(int code) {
             switch (code) {
@@ -1369,12 +1378,12 @@ namespace IronPython.Modules {
         }
 #endif
 
-        public static int write(CodeContext/*!*/ context, int fd, [BytesConversion]string text) {
+        public static int write(CodeContext/*!*/ context, int fd, [BytesConversion]IList<byte> text) {
             try {
                 PythonContext pythonContext = context.LanguageContext;
                 PythonFile pf = pythonContext.FileManager.GetFileFromId(pythonContext, fd);
                 pf.write(text);
-                return text.Length;
+                return text.Count;
             } catch (Exception e) {
                 throw ToPythonException(e);
             }

--- a/Src/IronPython.Modules/pyexpat.cs
+++ b/Src/IronPython.Modules/pyexpat.cs
@@ -579,6 +579,9 @@ namespace IronPython.Modules {
 
             private MemoryStream buffer = new MemoryStream();
 
+            public void Parse(CodeContext context, string data, bool isfinal = false)
+                => Parse(context, PythonOps.MakeBytes(data), isfinal);
+
             public void Parse(CodeContext context, [BytesConversion]IList<byte> data, bool isfinal = false) {
                 CheckParsingDone(context);
 

--- a/Src/IronPython.Modules/zlib/Compress.cs
+++ b/Src/IronPython.Modules/zlib/Compress.cs
@@ -49,7 +49,7 @@ namespace IronPython.Zlib
 After calling this function, some of the input data may still
 be stored in internal buffers for later processing.
 Call the flush() method to clear these buffers.")]
-        public string compress([BytesConversion]IList<byte> data)
+        public Bytes compress([BytesConversion]IList<byte> data)
         {
             byte[] input = data.ToArray();
             byte[] output = new byte[ZlibModule.DEFAULTALLOC];
@@ -80,7 +80,7 @@ Call the flush() method to clear these buffers.")]
                 throw ZlibModule.zlib_error(this.zst, err, "while compressing");
             }
 
-            return PythonAsciiEncoding.Instance.GetString(output, 0, (int)(zst.total_out - start_total_out));
+            return GetBytes(output, 0, (int)(zst.total_out - start_total_out));
         }
 
         [Documentation(@"flush( [mode] ) -- Return a string containing any remaining compressed data.
@@ -89,13 +89,13 @@ mode can be one of the constants Z_SYNC_FLUSH, Z_FULL_FLUSH, Z_FINISH; the
 default value used when mode is not specified is Z_FINISH.
 If mode == Z_FINISH, the compressor object can no longer be used after
 calling the flush() method.  Otherwise, more data can still be compressed.")]
-        public string flush(int mode=Z_FINISH)
+        public Bytes flush(int mode=Z_FINISH)
         {
             byte[] output = new byte[ZlibModule.DEFAULTALLOC];
 
             if(mode == Z_NO_FLUSH)
             {
-                return string.Empty;
+                return Bytes.Empty;
             }
 
             long start_total_out = zst.total_out;
@@ -129,7 +129,7 @@ calling the flush() method.  Otherwise, more data can still be compressed.")]
                 throw ZlibModule.zlib_error(this.zst, err, "while flushing");
             }
 
-            return PythonAsciiEncoding.Instance.GetString(output, 0, (int)(zst.total_out - start_total_out));
+            return GetBytes(output, 0, (int)(zst.total_out - start_total_out));
         }
 
         //[Documentation("copy() -- Return a copy of the compression object.")]
@@ -139,5 +139,12 @@ calling the flush() method.  Otherwise, more data can still be compressed.")]
         //}
 
         private ZStream zst;
+
+        private static Bytes GetBytes(byte[] bytes, int index, int count)
+        {
+            var res = new byte[count];
+            Array.Copy(bytes, index, res, 0, count);
+            return Bytes.Make(res);
+        }
     }
 }

--- a/Src/IronPython/Hosting/PythonOptionsParser.cs
+++ b/Src/IronPython/Hosting/PythonOptionsParser.cs
@@ -171,9 +171,6 @@ namespace IronPython.Hosting {
                 case "-X:MTA":
                     ConsoleOptions.IsMta = true;
                     break;
-                case "-X:Python30":
-                    LanguageSetup.Options["PythonVersion"] = new Version(3, 0);
-                    break;
 
                 case "-X:Debug":
                     RuntimeSetup.DebugMode = true;
@@ -262,7 +259,6 @@ namespace IronPython.Hosting {
                 { "-X:Debug",               "Enable application debugging (preferred over -D)" },
                 { "-X:NoDebug <regex>",     "Provides a regular expression of files which should not be emitted in debug mode"},
                 { "-X:MTA",                 "Run in multithreaded apartment" },
-                { "-X:Python30",            "Enable available Python 3.0 features" },
                 { "-X:EnableProfiler",      "Enables profiling support in the compiler" },
                 { "-X:LightweightScopes",   "Generate optimized scopes that can be garbage collected" },
                 { "-X:BasicConsole",        "Use only the basic console features" },

--- a/Src/IronPython/Modules/array.cs
+++ b/Src/IronPython/Modules/array.cs
@@ -37,7 +37,7 @@ namespace IronPython.Modules {
             private readonly char _typeCode;
             private WeakRefTracker _tracker;
 
-            public array([BytesConversion]string type, [Optional]object initializer) {
+            public array(string type, [Optional]object initializer) {
                 if (type == null || type.Length != 1) {
                     throw PythonOps.TypeError("expected character, got {0}", PythonTypeOps.GetName(type));
                 }

--- a/Src/IronPython/Runtime/Binding/ConversionBinder.cs
+++ b/Src/IronPython/Runtime/Binding/ConversionBinder.cs
@@ -161,17 +161,6 @@ namespace IronPython.Runtime.Binding {
                     res = TryToCharConversion(self);
                     break;
                 case TypeCode.String:
-                    var limitType = self.GetLimitType();
-                    if ((limitType == typeof(Bytes) || limitType == typeof(ByteArray)) &&
-                        !_context.PythonOptions.Python30) {
-                        res = new DynamicMetaObject(
-                            Ast.Call(
-                                typeof(PythonOps).GetMethod(nameof(PythonOps.MakeString)),
-                                AstUtils.Convert(self.Expression, typeof(IList<byte>))
-                            ),
-                            BindingRestrictionsHelpers.GetRuntimeTypeRestriction(self.Expression, limitType)
-                        );
-                    }
                     break;
                 case TypeCode.Object:
                     // !!! Deferral?

--- a/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
+++ b/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
@@ -69,8 +69,7 @@ namespace IronPython.Runtime.Binding {
             if ((fromType == typeof(PythonList) || fromType.IsSubclassOf(typeof(PythonList)))) {
                 if (toParameter.Type.IsGenericType() &&
                     toParameter.Type.GetGenericTypeDefinition() == typeof(IList<>) &&
-                    (toParameter.ParameterInfo.IsDefined(typeof(BytesConversionAttribute), false) ||
-                     toParameter.ParameterInfo.IsDefined(typeof(BytesConversionNoStringAttribute), false))) {
+                    toParameter.ParameterInfo.IsDefined(typeof(BytesConversionAttribute), false)) {
                     return false;
                 }
             } else if (fromType == typeof(string)) {

--- a/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
+++ b/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
@@ -72,19 +72,6 @@ namespace IronPython.Runtime.Binding {
                     toParameter.ParameterInfo.IsDefined(typeof(BytesConversionAttribute), false)) {
                     return false;
                 }
-            } else if (fromType == typeof(string)) {
-                if (toParameter.Type == typeof(IList<byte>) &&
-                    !Binder.Context.PythonOptions.Python30 &&
-                    toParameter.ParameterInfo.IsDefined(typeof(BytesConversionAttribute), false)) {
-                    // string -> byte array, we allow this in Python 2.6
-                    return true;
-                }
-            } else if (fromType == typeof(Bytes) || fromType == typeof(ByteArray)) {
-                if (toParameter.Type == typeof(string) &&
-                    !Binder.Context.PythonOptions.Python30 &&
-                    toParameter.ParameterInfo.IsDefined(typeof(BytesConversionAttribute), false)) {
-                    return true;
-                }
             }
 
             return base.CanConvertFrom(fromType, fromArg, toParameter, level);

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -495,7 +495,7 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ lstrip([BytesConversionNoString]IList<byte> bytes) {
+        public ByteArray/*!*/ lstrip([BytesConversion]IList<byte> bytes) {
             lock (this) {
                 List<byte> res = _bytes.LeftStrip(bytes);
                 if (res == null) {
@@ -647,11 +647,11 @@ namespace IronPython.Runtime {
             }
         }
 
-        public PythonList/*!*/ rsplit([BytesConversionNoString]IList<byte>/*!*/ sep) {
+        public PythonList/*!*/ rsplit([BytesConversion]IList<byte>/*!*/ sep) {
             return rsplit(sep, -1);
         }
 
-        public PythonList/*!*/ rsplit([BytesConversionNoString]IList<byte>/*!*/ sep, int maxsplit) {
+        public PythonList/*!*/ rsplit([BytesConversion]IList<byte>/*!*/ sep, int maxsplit) {
             return _bytes.RightSplit(sep, maxsplit, x => new ByteArray(new List<byte>(x)));
         }
 
@@ -666,7 +666,7 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/  rstrip([BytesConversionNoString]IList<byte> bytes) {
+        public ByteArray/*!*/  rstrip([BytesConversion]IList<byte> bytes) {
             lock (this) {
                 List<byte> res = _bytes.RightStrip(bytes);
                 if (res == null) {
@@ -683,11 +683,11 @@ namespace IronPython.Runtime {
             }
         }
 
-        public PythonList/*!*/ split([BytesConversionNoString]IList<byte> sep) {
+        public PythonList/*!*/ split([BytesConversion]IList<byte> sep) {
             return split(sep, -1);
         }
 
-        public PythonList/*!*/ split([BytesConversionNoString]IList<byte> sep, int maxsplit) {
+        public PythonList/*!*/ split([BytesConversion]IList<byte> sep, int maxsplit) {
             lock (this) {
                 return _bytes.Split(sep, maxsplit, x => new ByteArray(x));
             }
@@ -757,7 +757,7 @@ namespace IronPython.Runtime {
             }
         }
 
-        public ByteArray/*!*/ strip([BytesConversionNoString]IList<byte> chars) {
+        public ByteArray/*!*/ strip([BytesConversion]IList<byte> chars) {
             lock (this) {
                 List<byte> res = _bytes.Strip(chars);
                 if (res == null) {
@@ -839,7 +839,7 @@ namespace IronPython.Runtime {
             return _bytes.Count + 1;
         }
 
-        public bool __contains__([BytesConversionNoString]IList<byte> bytes) {
+        public bool __contains__([BytesConversion]IList<byte> bytes) {
             return this.IndexOf(bytes, 0) != -1;
         }
 

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -261,7 +261,9 @@ namespace IronPython.Runtime {
         }
 
         public string decode(CodeContext/*!*/ context, [Optional]object encoding, string errors = "strict") {
-            return StringOps.decode(context, _bytes.MakeString(), encoding, errors);
+            lock (this) {
+                return StringOps.RawDecode(context, _bytes.ToArray(), encoding, errors);
+            }
         }
 
         public bool endswith([BytesConversion]IList<byte>/*!*/ suffix) {

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -124,7 +124,7 @@ namespace IronPython.Runtime {
         }
 
         public string decode(CodeContext/*!*/ context, [Optional]object/*!*/ encoding, [NotNull]string/*!*/ errors="strict") {
-            return StringOps.decode(context, _bytes.MakeString(), encoding, errors);
+            return StringOps.RawDecode(context, _bytes, encoding, errors);
         }
 
         public bool endswith([BytesConversion]IList<byte>/*!*/ suffix) {

--- a/Src/IronPython/Runtime/BytesConversionAttribute.cs
+++ b/Src/IronPython/Runtime/BytesConversionAttribute.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace IronPython {
     /// <summary>
@@ -17,10 +15,5 @@ namespace IronPython {
     /// as well. (2.6 only)
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
-    public sealed class BytesConversionAttribute : Attribute {
-    }
-
-    [AttributeUsage(AttributeTargets.Parameter)]
-    public sealed class BytesConversionNoStringAttribute : Attribute {
-    }
+    public sealed class BytesConversionAttribute : Attribute { }
 }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -307,7 +307,7 @@ namespace IronPython.Runtime.Operations {
 
         [StaticExtensionMethod]
         public static object __new__(CodeContext/*!*/ context, PythonType cls,
-            [BytesConversion]object @string,
+            object @string,
             string encoding="utf-8",
             string errors="strict") {
 
@@ -339,7 +339,7 @@ namespace IronPython.Runtime.Operations {
 
         #region Python __ methods
 
-        public static bool __contains__(string s, [BytesConversion]string item) {
+        public static bool __contains__(string s, string item) {
             return s.Contains(item);
         }
 
@@ -347,7 +347,7 @@ namespace IronPython.Runtime.Operations {
             return s.IndexOf(item) != -1;
         }
 
-        public static string __format__(CodeContext/*!*/ context, string self, [BytesConversion]string formatSpec) {
+        public static string __format__(CodeContext/*!*/ context, string self, string formatSpec) {
             return ObjectOps.__format__(context, self, formatSpec);
         }
 
@@ -424,15 +424,15 @@ namespace IronPython.Runtime.Operations {
             return ret.ToString();
         }
 
-        public static int count(this string self, [BytesConversion]string sub) {
+        public static int count(this string self, string sub) {
             return count(self, sub, 0, self.Length);
         }
 
-        public static int count(this string self, [BytesConversion]string sub, int start) {
+        public static int count(this string self, string sub, int start) {
             return count(self, sub, start, self.Length);
         }
 
-        public static int count(this string self, [BytesConversion]string ssub, int start, int end) {
+        public static int count(this string self, string ssub, int start, int end) {
             if (ssub == null) throw PythonOps.TypeError("expected string for 'sub' argument, got NoneType");
 
             if (start > self.Length) {
@@ -540,7 +540,7 @@ namespace IronPython.Runtime.Operations {
             return ret.ToString();
         }
 
-        public static int find(this string self, [BytesConversion]string sub) {
+        public static int find(this string self, string sub) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (sub.Length == 1) return self.IndexOf(sub[0]);
             
@@ -548,7 +548,7 @@ namespace IronPython.Runtime.Operations {
             return c.IndexOf(self, sub, CompareOptions.Ordinal);
         }
 
-        public static int find(this string self, [BytesConversion]string sub, int start) {
+        public static int find(this string self, string sub, int start) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
             start = PythonOps.FixSliceIndex(start, self.Length);
@@ -557,13 +557,13 @@ namespace IronPython.Runtime.Operations {
             return c.IndexOf(self, sub, start, CompareOptions.Ordinal);
         }
 
-        public static int find(this string self, [BytesConversion]string sub, BigInteger start) {
+        public static int find(this string self, string sub, BigInteger start) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
             return find(self, sub, (int)start);
         }
 
-        public static int find(this string self, [BytesConversion]string sub, int start, int end) {
+        public static int find(this string self, string sub, int start, int end) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
             start = PythonOps.FixSliceIndex(start, self.Length);
@@ -574,34 +574,34 @@ namespace IronPython.Runtime.Operations {
             return c.IndexOf(self, sub, start, end - start, CompareOptions.Ordinal);
         }
 
-        public static int find(this string self, [BytesConversion]string sub, BigInteger start, BigInteger end) {
+        public static int find(this string self, string sub, BigInteger start, BigInteger end) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
             return find(self, sub, (int)start, (int)end);
         }
 
-        public static int find(this string self, [BytesConversion]string sub, object start, object end=null) {
+        public static int find(this string self, string sub, object start, object end=null) {
             return find(self, sub, CheckIndex(start, 0), CheckIndex(end, self.Length));
         }
 
-        public static int index(this string self, [BytesConversion]string sub) {
+        public static int index(this string self, string sub) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             return index(self, sub, 0, self.Length);
         }
 
-        public static int index(this string self, [BytesConversion]string sub, int start) {
+        public static int index(this string self, string sub, int start) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             return index(self, sub, start, self.Length);
         }
 
-        public static int index(this string self, [BytesConversion]string sub, int start, int end) {
+        public static int index(this string self, string sub, int start, int end) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             int ret = find(self, sub, start, end);
             if (ret == -1) throw PythonOps.ValueError("substring {0} not found in {1}", sub, self);
             return ret;
         }
 
-        public static int index(this string self, [BytesConversion]string sub, object start, object end=null) {
+        public static int index(this string self, string sub, object start, object end=null) {
             return index(self, sub, CheckIndex(start, 0), CheckIndex(end, self.Length));
         }
 
@@ -838,13 +838,13 @@ namespace IronPython.Runtime.Operations {
             return self.TrimStart();
         }
 
-        public static string lstrip(this string self, [BytesConversion]string chars) {
+        public static string lstrip(this string self, string chars) {
             if (chars == null) return lstrip(self);
             return self.TrimStart(chars.ToCharArray());
         }
 
         [return: SequenceTypeInfo(typeof(string))]
-        public static PythonTuple partition(this string self, [BytesConversion]string sep) {
+        public static PythonTuple partition(this string self, string sep) {
             if (sep == null)
                 throw PythonOps.TypeError("expected string, got NoneType");
             if (sep.Length == 0)
@@ -865,7 +865,7 @@ namespace IronPython.Runtime.Operations {
             return new PythonTuple(obj);
         }
 
-        public static string replace(this string self, [BytesConversion]string old, [BytesConversion]string @new,
+        public static string replace(this string self, string old, string @new,
             int count=-1) {
 
             if (old == null) {
@@ -894,24 +894,24 @@ namespace IronPython.Runtime.Operations {
             return ret.ToString();
         }
 
-        public static int rfind(this string self, [BytesConversion]string sub) {
+        public static int rfind(this string self, string sub) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             return rfind(self, sub, 0, self.Length);
         }
 
-        public static int rfind(this string self, [BytesConversion]string sub, int start) {
+        public static int rfind(this string self, string sub, int start) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
             return rfind(self, sub, start, self.Length);
         }
 
-        public static int rfind(this string self, [BytesConversion]string sub, BigInteger start) {
+        public static int rfind(this string self, string sub, BigInteger start) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
             return rfind(self, sub, (int)start, self.Length);
         }
 
-        public static int rfind(this string self, [BytesConversion]string sub, int start, int end) {
+        public static int rfind(this string self, string sub, int start, int end) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
 
@@ -926,31 +926,31 @@ namespace IronPython.Runtime.Operations {
             return c.LastIndexOf(self, sub, end - 1, end - start, CompareOptions.Ordinal);
         }
 
-        public static int rfind(this string self, [BytesConversion]string sub, BigInteger start, BigInteger end) {
+        public static int rfind(this string self, string sub, BigInteger start, BigInteger end) {
             if (sub == null) throw PythonOps.TypeError("expected string, got NoneType");
             if (start > self.Length) return -1;
             return rfind(self, sub, (int)start, (int)end);
         }
 
-        public static int rfind(this string self, [BytesConversion]string sub, object start, object end=null) {
+        public static int rfind(this string self, string sub, object start, object end=null) {
             return rfind(self, sub, CheckIndex(start, 0), CheckIndex(end, self.Length));
         }
 
-        public static int rindex(this string self, [BytesConversion]string sub) {
+        public static int rindex(this string self, string sub) {
             return rindex(self, sub, 0, self.Length);
         }
 
-        public static int rindex(this string self, [BytesConversion]string sub, int start) {
+        public static int rindex(this string self, string sub, int start) {
             return rindex(self, sub, start, self.Length);
         }
 
-        public static int rindex(this string self, [BytesConversion]string sub, int start, int end) {
+        public static int rindex(this string self, string sub, int start, int end) {
             int ret = rfind(self, sub, start, end);
             if (ret == -1) throw PythonOps.ValueError("substring {0} not found in {1}", sub, self);
             return ret;
         }
 
-        public static int rindex(this string self, [BytesConversion]string sub, object start, object end=null) {
+        public static int rindex(this string self, string sub, object start, object end=null) {
             return rindex(self, sub, CheckIndex(start, 0), CheckIndex(end, self.Length));
         }
 
@@ -969,7 +969,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         [return: SequenceTypeInfo(typeof(string))]
-        public static PythonTuple rpartition(this string self, [BytesConversion]string sep) {
+        public static PythonTuple rpartition(this string self, string sep) {
             if (sep == null)
                 throw PythonOps.TypeError("expected string, got NoneType");
             if (sep.Length == 0)
@@ -994,11 +994,11 @@ namespace IronPython.Runtime.Operations {
             return SplitInternal(self, (char[])null, -1);
         }
 
-        public static PythonList rsplit(this string self, [BytesConversion]string sep) {
+        public static PythonList rsplit(this string self, string sep) {
             return rsplit(self, sep, -1);
         }
 
-        public static PythonList rsplit(this string self, [BytesConversion]string sep, int maxsplit) {
+        public static PythonList rsplit(this string self, string sep, int maxsplit) {
             //  rsplit works like split but needs to split from the right;
             //  reverse the original string (and the sep), split, reverse 
             //  the split list and finally reverse each element of the list
@@ -1022,7 +1022,7 @@ namespace IronPython.Runtime.Operations {
             return self.TrimEnd();
         }
 
-        public static string rstrip(this string self, [BytesConversion]string chars) {
+        public static string rstrip(this string self, string chars) {
             if (chars == null) return rstrip(self);
             return self.TrimEnd(chars.ToCharArray());
         }
@@ -1031,11 +1031,11 @@ namespace IronPython.Runtime.Operations {
             return SplitInternal(self, (char[])null, -1);
         }
 
-        public static PythonList split(this string self, [BytesConversion]string sep) {
+        public static PythonList split(this string self, string sep) {
             return split(self, sep, -1);
         }
 
-        public static PythonList split(this string self, [BytesConversion]string sep, int maxsplit) {
+        public static PythonList split(this string self, string sep, int maxsplit) {
             if (sep == null) {
                 if (maxsplit == 0) {
                     // Corner case for CPython compatibility
@@ -1116,7 +1116,7 @@ namespace IronPython.Runtime.Operations {
             return self.Trim();
         }
 
-        public static string strip(this string self, [BytesConversion]string chars) {
+        public static string strip(this string self, string chars) {
             if (chars == null) return strip(self);
             return self.Trim(chars.ToCharArray());
         }
@@ -1189,11 +1189,11 @@ namespace IronPython.Runtime.Operations {
             return ret.ToString();
         }
 
-        public static string translate(this string self, [BytesConversion]string table) {
+        public static string translate(this string self, string table) {
             return translate(self, table, (string)null);
         }
 
-        public static string translate(this string self, [BytesConversion]string table, [BytesConversion]string deletechars) {
+        public static string translate(this string self, string table, string deletechars) {
             if (table != null && table.Length != 256) {
                 throw PythonOps.ValueError("translation table must be 256 characters long");
             } else if (self.Length == 0) {
@@ -2104,7 +2104,7 @@ namespace IronPython.Runtime.Operations {
             return ret;
         }
 
-        public static bool endswith(string self, [BytesConversion]string suffix) {
+        public static bool endswith(string self, string suffix) {
             return self.EndsWith(suffix, StringComparison.Ordinal);
         }
 
@@ -2116,7 +2116,7 @@ namespace IronPython.Runtime.Operations {
         //    0   1   2   3   4
         //   -5  -4  -3  -2  -1
 
-        public static bool endswith(string self, [BytesConversion]string suffix, int start) {
+        public static bool endswith(string self, string suffix, int start) {
             int len = self.Length;
             if (start > len) return false;
             // map the negative indice to its positive counterpart
@@ -2130,7 +2130,7 @@ namespace IronPython.Runtime.Operations {
         //  With optional start, test beginning at that position (the char at that index is
         //  included in the test). With optional end, stop comparing at that position (the
         //  char at that index is not included in the test)
-        public static bool endswith(string self, [BytesConversion]string suffix, int start, int end) {
+        public static bool endswith(string self, string suffix, int start, int end) {
             int len = self.Length;
             if (start > len) return false;
             // map the negative indices to their positive counterparts
@@ -2174,11 +2174,11 @@ namespace IronPython.Runtime.Operations {
             return false;
         }
 
-        public static bool startswith(string self, [BytesConversion]string prefix) {
+        public static bool startswith(string self, string prefix) {
             return self.StartsWith(prefix, StringComparison.Ordinal);
         }
 
-        public static bool startswith(string self, [BytesConversion]string prefix, int start) {
+        public static bool startswith(string self, string prefix, int start) {
             int len = self.Length;
             if (start > len) return false;
             if (start < 0) {
@@ -2188,7 +2188,7 @@ namespace IronPython.Runtime.Operations {
             return self.Substring(start).StartsWith(prefix, StringComparison.Ordinal);
         }
 
-        public static bool startswith(string self, [BytesConversion]string prefix, int start, int end) {
+        public static bool startswith(string self, string prefix, int start, int end) {
             int len = self.Length;
             if (start > len) return false;
             // map the negative indices to their positive counterparts

--- a/Src/IronPython/Runtime/PythonOptions.cs
+++ b/Src/IronPython/Runtime/PythonOptions.cs
@@ -9,8 +9,6 @@ using System.Text.RegularExpressions;
 
 using Microsoft.Scripting;
 
-using IronPython.Runtime.Exceptions;
-
 namespace IronPython {
 
     [Serializable, CLSCompliant(true)]
@@ -39,11 +37,6 @@ namespace IronPython {
         /// Enables warnings related to Python 3.0 features.
         /// </summary>
         public bool WarnPython30 { get; }
-
-        /// <summary>
-        /// Enables 3.0 features that are implemented in IronPython.
-        /// </summary>
-        public bool Python30 { get; }
 
         public bool BytesWarning { get; }
 
@@ -136,12 +129,6 @@ namespace IronPython {
             : this(null) {
         }
 
-        /// <summary>
-        /// Gets the CPython version which IronPython will emulate.  Currently limited
-        /// to either 2.6 or 3.0.
-        /// </summary>
-        public Version PythonVersion { get; }
-
         public PythonOptions(IDictionary<string, object> options)
             : base(EnsureSearchPaths(options)) {
 
@@ -168,25 +155,6 @@ namespace IronPython {
             Tracing = GetOption(options, "Tracing", false);
             NoDebug = GetOption(options, "NoDebug", (Regex)null);
             Quiet = GetOption(options, "Quiet", false);
-
-            object value;
-            if (options != null && options.TryGetValue("PythonVersion", out value)) {
-                if (value is Version) {
-                    PythonVersion = (Version)value;
-                } else if (value is string) {
-                    PythonVersion = new Version((string)value);
-                } else {
-                    throw new ValueErrorException("Expected string or Version for PythonVersion");
-                }
-
-                if (PythonVersion != new Version(2, 7) && PythonVersion != new Version(3, 0)) {
-                    throw new ValueErrorException("Expected Version to be 2.7 or 3.0");
-                }
-            } else {
-                PythonVersion = new Version(2, 7);
-            }
-
-            Python30 = PythonVersion == new Version(3, 0);
         }
 
         private static IDictionary<string, object> EnsureSearchPaths(IDictionary<string, object> options) {

--- a/Src/IronPython/Runtime/PythonTuple.cs
+++ b/Src/IronPython/Runtime/PythonTuple.cs
@@ -670,4 +670,22 @@ namespace IronPython.Runtime {
             return _tuple.__len__() - _curIndex - 1;
         }
     }
+
+    internal static class TupleExtensions {
+        public static PythonTuple ToPythonTuple<T1>(this Tuple<T1> value) {
+            return PythonTuple.MakeTuple(value.Item1);
+        }
+
+        public static PythonTuple ToPythonTuple<T1, T2>(this Tuple<T1, T2> value) {
+            return PythonTuple.MakeTuple(value.Item1, value.Item2);
+        }
+
+        public static PythonTuple ToPythonTuple<T1, T2, T3>(this Tuple<T1, T2, T3> value) {
+            return PythonTuple.MakeTuple(value.Item1, value.Item2, value.Item3);
+        }
+
+        public static PythonTuple ToPythonTuple<T1, T2, T3, T4>(this Tuple<T1, T2, T3, T4> value) {
+            return PythonTuple.MakeTuple(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+    }
 }

--- a/Src/IronPython/Runtime/Types/NewTypeMaker.cs
+++ b/Src/IronPython/Runtime/Types/NewTypeMaker.cs
@@ -421,9 +421,6 @@ namespace IronPython.Runtime.Types {
                     } else if (pi.IsDefined(typeof(BytesConversionAttribute), false)) {
                         pb.SetCustomAttribute(new CustomAttributeBuilder(
                             typeof(BytesConversionAttribute).GetConstructor(ReflectionUtils.EmptyTypes), ArrayUtils.EmptyObjects));
-                    } else if (pi.IsDefined(typeof(BytesConversionNoStringAttribute), false)) {
-                        pb.SetCustomAttribute(new CustomAttributeBuilder(
-                            typeof(BytesConversionNoStringAttribute).GetConstructor(ReflectionUtils.EmptyTypes), ArrayUtils.EmptyObjects));
                     }
 
                     if ((pi.Attributes & ParameterAttributes.HasDefault) != 0) {

--- a/Tests/test_struct.py
+++ b/Tests/test_struct.py
@@ -23,16 +23,6 @@ class StructTest(unittest.TestCase):
         self.assertSequenceEqual(result, b"\x00\x01\x00\x02")
 
     def test_unpack(self):
-        # test string/string combination
-        a,b = struct.unpack(">HH", "\x00\x01\x00\x02")
-        self.assertEqual(a, 1)
-        self.assertEqual(b, 2)
-
-        # test bytes/string combination
-        a,b = struct.unpack(b">HH", "\x00\x01\x00\x02")
-        self.assertEqual(a, 1)
-        self.assertEqual(b, 2)
-
         # test bytes/string combination
         a,b = struct.unpack(b">HH", b"\x00\x01\x00\x02")
         self.assertEqual(a, 1)


### PR DESCRIPTION
Removes the Python30 option (which was still defaulting to the 2.7 behavior) so that `BytesConversionAttribute` no longer converts strings to bytes. Also removes `str.decode` and fixes up encoding/decoding of codecs to produce/consume bytes properly.