### PR TITLE
Correct NuGet API URL

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,7 @@
     <add key="globalPackagesFolder" value="./packages" />
   </config>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="nunit.myget.org" value="https://www.myget.org/F/nunit/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
I have finally got the build working on my macOS, but it required a change in the NuGet API URL. The old URL points to a non-existent resource and I don't know how the build could have been working on Linux, CI, or on macOS for other people. Perhaps some clever rewriting rules that I don't have. Anyway, the correct URL for the packages index can be easily verified in a web browser.