### PR TITLE
Add 'surrogatepass' codec error handler

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3632,8 +3632,6 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static Exception UnicodeEncodeError(string encoding, char charUnknown, int index, string format, params object[] args) {
-            var ctor = typeof (EncoderFallbackException).GetConstructor(
-                BindingFlags.NonPublic | BindingFlags.Instance, null, new [] { typeof(string), typeof(char), typeof(int) } , null);
             var ex = (EncoderFallbackException)UnicodeEncodeError(string.Format(format, args), charUnknown, index);
             ex.Data["encoding"] = encoding;
             return ex;

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3631,12 +3631,18 @@ namespace IronPython.Runtime.Operations {
             return PythonExceptions.CreateThrowable(PythonExceptions.UnicodeEncodeError, encoding, @object, start, end, reason);
         }
 
-        public static Exception UnicodeEncodeError(string encoding, char charUnkown, int index, string format, params object[] args) {
+        public static Exception UnicodeEncodeError(string encoding, char charUnknown, int index, string format, params object[] args) {
             var ctor = typeof (EncoderFallbackException).GetConstructor(
                 BindingFlags.NonPublic | BindingFlags.Instance, null, new [] { typeof(string), typeof(char), typeof(int) } , null);
-            var ex = (EncoderFallbackException)ctor.Invoke(new object[] { string.Format(format, args), charUnkown, index });
+            var ex = (EncoderFallbackException)UnicodeEncodeError(string.Format(format, args), charUnknown, index);
             ex.Data["encoding"] = encoding;
             return ex;
+        }
+
+        public static Exception UnicodeEncodeError(string message, char charUnknown, int index) {
+            var ctor = typeof(EncoderFallbackException).GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(string), typeof(char), typeof(int) }, null);
+            return (EncoderFallbackException)ctor.Invoke(new object[] { message, charUnknown, index });
         }
 
         public static Exception IOError(Exception inner) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1686,6 +1686,7 @@ namespace IronPython.Runtime.Operations {
                 case "replace": e.DecoderFallback = ReplacementFallback; break;
                 case "ignore": e.DecoderFallback = new PythonDecoderFallback(); break;
                 case "surrogateescape": e =  new PythonSurrogateEscapeEncoding(e); break;
+                case "surrogatepass": e =  new PythonSurrogatePassEncoding(e); break;
                 default:
                     e.DecoderFallback = new PythonDecoderFallback(encoding, s,
                         () => LightExceptions.CheckAndThrow(PythonOps.LookupEncodingError(context, errors)));
@@ -1753,6 +1754,7 @@ namespace IronPython.Runtime.Operations {
                 case "xmlcharrefreplace": e.EncoderFallback = new XmlCharRefEncoderReplaceFallback(); break;
                 case "ignore": e.EncoderFallback = new PythonEncoderFallback(); break;
                 case "surrogateescape": e = new PythonSurrogateEscapeEncoding(e); break;
+                case "surrogatepass": e = new PythonSurrogatePassEncoding(e); break;
                 default:
                     e.EncoderFallback = new PythonEncoderFallback(encoding, s,
                         () => LightExceptions.CheckAndThrow(PythonOps.LookupEncodingError(context, errors)));

--- a/Src/IronPython/Runtime/PythonEncoding.cs
+++ b/Src/IronPython/Runtime/PythonEncoding.cs
@@ -455,7 +455,7 @@ namespace IronPython.Runtime {
             public abstract char[] GetFallbackChars(byte[] bytesUnknown, int index);
 
             public override bool Fallback(byte[] bytesUnknown, int index) {
-                if (PythonEncoding.HasBugCorefx29898 && this.CharCountingMode && this.CodePage == 65001) { // only for UTF-8
+                if (this.CharCountingMode && this.CodePage == 65001 && PythonEncoding.HasBugCorefx29898) { // only for UTF-8
                     index += bytesUnknown.Length;
                 }
                 char[] newFallbackChars = GetFallbackChars(bytesUnknown, index);

--- a/Tests/test_surrogatepass.py
+++ b/Tests/test_surrogatepass.py
@@ -1,0 +1,79 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+##
+## Test surrogatepass encoding error handler
+##
+
+import unittest
+import codecs
+
+from iptest import run_test
+
+class SurrogatePassTest(unittest.TestCase):
+    def test_ascii(self):
+        self.assertEqual("abc".encode("ascii", errors="surrogatepass"), b"abc")
+        self.assertEqual(b"abc".decode("ascii", errors="surrogatepass"), "abc")
+
+    def test_utf_7(self):
+        self.assertEqual("abc\ud810xyz".encode("utf_7", errors="surrogatepass"), b"abc+2BA-xyz")
+        self.assertEqual(b"abc+2BA-xyz".decode("utf_7", errors="surrogatepass"), "abc\ud810xyz")
+
+    def test_utf_8(self):
+        self.assertEqual("abc\ud810xyz".encode("utf_8", errors="surrogatepass"), b"abc\xed\xa0\x90xyz")
+        self.assertEqual(b"abc\xed\xa0\x90xyz".decode("utf_8", errors="surrogatepass"), "abc\ud810xyz")
+
+    def test_utf_16_le(self):
+        # lone high surrogate
+        self.assertEqual("\ud810".encode("utf_16_le", errors="surrogatepass"), b"\x10\xd8")
+        self.assertEqual(b"\x10\xd8".decode("utf_16_le", errors="surrogatepass"), "\ud810")
+
+        #lone low surrogate
+        self.assertEqual("\udc0a".encode("utf_16_le", errors="surrogatepass"), b"\n\xdc")
+        self.assertEqual(b"\n\xdc".decode("utf_16_le", errors="surrogatepass"), "\udc0a")
+        
+        # invalid surrogate pair (low, high)
+        self.assertEqual("\ude51\uda2f".encode("utf_16_le", errors="surrogatepass"), b"Q\xde/\xda")
+        self.assertEqual(b"Q\xde/\xda".decode("utf_16_le", errors="surrogatepass"), "\ude51\uda2f")
+        
+    def test_utf_16_be(self):
+        # lone high surrogate
+        self.assertEqual("\ud810".encode("utf_16_be", errors="surrogatepass"), b"\xd8\x10")
+        self.assertEqual(b"\xd8\x10".decode("utf_16_be", errors="surrogatepass"), "\ud810")
+
+        #lone low surrogate
+        self.assertEqual("\udc0a".encode("utf_16_be", errors="surrogatepass"), b"\xdc\n")
+        self.assertEqual(b"\xdc\n".decode("utf_16_be", errors="surrogatepass"), "\udc0a")
+        
+        # invalid surrogate pair (low, high)
+        self.assertEqual("\ude51\uda2f".encode("utf_16_be", errors="surrogatepass"), b"\xdeQ\xda/")
+        self.assertEqual(b"\xdeQ\xda/".decode("utf_16_be", errors="surrogatepass"), "\ude51\uda2f")
+
+    def test_utf_32_le(self):
+        # lone high surrogate
+        self.assertEqual("\ud810".encode("utf_32_le", errors="surrogatepass"), b"\x10\xd8\x00\x00")
+        self.assertEqual(b"\x10\xd8\x00\x00".decode("utf_32_le", errors="surrogatepass"), "\ud810")
+
+        #lone low surrogate
+        self.assertEqual("\udc0a".encode("utf_32_le", errors="surrogatepass"), b"\n\xdc\x00\x00")
+        self.assertEqual(b"\n\xdc\x00\x00".decode("utf_32_le", errors="surrogatepass"), "\udc0a")
+        
+        # invalid surrogate pair (low, high)
+        self.assertEqual("\ude51\uda2f".encode("utf_32_le", errors="surrogatepass"), b"Q\xde\x00\x00/\xda\x00\x00")
+        self.assertEqual(b"Q\xde\x00\x00/\xda\x00\x00".decode("utf_32_le", errors="surrogatepass"), "\ude51\uda2f")
+        
+    def test_utf_32_be(self):
+        # lone high surrogate
+        self.assertEqual("\ud810".encode("utf_32_be", errors="surrogatepass"), b"\x00\x00\xd8\x10")
+        self.assertEqual(b"\x00\x00\xd8\x10".decode("utf_32_be", errors="surrogatepass"), "\ud810")
+
+        #lone low surrogate
+        self.assertEqual("\udc0a".encode("utf_32_be", errors="surrogatepass"), b"\x00\x00\xdc\n")
+        self.assertEqual(b"\x00\x00\xdc\n".decode("utf_32_be", errors="surrogatepass"), "\udc0a")
+        
+        # invalid surrogate pair (low, high)
+        self.assertEqual("\ude51\uda2f".encode("utf_32_be", errors="surrogatepass"), b"\x00\x00\xdeQ\x00\x00\xda/")
+        self.assertEqual(b"\x00\x00\xdeQ\x00\x00\xda/".decode("utf_32_be", errors="surrogatepass"), "\ude51\uda2f")
+
+run_test(__name__)


### PR DESCRIPTION
To perform _surrogatepass_ during decoding, the correct value of `index` of the fallback buffer is essential. Therefore I have added a workaround for the dotnet/corefx#29898 bug. The bug should be resolved in .NET Core 3.0 (and presumably Mono 5.18), but there are still some other frameworks around with it that we want to support. 