### PR TITLE
Make PythonAsciiEncoding compliant with System.Text.Encoding protocol

### DIFF
--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1685,10 +1685,7 @@ namespace IronPython.Runtime.Operations {
                 case "strict": e.DecoderFallback = final ? DecoderFallback.ExceptionFallback : new ExceptionFallBack(numBytes, e is UTF8Encoding); break;
                 case "replace": e.DecoderFallback = ReplacementFallback; break;
                 case "ignore": e.DecoderFallback = new PythonDecoderFallback(); break;
-                case "surrogateescape":
-                    e = (e is PythonAsciiEncoding) ? // PythonAsciiEncoding insists on using its own fallbacks, downgrade to pure ASCII
-                        new PythonSurrogateEscapeEncoding(Encoding.ASCII) : new PythonSurrogateEscapeEncoding(e);
-                    break;
+                case "surrogateescape": e =  new PythonSurrogateEscapeEncoding(e); break;
                 default:
                     e.DecoderFallback = new PythonDecoderFallback(encoding, s,
                         () => LightExceptions.CheckAndThrow(PythonOps.LookupEncodingError(context, errors)));
@@ -1755,10 +1752,7 @@ namespace IronPython.Runtime.Operations {
                 case "backslashreplace": e.EncoderFallback = new BackslashEncoderReplaceFallback(); break;
                 case "xmlcharrefreplace": e.EncoderFallback = new XmlCharRefEncoderReplaceFallback(); break;
                 case "ignore": e.EncoderFallback = new PythonEncoderFallback(); break;
-                case "surrogateescape":
-                    e = (e is PythonAsciiEncoding) ? // PythonAsciiEncoding insists on using its own fallbacks, downgrade to pure ASCII
-                        new PythonSurrogateEscapeEncoding(Encoding.ASCII) : new PythonSurrogateEscapeEncoding(e);
-                    break;
+                case "surrogateescape": e = new PythonSurrogateEscapeEncoding(e); break;
                 default:
                     e.EncoderFallback = new PythonEncoderFallback(encoding, s,
                         () => LightExceptions.CheckAndThrow(PythonOps.LookupEncodingError(context, errors)));

--- a/Src/IronPython/Runtime/PythonAsciiEncoding.cs
+++ b/Src/IronPython/Runtime/PythonAsciiEncoding.cs
@@ -27,10 +27,10 @@ namespace IronPython.Runtime {
         }
 
         internal PythonAsciiEncoding(EncoderFallback encoderFallback, DecoderFallback decoderFallback)
-#if NETCOREAPP2_1
+#if !NET45
+            // base(0, encoderFallback, decoderFallback) publicly accessible only in .NET Framework 4.6 and up
             : base(0, encoderFallback, decoderFallback) {
 #else
-            // base(0, encoderFallback, decoderFallback) publicly accessible only in .NET Framework 4.6 and up
             : base() {
             // workaround for lack of proper base constructor access - implementation dependent
             typeof(Encoding).GetField("encoderFallback", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(this, encoderFallback);
@@ -38,7 +38,7 @@ namespace IronPython.Runtime {
 #endif
         }
 
-    internal static Encoding MakeNonThrowing() {
+        internal static Encoding MakeNonThrowing() {
             Encoding enc;
 #if FEATURE_ENCODING
             enc = new PythonAsciiEncoding(new NonStrictEncoderFallback(), new NonStrictDecoderFallback());

--- a/Src/IronPython/Runtime/PythonAsciiEncoding.cs
+++ b/Src/IronPython/Runtime/PythonAsciiEncoding.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Reflection;
 
 using IronPython.Runtime.Operations;
 
@@ -17,6 +18,7 @@ namespace IronPython.Runtime {
     /// </summary>
     [Serializable]
     sealed class PythonAsciiEncoding : Encoding {
+        // Singleton (global) instances are readonly, so their fallbacks cannot be accidentally modified unless cloned
         internal static readonly Encoding Instance = MakeNonThrowing();
         internal static readonly Encoding SourceEncoding = MakeSourceEncoding();
 
@@ -24,37 +26,54 @@ namespace IronPython.Runtime {
             : base() {
         }
 
-        internal static Encoding MakeNonThrowing() {
-            Encoding enc = new PythonAsciiEncoding();
+        internal PythonAsciiEncoding(EncoderFallback encoderFallback, DecoderFallback decoderFallback)
+#if NETCOREAPP2_1
+            : base(0, encoderFallback, decoderFallback) {
+#else
+            // base(0, encoderFallback, decoderFallback) publicly accessible only in .NET Framework 4.6 and up
+            : base() {
+            // workaround for lack of proper base constructor access - implementation dependent
+            typeof(Encoding).GetField("encoderFallback", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(this, encoderFallback);
+            typeof(Encoding).GetField("decoderFallback", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(this, decoderFallback);
+#endif
+        }
+
+    internal static Encoding MakeNonThrowing() {
+            Encoding enc;
 #if FEATURE_ENCODING
-            // we need to Clone the new instance here so that the base class marks us as non-readonly
-            enc = (Encoding)enc.Clone();
-            enc.DecoderFallback = new NonStrictDecoderFallback();
-            enc.EncoderFallback = new NonStrictEncoderFallback();
+            enc = new PythonAsciiEncoding(new NonStrictEncoderFallback(), new NonStrictDecoderFallback());
+#else
+            enc = new PythonAsciiEncoding();
 #endif
             return enc;
         }
 
         private static Encoding MakeSourceEncoding() {
-            Encoding enc = new PythonAsciiEncoding();
+            Encoding enc;
 #if FEATURE_ENCODING
-            // we need to Clone the new instance here so that the base class marks us as non-readonly
-            enc = (Encoding)enc.Clone();
-            enc.DecoderFallback = new SourceNonStrictDecoderFallback();
+            enc = new PythonAsciiEncoding(new NonStrictEncoderFallback(), new SourceNonStrictDecoderFallback());
+#else
+            enc = new PythonAsciiEncoding();
 #endif
             return enc;
         }
 
-        public override int GetByteCount(char[] chars, int index, int count) {
+        public override int GetByteCount(char[] chars, int index, int count)
+            => GetByteCount(chars, index, count, null);
+
+        private int GetByteCount(char[] chars, int index, int count, EncoderFallbackBuffer efb) {
 #if FEATURE_ENCODING
             int byteCount = 0;
             int charEnd = index + count;
             while (index < charEnd) {
                 char c = chars[index];
                 if (c > 0x7f) {
-                    EncoderFallbackBuffer efb = EncoderFallback.CreateFallbackBuffer();
+                    if (efb == null) {
+                        efb = EncoderFallback.CreateFallbackBuffer();
+                    }
                     if (efb.Fallback(c, index)) {
                         byteCount += efb.Remaining;
+                        while (efb.GetNextChar() != char.MinValue) { /* empty */ }
                     }
                 } else {
                     byteCount++;
@@ -67,14 +86,19 @@ namespace IronPython.Runtime {
 #endif
         }
 
-        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+            => GetBytes(chars, charIndex, charCount, bytes, byteIndex, null);
+
+        private int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, EncoderFallbackBuffer efb) {
             int charEnd = charIndex + charCount;
             int outputBytes = 0;
             while (charIndex < charEnd) {
                 char c = chars[charIndex];
 #if FEATURE_ENCODING
                 if (c > 0x7f) {
-                    EncoderFallbackBuffer efb = EncoderFallback.CreateFallbackBuffer();
+                    if (efb == null) {
+                        efb = EncoderFallback.CreateFallbackBuffer();
+                    }
                     if (efb.Fallback(c, charIndex)) {
                         while (efb.Remaining != 0) {
                             bytes[byteIndex++] = (byte)efb.GetNextChar();
@@ -94,17 +118,23 @@ namespace IronPython.Runtime {
             return outputBytes;
         }
 
-        public override int GetCharCount(byte[] bytes, int index, int count) {
+        public override int GetCharCount(byte[] bytes, int index, int count)
+            => GetCharCount(bytes, index, count, null);
+
+        private int GetCharCount(byte[] bytes, int index, int count, DecoderFallbackBuffer dfb) {
             int byteEnd = index + count;
             int outputChars = 0;
             while (index < byteEnd) {
                 byte b = bytes[index];
 #if FEATURE_ENCODING
                 if (b > 0x7f) {
-                    DecoderFallbackBuffer dfb = DecoderFallback.CreateFallbackBuffer();
+                    if (dfb == null) {
+                        dfb = DecoderFallback.CreateFallbackBuffer();
+                    }
                     try {
-                        if (dfb.Fallback(new[] { b }, 0)) {
+                        if (dfb.Fallback(new[] { b }, index)) {
                             outputChars += dfb.Remaining;
+                            while (dfb.GetNextChar() != char.MinValue) { /* empty */ }
                         }
                     } catch (DecoderFallbackException ex) {
                         var dfe = new DecoderFallbackException("ordinal out of range(128)", ex.BytesUnknown, ex.Index);
@@ -122,16 +152,21 @@ namespace IronPython.Runtime {
             return outputChars;
         }
 
-        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) {
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+            => GetChars(bytes, byteIndex, byteCount, chars, charIndex, null);
+
+        private int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, DecoderFallbackBuffer dfb) {
             int byteEnd = byteIndex + byteCount;
             int outputChars = 0;
             while (byteIndex < byteEnd) {
                 byte b = bytes[byteIndex];
 #if FEATURE_ENCODING
                 if (b > 0x7f) {
-                    DecoderFallbackBuffer dfb = DecoderFallback.CreateFallbackBuffer();
+                    if (dfb == null) {
+                        dfb = DecoderFallback.CreateFallbackBuffer();
+                    }
                     try {
-                        if (dfb.Fallback(new[] { b }, 0)) {
+                        if (dfb.Fallback(new[] { b }, byteIndex)) {
                             while (dfb.Remaining != 0) {
                                 chars[charIndex++] = dfb.GetNextChar();
                                 outputChars++;
@@ -156,11 +191,11 @@ namespace IronPython.Runtime {
         }
 
         public override int GetMaxByteCount(int charCount) {
-            return charCount * 4;
+            return charCount * Math.Max(1, EncoderFallback.MaxCharCount);
         }
 
         public override int GetMaxCharCount(int byteCount) {
-            return byteCount;
+            return byteCount * Math.Max(1, DecoderFallback.MaxCharCount);
         }
 
         public override string WebName {
@@ -174,6 +209,40 @@ namespace IronPython.Runtime {
             get {
                 return "ascii";
             }
+        }
+
+        public override Encoder GetEncoder() => new PythonAsciiEncoder(this);
+
+        private class PythonAsciiEncoder : Encoder {
+            private readonly PythonAsciiEncoding _encoding;
+
+            public PythonAsciiEncoder(PythonAsciiEncoding encoding) {
+                _encoding = encoding;
+                this.Fallback = encoding.EncoderFallback;
+            }
+
+            public override int GetByteCount(char[] chars, int index, int count, bool flush)
+                => _encoding.GetByteCount(chars, index, count, this.FallbackBuffer);
+
+            public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, bool flush)
+                => _encoding.GetBytes(chars, charIndex, charCount, bytes, byteIndex, this.FallbackBuffer);
+        }
+
+        public override Decoder GetDecoder() => new PythonAsciiDecoder(this);
+
+        private class PythonAsciiDecoder : Decoder {
+            private readonly PythonAsciiEncoding _encoding;
+
+            public PythonAsciiDecoder(PythonAsciiEncoding encoding) {
+                _encoding = encoding;
+                this.Fallback = encoding.DecoderFallback;
+            }
+
+            public override int GetCharCount(byte[] bytes, int index, int count)
+                => _encoding.GetCharCount(bytes, index, count, this.FallbackBuffer);
+
+            public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+                => _encoding.GetChars(bytes, byteIndex, byteCount, chars, charIndex, this.FallbackBuffer);
         }
 #endif
     }
@@ -191,7 +260,8 @@ namespace IronPython.Runtime {
 
     class NonStrictEncoderFallbackBuffer : EncoderFallbackBuffer {
         private List<char> _buffer = new List<char>();
-        private int _index;
+        private int _curIndex;
+        private int _prevIndex;
 
         public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index) {
             throw PythonOps.UnicodeEncodeError("'ascii' codec can't encode character '\\u{0:X}{1:04X}' in position {2}: ordinal not in range(128)", (int)charUnknownHigh, (int)charUnknownLow, index);
@@ -202,27 +272,33 @@ namespace IronPython.Runtime {
                 throw PythonOps.UnicodeEncodeError("ascii", charUnknown.ToString(), index, index + 1, "ordinal not in range(128)");
             }
 
+            if (_curIndex == _buffer.Count && _curIndex > 0) {
+                // save memory
+                _buffer.Clear();
+                _curIndex = 0;
+            }
+            _prevIndex = _curIndex;
             _buffer.Add(charUnknown);
             return true;
         }
         
         public override char GetNextChar() {
-            if (_index == _buffer.Count) {
+            if (_curIndex == _buffer.Count) {
                 return char.MinValue;
             }
-            return _buffer[_index++];
+            return _buffer[_curIndex++];
         }
 
         public override bool MovePrevious() {
-            if (_index > 0) {
-                _index--;
+            if (_curIndex > _prevIndex) {
+                _curIndex--;
                 return true;
             }
             return false;
         }
 
         public override int Remaining {
-            get { return _buffer.Count - _index; }
+            get { return _buffer.Count - _curIndex; }
         }
     }
 
@@ -239,30 +315,37 @@ namespace IronPython.Runtime {
     // no ctors on DecoderFallbackBuffer in Silverlight
     class NonStrictDecoderFallbackBuffer : DecoderFallbackBuffer {
         private List<byte> _bytes = new List<byte>();
-        private int _index;
+        private int _curIndex;
+        private int _prevIndex;
 
         public override bool Fallback(byte[] bytesUnknown, int index) {
+            if (_curIndex == _bytes.Count && _curIndex > 0) {
+                // save memory
+                _bytes.Clear();
+                _curIndex = 0;
+            }
+            _prevIndex = _curIndex;
             _bytes.AddRange(bytesUnknown);
             return true;
         }
 
         public override char GetNextChar() {
-            if (_index == _bytes.Count) {
+            if (_curIndex == _bytes.Count) {
                 return char.MinValue;
             }
-            return (char)_bytes[_index++];
+            return (char)_bytes[_curIndex++];
         }
 
         public override bool MovePrevious() {
-            if (_index > 0) {
-                _index--;
+            if (_curIndex > _prevIndex) {
+                _curIndex--;
                 return true;
             }
             return false;
         }
 
         public override int Remaining {
-            get { return _bytes.Count - _index; }
+            get { return _bytes.Count - _curIndex; }
         }
     }
     

--- a/Src/IronPython/Runtime/PythonEncoding.cs
+++ b/Src/IronPython/Runtime/PythonEncoding.cs
@@ -168,7 +168,7 @@ namespace IronPython.Runtime {
                 int written = _pass1encoder.GetBytes(chars, charIndex, charCount, bytes, byteIndex, flush);
 
                 // If there were no fallback bytes, the job is done
-                if (fbuf1?.FallbackByteCount == fbkIdxStart && (fbuf2?.IsEmpty ?? true) && flush) {
+                if (fbuf1 == null || fbuf1.FallbackByteCount == fbkIdxStart && (fbuf2?.IsEmpty ?? true) && flush) {
                     return written;
                 }
 
@@ -328,7 +328,7 @@ namespace IronPython.Runtime {
                 int written = _pass1decoder.GetChars(bytes, byteIndex, byteCount, chars, charIndex, flush);
 
                 // If there were no lone surrogates, the job is done
-                if (fbuf1?.FallbackCharCount == surIdxStart && (fbuf2?.IsEmpty ?? true) && flush) {
+                if (fbuf1 == null || fbuf1.FallbackCharCount == surIdxStart && (fbuf2?.IsEmpty ?? true) && flush) {
                     return written;
                 }
 

--- a/Src/IronPythonTest/EncodingTest.cs
+++ b/Src/IronPythonTest/EncodingTest.cs
@@ -26,6 +26,7 @@ namespace IronPythonTest {
             }
 
             [Test] public void Test256WithAscii() => TestRoundTrip(Encoding.ASCII, _bytes);
+            [Test] public void Test256WithPythonAscii() => TestRoundTrip(PythonAsciiEncoding.Instance, _bytes);
             [Test] public void Test256WithUtf8() => TestRoundTrip(Encoding.UTF8, _bytes);
             [Test] public void Test256WithDefault() => TestRoundTrip(Encoding.Default, _bytes);
             [Test] public void Test256WithUnicode() => TestRoundTrip(Encoding.Unicode, _bytes);
@@ -46,6 +47,7 @@ namespace IronPythonTest {
             }
 
             [Test] public void TestValidUtf8WithAscii() => TestRoundTrip(Encoding.ASCII, _bytes);
+            [Test] public void TestValidUtf8WithPythonAscii() => TestRoundTrip(PythonAsciiEncoding.Instance, _bytes);
             [Test] public void TestValidUtf8WithUtf8() => TestRoundTrip(Encoding.UTF8, _bytes);
             [Test] public void TestValidUtf8WithDefault() => TestRoundTrip(Encoding.Default, _bytes);
             [Test] public void TestValidUtf8WithUnicode() => TestRoundTrip(Encoding.Unicode, _bytes);
@@ -68,6 +70,7 @@ namespace IronPythonTest {
             }
 
             [Test] public void TestBrokenUtf8WithAscii() => TestRoundTrip(Encoding.ASCII, _bytes);
+            [Test] public void TestBrokenUtf8WithPythonAscii() => TestRoundTrip(PythonAsciiEncoding.Instance, _bytes);
             [Test] public void TestBrokenUtf8WithUtf8() => TestRoundTrip(Encoding.UTF8, _bytes);
             [Test] public void TestBrokenUtf8WithDefault() => TestRoundTrip(Encoding.Default, _bytes);
             [Test] public void TestBrokenUtf8WithUnicode() => TestRoundTrip(Encoding.Unicode, _bytes);
@@ -110,6 +113,15 @@ namespace IronPythonTest {
             [Test]
             public void TestCompare256WithAscii() {
                 Encoding penc = new PythonSurrogateEscapeEncoding(Encoding.ASCII);
+                char[] chars = penc.GetChars(bytes);
+                string python_chars = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\udc80\udc81\udc82\udc83\udc84\udc85\udc86\udc87\udc88\udc89\udc8a\udc8b\udc8c\udc8d\udc8e\udc8f\udc90\udc91\udc92\udc93\udc94\udc95\udc96\udc97\udc98\udc99\udc9a\udc9b\udc9c\udc9d\udc9e\udc9f\udca0\udca1\udca2\udca3\udca4\udca5\udca6\udca7\udca8\udca9\udcaa\udcab\udcac\udcad\udcae\udcaf\udcb0\udcb1\udcb2\udcb3\udcb4\udcb5\udcb6\udcb7\udcb8\udcb9\udcba\udcbb\udcbc\udcbd\udcbe\udcbf\udcc0\udcc1\udcc2\udcc3\udcc4\udcc5\udcc6\udcc7\udcc8\udcc9\udcca\udccb\udccc\udccd\udcce\udccf\udcd0\udcd1\udcd2\udcd3\udcd4\udcd5\udcd6\udcd7\udcd8\udcd9\udcda\udcdb\udcdc\udcdd\udcde\udcdf\udce0\udce1\udce2\udce3\udce4\udce5\udce6\udce7\udce8\udce9\udcea\udceb\udcec\udced\udcee\udcef\udcf0\udcf1\udcf2\udcf3\udcf4\udcf5\udcf6\udcf7\udcf8\udcf9\udcfa\udcfb\udcfc\udcfd\udcfe\udcff";
+                Assert.AreEqual(python_chars, chars);
+            }
+
+
+            [Test]
+            public void TestCompare256WithPythonAscii() {
+                Encoding penc = new PythonSurrogateEscapeEncoding(PythonAsciiEncoding.Instance);
                 char[] chars = penc.GetChars(bytes);
                 string python_chars = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\udc80\udc81\udc82\udc83\udc84\udc85\udc86\udc87\udc88\udc89\udc8a\udc8b\udc8c\udc8d\udc8e\udc8f\udc90\udc91\udc92\udc93\udc94\udc95\udc96\udc97\udc98\udc99\udc9a\udc9b\udc9c\udc9d\udc9e\udc9f\udca0\udca1\udca2\udca3\udca4\udca5\udca6\udca7\udca8\udca9\udcaa\udcab\udcac\udcad\udcae\udcaf\udcb0\udcb1\udcb2\udcb3\udcb4\udcb5\udcb6\udcb7\udcb8\udcb9\udcba\udcbb\udcbc\udcbd\udcbe\udcbf\udcc0\udcc1\udcc2\udcc3\udcc4\udcc5\udcc6\udcc7\udcc8\udcc9\udcca\udccb\udccc\udccd\udcce\udccf\udcd0\udcd1\udcd2\udcd3\udcd4\udcd5\udcd6\udcd7\udcd8\udcd9\udcda\udcdb\udcdc\udcdd\udcde\udcdf\udce0\udce1\udce2\udce3\udce4\udce5\udce6\udce7\udce8\udce9\udcea\udceb\udcec\udced\udcee\udcef\udcf0\udcf1\udcf2\udcf3\udcf4\udcf5\udcf6\udcf7\udcf8\udcf9\udcfa\udcfb\udcfc\udcfd\udcfe\udcff";
                 Assert.AreEqual(python_chars, chars);
@@ -261,6 +273,22 @@ namespace IronPythonTest {
             public void SetUp() {
                 // In UTF-16LE: Lone high surrogate (invalid), surrogate pair: high-low (valid), lone low surrogate (invalid)
                 _bytes = new byte[] { 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf };
+            }
+
+            [Test]
+            public void TestBlockWiseWithtAscii() {
+                // intersperse with ASCII letters
+                _bytes = _bytes.SelectMany((b, i) => new[] { (byte)('A' + i), b }).Concat(new[] { (byte)'Z' }).ToArray();
+                Encoding penc = new PythonSurrogateEscapeEncoding(Encoding.ASCII);
+                BlockWiseTest(penc);
+            }
+
+            [Test]
+            public void TestBlockWiseWithtPythonAscii() {
+                // intersperse with ASCII letters
+                _bytes = _bytes.SelectMany((b, i) => new[] { (byte)('A' + i), b }).Concat(new[] { (byte)'Z' }).ToArray();
+                Encoding penc = new PythonSurrogateEscapeEncoding(PythonAsciiEncoding.Instance);
+                BlockWiseTest(penc);
             }
 
             [Test]


### PR DESCRIPTION
This is primarily to enable `PythonAsciiEncoding` to work with the `PythonEncoding` family (`PythonSurrogateEscapeEncoding`, `PythonSurrogatePassEncoding`, and future user-registered encoding error handlers).

The old `PythonAsciiEncoding` was assuming that all fallbacks were stateless. With this change, the workaround for `surrogateescape` to downgrade `PythonAsciiEncoding` to .NET `Encoding.ASCII` is not necessary anymore.

Also, some tests are added to test workings of `PythonAsciiEncoding` with `PythonSurrogateEscapeEncoding`.