### PR TITLE
Only use __lt__ in list.sort

### DIFF
--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -116,6 +116,7 @@ namespace IronPython.Runtime
         private Dictionary<Type, CallSite<Func<CallSite, object, object>>> _implicitConvertSites;
         private Dictionary<PythonOperationKind, CallSite<Func<CallSite, object, object, object>>> _binarySites;
         private Dictionary<Type, DefaultPythonComparer> _defaultComparer;
+        private Dictionary<Type, DefaultPythonLtComparer> _defaultLtComparer;
         private CallSite<Func<CallSite, CodeContext, object, object, object, int>> _sharedFunctionCompareSite;
         private CallSite<Func<CallSite, CodeContext, PythonFunction, object, object, int>> _sharedPythonFunctionCompareSite;
         private CallSite<Func<CallSite, CodeContext, BuiltinFunction, object, object, int>> _sharedBuiltinFunctionCompareSite;
@@ -3269,6 +3270,17 @@ namespace IronPython.Runtime
             }
         }
 
+        private class DefaultPythonLtComparer : IComparer {
+            private readonly CallSite<Func<CallSite, object, object, bool>> _lessThanSite;
+            public DefaultPythonLtComparer(PythonContext context) {
+                _lessThanSite = context.CreateComparisonSite(PythonOperationKind.LessThan);
+            }
+
+            public int Compare(object x, object y) {
+                return _lessThanSite.Target(_lessThanSite, x, y) ? -1 : 0;
+            }
+        }
+
         private class FunctionComparer<T> : IComparer {
             private T _cmpfunc;
             private CallSite<Func<CallSite, CodeContext, T, object, object, int>> _funcSite;
@@ -3353,6 +3365,28 @@ namespace IronPython.Runtime
 
             return new FunctionComparer<object>(this, cmp, _sharedFunctionCompareSite);
 
+        }
+
+        internal IComparer GetLtComparer(Type type) {
+            if (type == null) {
+                return new DefaultPythonLtComparer(this);
+            }
+
+            if (_defaultLtComparer == null) {
+                Interlocked.CompareExchange(
+                    ref _defaultLtComparer,
+                    new Dictionary<Type, DefaultPythonLtComparer>(),
+                    null
+                );
+            }
+
+            lock (_defaultLtComparer) {
+                DefaultPythonLtComparer comparer;
+                if (!_defaultLtComparer.TryGetValue(type, out comparer)) {
+                    _defaultLtComparer[type] = comparer = new DefaultPythonLtComparer(this);
+                }
+                return comparer;
+            }
         }
 
         internal CallSite<Func<CallSite, CodeContext, object, int, object>> GetItemCallSite {

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -879,9 +879,7 @@ namespace IronPython.Runtime {
                          bool reverse=false) {
             // the empty list is already sorted
             if (_size != 0) {                
-                IComparer comparer = context.LanguageContext.GetComparer(
-                    null,
-                    GetComparisonType());
+                IComparer comparer = context.LanguageContext.GetLtComparer(GetComparisonType());
 
                 DoSort(context, comparer, key, reverse, 0, _size);
             }
@@ -1046,8 +1044,8 @@ namespace IronPython.Runtime {
         private bool DoCompare(object[] keys, IComparer cmp, int p, int q, bool reverse) {
             Debug.Assert(_data.Length == 0);
 
-            int result = cmp.Compare(keys[p], keys[q]);
-            bool ret = reverse ? (result >= 0) : (result <= 0);
+            int result = reverse ? cmp.Compare(keys[p], keys[q]) : cmp.Compare(keys[q], keys[p]);
+            bool ret = !(result < 0);
 
             if (_data.Length != 0) throw PythonOps.ValueError("list mutated during sort");
             return ret;


### PR DESCRIPTION
Prep work to eliminate `__cmp__`.