### PR TITLE
Bypass surrogateescape in test.support

### DIFF
--- a/Src/StdLib/Lib/os.py
+++ b/Src/StdLib/Lib/os.py
@@ -706,8 +706,12 @@ def _createenviron():
         def encode(value):
             if not isinstance(value, str):
                 raise TypeError("str expected, not %s" % type(value).__name__)
+            if sys.implementation.name == "ironpython":
+                return value
             return value.encode(encoding, 'surrogateescape')
         def decode(value):
+            if sys.implementation.name == "ironpython":
+                return value
             return value.decode(encoding, 'surrogateescape')
         encodekey = encode
         data = environ

--- a/Src/StdLib/Lib/test/support/__init__.py
+++ b/Src/StdLib/Lib/test/support/__init__.py
@@ -826,8 +826,13 @@ elif sys.platform != 'darwin':
         b'\xff'.decode(TESTFN_ENCODING)
     except UnicodeDecodeError:
         # 0xff will be encoded using the surrogate character u+DCFF
-        TESTFN_UNENCODABLE = TESTFN \
-            + b'-\xff'.decode(TESTFN_ENCODING, 'surrogateescape')
+        try:
+            TESTFN_UNENCODABLE = TESTFN \
+                + b'-\xff'.decode(TESTFN_ENCODING, 'surrogateescape')
+        except LookupError:
+            pass
+        else:
+            raise Exception("Revert this workaround when https://github.com/IronLanguages/ironpython3/issues/2 is resolved")
     else:
         # File system encoding (eg. ISO-8859-* encodings) can encode
         # the byte 0xff. Skip some unicode filename tests.


### PR DESCRIPTION
Revert this when https://github.com/IronLanguages/ironpython3/issues/2 is implemented.