### PR TITLE
Get test_hash passing

### DIFF
--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -197,7 +197,9 @@ namespace IronPython.Runtime {
             }
         }
 
-        public const object __hash__ = null;
+        public int __hash__(CodeContext context) {
+            return tobytes().GetHashCode();
+        }
 
         public bool __eq__(CodeContext/*!*/ context, [NotNull]MemoryView value) => tobytes().Equals(value.tobytes());
 

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -198,12 +198,12 @@ namespace IronPython.Runtime {
         }
 
         public int __hash__(CodeContext context) {
-            if (format != "B" && format != "b" && format != "c") {
-                throw PythonOps.ValueError("memoryview: hashing is restricted to formats 'B', 'b' or 'c'");
-            }
-
             if (!@readonly) {
                 throw PythonOps.ValueError("cannot hash writable memoryview object");
+            }
+
+            if (format != "B" && format != "b" && format != "c") {
+                throw PythonOps.ValueError("memoryview: hashing is restricted to formats 'B', 'b' or 'c'");
             }
 
             return tobytes().GetHashCode();

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -198,11 +198,15 @@ namespace IronPython.Runtime {
         }
 
         public int __hash__(CodeContext context) {
-            if (format == "B" || format == "b" || format == "c") {
-                return tobytes().GetHashCode();
+            if (format != "B" && format != "b" && format != "c") {
+                throw PythonOps.ValueError("memoryview: hashing is restricted to formats 'B', 'b' or 'c'");
             }
 
-            throw PythonOps.ValueError("memoryview: hashing is restricted to formats 'B', 'b' or 'c'");
+            if (!@readonly) {
+                throw PythonOps.ValueError("cannot hash writable memoryview object");
+            }
+
+            return tobytes().GetHashCode();
         }
 
         public bool __eq__(CodeContext/*!*/ context, [NotNull]MemoryView value) => tobytes().Equals(value.tobytes());

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -198,7 +198,11 @@ namespace IronPython.Runtime {
         }
 
         public int __hash__(CodeContext context) {
-            return tobytes().GetHashCode();
+            if (format == "B" || format == "b" || format == "c") {
+                return tobytes().GetHashCode();
+            }
+
+            throw PythonOps.ValueError("memoryview: hashing is restricted to formats 'B', 'b' or 'c'");
         }
 
         public bool __eq__(CodeContext/*!*/ context, [NotNull]MemoryView value) => tobytes().Equals(value.tobytes());

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -1314,6 +1314,8 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             } else if (name == "__init__") {
                 _objectInit = null;
                 ClearObjectInitInSubclasses(this);
+            } else if (name == "__eq__" && !_dict.ContainsKey("__hash__")) {
+                AddSlot("__hash__", ToTypeSlot(null));
             }
         }
 

--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -401,9 +401,6 @@ Reason=Only valid for Unix
 [AllCPython.test_gzip]
 Ignore=true
 
-[AllCPython.test_hash]
-Ignore=true
-
 [AllCPython.test_hashlib]
 Ignore=true
 

--- a/Tests/test_dict.py
+++ b/Tests/test_dict.py
@@ -1117,6 +1117,8 @@ class DictTest(IronPythonTestCase):
                     return False
             def __ne__(self, other):
                     return True
+            def __hash__(self):
+                    return 0
 
         a = x()
         d = {}

--- a/Tests/test_hash.py
+++ b/Tests/test_hash.py
@@ -1,0 +1,28 @@
+import unittest
+
+from iptest import IronPythonTestCase, is_cli, path_modifier, run_test
+
+class HashTest(IronPythonTestCase):
+    def test_hash_before_eq(self):
+        class HashBeforeEq:
+            def __hash__(self):
+                return 1
+            def __eq__(self, other):
+                return self is other
+
+        x = HashBeforeEq()
+        self.assertNotEquals(x.__hash__, None)
+        self.assertEquals(hash(x), 1)
+
+    def test_eq_before_hash(self):
+        class EqBeforeHash:
+            def __eq__(self, other):
+                return self is other
+            def __hash__(self):
+                return 1
+
+        x = EqBeforeHash()
+        self.assertNotEquals(x.__hash__, None)
+        self.assertEquals(hash(x), 1)
+
+run_test(__name__)

--- a/Tests/test_hash.py
+++ b/Tests/test_hash.py
@@ -1,4 +1,5 @@
 import unittest
+import array
 
 from iptest import IronPythonTestCase, is_cli, path_modifier, run_test
 
@@ -24,5 +25,9 @@ class HashTest(IronPythonTestCase):
         x = EqBeforeHash()
         self.assertNotEquals(x.__hash__, None)
         self.assertEquals(hash(x), 1)
+
+    def test_hash_writable_memoryviews(self):
+        buffer = array.array('b', [1,2,3])
+        self.assertRaises(ValueError, hash, memoryview(buffer))
 
 run_test(__name__)


### PR DESCRIPTION
It looks like test_hash is just missing a few small changes. The first is that `__hash__` is not inherited when `__eq__` is implemented as of Python 3. The second is that the memoryview type was made hashable if the underlying type is bytes and the buffer is readonly (otherwise throws a ValueError). This is new in Python 3.3.

I couldn't figure out how to create a readonly int buffer without making a memoryview over bytes and then casting it, which isn't yet implemented.

I don't have any checks for the dimensionality of the memoryview because it seems like CPython allows hashing of reshaped memory (this is Python 3.6.6):
```
>>> x = memoryview(bytes(b'abcd'))
>>> x.format
'B'
>>> x.cast('B', shape=[2,2])
<memory at 0x000001CCD9687B40>
>>> y = x.cast('B', shape=[2,2])
>>> y.format
'B'
>>> y.shape
(2, 2)
>>> hash(x)
-6735250001301804499
>>> hash(y)
-6735250001301804499
```