### PR TITLE
Make make.ps1 executable in a portable way

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/pwsh
+#!/usr/bin/env pwsh
 [CmdletBinding()]
 Param(
     [Parameter(Position=1)]


### PR DESCRIPTION
The location of `pwsh` is system-dependent. On my Ubuntu Linux, it is `/snap/bin/pwsh`; on my macOS it is `/usr/local/bin/pwsh`. However, the location of `env` is the same on all Unix-like systems.