### PR TITLE
Interop with System.Text.Encoding, DecoderFallbackException and EncoderFallbackException

### DIFF
--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -14,6 +14,7 @@ using Microsoft.Scripting.Utils;
 
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
+using System.Text;
 
 namespace IronPython.Runtime {
     /// <summary>
@@ -263,6 +264,12 @@ namespace IronPython.Runtime {
         public string decode(CodeContext/*!*/ context, [NotNull]string encoding = "utf-8", [NotNull]string errors = "strict") {
             lock (this) {
                 return StringOps.RawDecode(context, _bytes, encoding, errors);
+            }
+        }
+
+        public string decode(CodeContext/*!*/ context, [NotNull]Encoding encoding, [NotNull]string errors = "strict") {
+            lock (this) {
+                return StringOps.DoDecode(context, _bytes, errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
             }
         }
 

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -8,13 +8,13 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
-using System.Text;
 
 namespace IronPython.Runtime {
     /// <summary>

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -10,16 +10,16 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
-using System.Text;
 
 namespace IronPython.Runtime {
-    [PythonType("bytes")]
+    [PythonType("bytes"), Serializable]
     public class Bytes : IList<byte>, IEquatable<Bytes>, ICodeFormattable, IExpressionSerializable, IBufferProtocol {
         internal byte[]/*!*/ _bytes;
         internal static Bytes/*!*/ Empty = new Bytes();

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -16,6 +16,7 @@ using Microsoft.Scripting.Utils;
 
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
+using System.Text;
 
 namespace IronPython.Runtime {
     [PythonType("bytes")]
@@ -136,6 +137,10 @@ namespace IronPython.Runtime {
 
         public string decode(CodeContext/*!*/ context, [NotNull]string encoding = "utf-8", [NotNull]string errors = "strict") {
             return StringOps.RawDecode(context, _bytes, encoding, errors);
+        }
+
+        public string decode(CodeContext/*!*/ context, [NotNull]Encoding encoding, [NotNull]string errors = "strict") {
+            return StringOps.DoDecode(context, _bytes, errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
         }
 
         public bool endswith([BytesConversion]IList<byte>/*!*/ suffix) {

--- a/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
+++ b/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Linq.Expressions;
 
 #if !FEATURE_REMOTING
@@ -829,26 +830,50 @@ for k, v in toError.items():
             [PythonHidden]
             protected internal override void InitializeFromClr(System.Exception/*!*/ exception) {
                 if (exception is DecoderFallbackException ex) {
-                    StringBuilder sb = new StringBuilder();
-                    if (ex.BytesUnknown != null) {
-                        for (int i = 0; i < ex.BytesUnknown.Length; i++) {
-                            sb.Append((char)ex.BytesUnknown[i]);
-                        }
+                    object inputData = ex.BytesUnknown;
+                    int startIdx = 0;
+                    int endIdx = ex.BytesUnknown?.Length ?? 0;
+                    if (ex.Data.Contains("object") && ex.Data["object"] is IList<byte> s) {
+                        inputData = s;
+                        startIdx = ex.Index;
+                        endIdx += startIdx;
                     }
-                    __init__(ex.Data.Contains("encoding") ? ex.Data["encoding"] : "unknown", sb.ToString(), ex.Index, ex.Index + sb.Length, ex.Message);
+                    __init__(ex.Data.Contains("encoding") ? ex.Data["encoding"] : "unknown", inputData, startIdx, endIdx, ex.Message);
                 } else {
                     base.InitializeFromClr(exception);
                 }
             }
 
             public override string ToString() {
-                if (@object is Bytes s) {
-                    if (s.Count == 1) {
-                        return $"'{encoding}' codec can't decode byte 0x{(byte)s[0]:x2} in position {start}: {reason}";
+                if (@object is IList<byte> s && start is int startIdx && end is int endIdx) {
+                    if (0 <= startIdx && startIdx < endIdx && endIdx <= s.Count) {
+                        int numBytes = endIdx - startIdx;
+                        if (numBytes == 1) {
+                            return $"'{encoding}' codec can't decode byte 0x{s[startIdx]:x2} in position {startIdx}: {reason}";
+                        } else {
+                            // Create a string representation of our bytes.
+                            const int maxNumBytes = 20;
+
+                            StringBuilder strBytes = new StringBuilder(3 + Math.Min(numBytes, maxNumBytes + 1) * 4);
+
+                            strBytes.Append("b'");
+                            int i;
+                            for (i = startIdx; i < endIdx && i < s.Count && i < maxNumBytes; i++) {
+                                strBytes.Append("\\x");
+                                strBytes.Append(s[i].ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+                            }
+                            strBytes.Append("'");
+
+                            // In case the string's really long...
+                            if (i < endIdx) strBytes.Append("...");
+
+                            return $"'{encoding}' codec can't decode bytes {strBytes} in position {startIdx}-{endIdx - 1}: {reason}";
+                        }
+                    } else {
+                        return $"'{encoding}' codec can't decode bytes in position {startIdx}-{endIdx - 1}: {reason}";
                     }
-                    return $"'{encoding}' codec can't decode bytes in position {start}-{end}: {reason}";
                 }
-                return reason.ToString();
+                return reason?.ToString() ?? GetType().Name;
             }
         }
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3353,7 +3353,7 @@ namespace IronPython.Runtime.Operations {
                 if (s[i] < 0x100) {
                     ret[i] = (byte)s[i];
                 } else {
-                    throw PythonOps.UnicodeEncodeError("ascii", s[i].ToString(), i, i + 1, "ordinal not in range(128)");
+                    throw PythonOps.UnicodeEncodeError("ascii", s, i, i + 1, "ordinal not in range(128)");
                 }
             }
             return ret;

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3353,7 +3353,7 @@ namespace IronPython.Runtime.Operations {
                 if (s[i] < 0x100) {
                     ret[i] = (byte)s[i];
                 } else {
-                    throw PythonOps.UnicodeEncodeError("ascii", s, i, i + 1, "ordinal not in range(128)");
+                    throw PythonOps.UnicodeEncodeError("latin-1", s, i, i + 1, "ordinal not in range(256)");
                 }
             }
             return ret;
@@ -3619,32 +3619,25 @@ namespace IronPython.Runtime.Operations {
             return new KeyNotFoundException(string.Format(format, args));
         }
 
-        public static Exception UnicodeDecodeError(string format, params object[] args) {
-            return new System.Text.DecoderFallbackException(string.Format(format, args));
-        }
-
         public static Exception UnicodeDecodeError(string message, byte[] bytesUnknown, int index) {
-            return new System.Text.DecoderFallbackException(message, bytesUnknown, index);
-        }
-
-        public static Exception UnicodeEncodeError(string format, params object[] args) {
-            return new EncoderFallbackException(string.Format(format, args));
+            return new DecoderFallbackException(message, bytesUnknown, index);
         }
 
         public static Exception UnicodeEncodeError(string encoding, string @object, int start, int end, string reason) {
             return PythonExceptions.CreateThrowable(PythonExceptions.UnicodeEncodeError, encoding, @object, start, end, reason);
         }
 
-        public static Exception UnicodeEncodeError(string encoding, char charUnknown, int index, string format, params object[] args) {
-            var ex = (EncoderFallbackException)UnicodeEncodeError(string.Format(format, args), charUnknown, index);
-            ex.Data["encoding"] = encoding;
-            return ex;
-        }
-
+        // access to possibly internal constructors of EncoderFallbackException
         public static Exception UnicodeEncodeError(string message, char charUnknown, int index) {
             var ctor = typeof(EncoderFallbackException).GetConstructor(
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(string), typeof(char), typeof(int) }, null);
             return (EncoderFallbackException)ctor.Invoke(new object[] { message, charUnknown, index });
+        }
+
+        public static Exception UnicodeEncodeError(string message, char charUnknownHigh, char charUnknownLow, int index) {
+            var ctor = typeof(EncoderFallbackException).GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(string), typeof(char), typeof(char), typeof(int) }, null);
+            return (EncoderFallbackException)ctor.Invoke(new object[] { message, charUnknownHigh, charUnknownLow, index });
         }
 
         public static Exception IOError(Exception inner) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -133,8 +133,8 @@ namespace IronPython.Runtime.Operations {
         }
 
         public virtual bool __contains__(object value) {
-            if (value is string) return Value.Contains((string)value);
-            else if (value is ExtensibleString) return Value.Contains(((ExtensibleString)value).Value);
+            if (value is ExtensibleString es) return Value.Contains(es.Value);
+            if (value is string s) return Value.Contains((string)value);
 
             throw PythonOps.TypeErrorForBadInstance("expected string, got {0}", value);
         }
@@ -1416,6 +1416,10 @@ namespace IronPython.Runtime.Operations {
 
         public static Extensible<string> __str__(ExtensibleString self) {
             return self;
+        }
+
+        public static string/*!*/ __repr__(string/*!*/ self) {
+            return StringOps.Quote(self);
         }
 
         #region Internal implementation details
@@ -2779,9 +2783,5 @@ namespace IronPython.Runtime.Operations {
 #endif
 
         #endregion
-
-        public static string/*!*/ __repr__(string/*!*/ self) {
-            return StringOps.Quote(self);
-        }
     }
 }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -134,7 +134,7 @@ namespace IronPython.Runtime.Operations {
 
         public virtual bool __contains__(object value) {
             if (value is ExtensibleString es) return Value.Contains(es.Value);
-            if (value is string s) return Value.Contains((string)value);
+            if (value is string s) return Value.Contains(s);
 
             throw PythonOps.TypeErrorForBadInstance("expected string, got {0}", value);
         }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1801,6 +1801,7 @@ namespace IronPython.Runtime.Operations {
                 bytes = e.GetBytes(s);
             } catch (EncoderFallbackException ex) {
                 ex.Data["encoding"] = encoding;
+                ex.Data["object"] = s;
                 throw;
             }
 

--- a/Src/IronPython/Runtime/PythonAsciiEncoding.cs
+++ b/Src/IronPython/Runtime/PythonAsciiEncoding.cs
@@ -269,7 +269,7 @@ namespace IronPython.Runtime {
 
         public override bool Fallback(char charUnknown, int index) {
             if (charUnknown > 0xff) {
-                throw PythonOps.UnicodeEncodeError("ascii", charUnknown.ToString(), index, index + 1, "ordinal not in range(128)");
+                throw PythonOps.UnicodeEncodeError("ordinal not in range(128)", charUnknown, index);
             }
 
             if (_curIndex == _buffer.Count && _curIndex > 0) {

--- a/Src/IronPython/Runtime/PythonAsciiEncoding.cs
+++ b/Src/IronPython/Runtime/PythonAsciiEncoding.cs
@@ -264,7 +264,7 @@ namespace IronPython.Runtime {
         private int _prevIndex;
 
         public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index) {
-            throw PythonOps.UnicodeEncodeError("'ascii' codec can't encode character '\\u{0:X}{1:04X}' in position {2}: ordinal not in range(128)", (int)charUnknownHigh, (int)charUnknownLow, index);
+            throw PythonOps.UnicodeEncodeError("ordinal not in range(128)", charUnknownHigh, charUnknownLow, index);
         }
 
         public override bool Fallback(char charUnknown, int index) {

--- a/Tests/test_codecs.py
+++ b/Tests/test_codecs.py
@@ -1,0 +1,102 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+##
+## Test codecs, in addition to test_codecs from StdLib and from modules/io_related
+##
+
+import unittest
+import codecs
+
+import System.Text
+
+from iptest import run_test
+
+class CodecsTest(unittest.TestCase):
+    def test_interop_ascii(self):
+        self.assertEqual("abc".encode(System.Text.Encoding.ASCII), b"abc")
+        self.assertEqual(b"abc".decode(System.Text.Encoding.ASCII), "abc")
+
+        us_ascii = System.Text.ASCIIEncoding()
+        self.assertEqual("abc".encode(us_ascii), b"abc")
+        self.assertEqual(b"abc".decode(us_ascii), "abc")
+
+    def test_interop_utf8(self):
+        utf_8 = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True)
+        utf_8_sig = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True)
+
+        self.assertEqual("abć".encode(utf_8), b"ab\xc4\x87")
+        self.assertEqual(b"ab\xc4\x87".decode(utf_8), "abć")
+        self.assertEqual(b"ab\xc4\x87".decode(utf_8_sig), "abć")
+
+        self.assertEqual("abć".encode(utf_8_sig), b"\xef\xbb\xbfab\xc4\x87")
+        self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode(utf_8), "\ufeffabć")
+        self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode(utf_8_sig), "abć")
+
+        # now for comparison the same but with codec names
+        self.assertEqual("abć".encode('utf_8'), b"ab\xc4\x87")
+        self.assertEqual(b"ab\xc4\x87".decode('utf_8'), "abć")
+        self.assertEqual(b"ab\xc4\x87".decode('utf_8_sig'), "abć")
+
+        self.assertEqual("abć".encode('utf_8_sig'), b"\xef\xbb\xbfab\xc4\x87")
+        self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode('utf_8'), "\ufeffabć")
+        self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode('utf_8_sig'), "abć")
+
+    def test_interop_utf16(self):
+        utf_16 = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True)
+        utf_16_le = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True)
+        utf_16_be = System.Text.UnicodeEncoding(bigEndian=True, byteOrderMark=False, throwOnInvalidBytes=True)
+
+        self.assertEqual("abć".encode(utf_16), b"\xff\xfea\x00b\x00\x07\x01")
+        self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode(utf_16), "abć")
+        self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode(utf_16_le), "\ufeffabć")
+
+        self.assertEqual("abć".encode(utf_16_le), b"a\x00b\x00\x07\x01")
+        self.assertEqual(b"a\x00b\x00\x07\x01".decode(utf_16), "abć")
+        self.assertEqual(b"a\x00b\x00\x07\x01".decode(utf_16_le), "abć")
+
+        self.assertEqual("abć".encode(utf_16_be), b"\x00a\x00b\x01\x07")
+        self.assertEqual(b"\x00a\x00b\x01\x07".decode(utf_16_be), "abć")
+
+        # now for comparison the same but with codec names
+        self.assertEqual("abć".encode('utf_16'), b"\xff\xfea\x00b\x00\x07\x01")
+        self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode('utf_16'), "abć")
+        self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode('utf_16_le'), "\ufeffabć")
+
+        self.assertEqual("abć".encode('utf_16_le'), b"a\x00b\x00\x07\x01")
+        self.assertEqual(b"a\x00b\x00\x07\x01".decode('utf_16'), "abć")
+        self.assertEqual(b"a\x00b\x00\x07\x01".decode('utf_16_le'), "abć")
+
+        self.assertEqual("abć".encode('utf_16_be'), b"\x00a\x00b\x01\x07")
+        self.assertEqual(b"\x00a\x00b\x01\x07".decode('utf_16_be'), "abć")
+
+    def test_interop_utf32(self):
+        utf_32 = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=True, throwOnInvalidCharacters=True)
+        utf_32_le = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=False, throwOnInvalidCharacters=True)
+        utf_32_be = System.Text.UTF32Encoding(bigEndian=True, byteOrderMark=False, throwOnInvalidCharacters=True)
+
+        self.assertEqual("abć".encode(utf_32), b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
+        self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32), "abć")
+        self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32_le), "\ufeffabć")
+
+        self.assertEqual("abć".encode(utf_32_le), b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
+        self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32), "abć")
+        self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32_le), "abć")
+
+        self.assertEqual("abć".encode(utf_32_be), b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07")
+        self.assertEqual(b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07".decode(utf_32_be), "abć")
+
+        # now for comparison the same but with codec names
+        self.assertEqual("abć".encode('utf_32'), b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
+        self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode('utf_32'), "abć")
+        self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode('utf_32_le'), "\ufeffabć")
+
+        self.assertEqual("abć".encode('utf_32_le'), b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
+        self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode('utf_32'), "abć")
+        self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode('utf_32_le'), "abć")
+
+        self.assertEqual("abć".encode('utf_32_be'), b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07")
+        self.assertEqual(b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07".decode('utf_32_be'), "abć")
+
+run_test(__name__)

--- a/Tests/test_codecs.py
+++ b/Tests/test_codecs.py
@@ -99,4 +99,93 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual("abć".encode('utf_32_be'), b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07")
         self.assertEqual(b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07".decode('utf_32_be'), "abć")
 
+    def test_interop_ascii_decode_exeption(self):
+        def check_error(encoding, name):
+            with self.assertRaises(UnicodeDecodeError) as ude:
+                b"abc\xffxyz".decode(encoding)
+            self.assertEqual(ude.exception.encoding, name)
+            self.assertEqual(ude.exception.object, b"abc\xffxyz")
+            self.assertEqual(ude.exception.start, 3)
+            self.assertEqual(ude.exception.end, 4)
+
+        check_error(System.Text.ASCIIEncoding(), 'us-ascii')
+        check_error(System.Text.Encoding.ASCII, 'us-ascii')
+        check_error('ascii', 'ascii')
+
+    def test_interop_utf8_decode_exeption(self):
+        def check_error(encoding, name):
+            with self.assertRaises(UnicodeDecodeError) as ude:
+                # broken input (� is 0xff): "abć�ẋyz"
+                # does not work with 'strict' due to UTF-8 bug https://github.com/dotnet/corefx/issues/29898
+                b"ab\xc4\x87\xff\xe1\xba\x8byz".decode(encoding,'surrogatepass')
+            self.assertEqual(ude.exception.encoding, name)
+            self.assertEqual(ude.exception.object, b"ab\xc4\x87\xff\xe1\xba\x8byz")
+            self.assertEqual(ude.exception.start, 4)
+            self.assertEqual(ude.exception.end, 5)
+
+        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
+        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
+        check_error(System.Text.Encoding.UTF8, 'utf-8')
+        check_error('utf-8', 'utf-8')
+
+    def test_interop_utf8bom_decode_exeption(self):
+        def check_error(encoding, name):
+            with self.assertRaises(UnicodeDecodeError) as ude:
+                # broken input (� is 0xff): BOM + "abć�ẋyz"
+                # does not work with 'strict' due to UTF-8 bug https://github.com/dotnet/corefx/issues/29898
+                b"\xef\xbb\xbfab\xc4\x87\xff\xe1\xba\x8byz".decode(encoding,'surrogatepass')
+            self.assertEqual(ude.exception.encoding, name)
+            # regular utf-8 retains BOM if present
+            self.assertEqual(ude.exception.object, b"\xef\xbb\xbfab\xc4\x87\xff\xe1\xba\x8byz")
+            self.assertEqual(ude.exception.start, 7)
+            self.assertEqual(ude.exception.end, 8)
+
+        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
+        check_error('utf-8', 'utf-8')
+
+    def test_interop_utf8sigbom_decode_exeption(self):
+        def check_error(encoding, name):
+            with self.assertRaises(UnicodeDecodeError) as ude:
+                # broken input (� is 0xff): BOM_UTF8 + "abć�ẋyz"
+                # does not work with 'strict' due to UTF-8 bug https://github.com/dotnet/corefx/issues/29898
+                b"\xef\xbb\xbfab\xc4\x87\xff\xe1\xba\x8byz".decode(encoding,'surrogatepass')
+            self.assertEqual(ude.exception.encoding, name)
+            # utf-8 with signature skips BOM
+            self.assertEqual(ude.exception.object, b"ab\xc4\x87\xff\xe1\xba\x8byz")
+            self.assertEqual(ude.exception.start, 4)
+            self.assertEqual(ude.exception.end, 5)
+
+        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
+        check_error(System.Text.Encoding.UTF8, 'utf-8')
+        check_error('utf-8-sig', 'utf-8-sig') # TODO: CPython uses 'utf-8' as encoding name in UnicodeDecodeError
+
+    def test_interop_utf16_decode_exception(self):
+        def check_error(encoding, name):
+            with self.assertRaises(UnicodeDecodeError) as ude:
+                # broken input (� is lone surrogate 0xdddd): BOM_UTF16_LE + "abć�ẋyz"
+                b'\xff\xfea\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00'.decode(encoding,'strict')
+            self.assertEqual(ude.exception.encoding, name)
+            # regular utf-16 skips BOM
+            # NOTE: CPython is not consistent in this behavor, possibly a CPython bug
+            self.assertEqual(ude.exception.object, b'a\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00')
+            self.assertEqual(ude.exception.start, 6)
+            self.assertEqual(ude.exception.end, 8)
+
+        check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16LE')
+        check_error('utf-16', 'utf-16') # TODO: should be 'utf-16LE', CPython uses 'utf-16-le' here
+
+    def test_interop_utf16le_decode_exception(self):
+        def check_error(encoding, name):
+            with self.assertRaises(UnicodeDecodeError) as ude:
+                # broken input (� is lone surrogate 0xdddd): BOM_UTF16_LE + "abć�ẋyz"
+                b'\xff\xfea\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00'.decode(encoding,'strict')
+            self.assertEqual(ude.exception.encoding, name)
+            # utf-16LE treats BOM as a regular character
+            self.assertEqual(ude.exception.object, b'\xff\xfea\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00')
+            self.assertEqual(ude.exception.start, 8)
+            self.assertEqual(ude.exception.end, 10)
+
+        check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True), 'utf-16LE')
+        check_error('utf-16LE', 'utf-16LE')
+
 run_test(__name__)

--- a/Tests/test_unicode.py
+++ b/Tests/test_unicode.py
@@ -77,10 +77,7 @@ class UnicodeTest(unittest.TestCase):
             self.assertEqual(ex.encoding, 'ascii')
             self.assertEqual(ex.start, 2)
             self.assertEqual(ex.end, 3)
-            if is_cli:
-                self.assertEqual(ex.object, u'\uff21')
-            else:
-                self.assertEqual(ex.object, u'xx\uff21')
+            self.assertEqual(ex.object, u'xx\uff21')
             self.assertTrue(ex.reason is not None)
             self.assertTrue(len(ex.reason) > 0)
 


### PR DESCRIPTION
To get encoding names on .NET Core, the code detects the most common encodings and gives (most of) them [canonical .NET names](https://docs.microsoft.com/en-us/dotnet/api/system.text.encodinginfo.name?view=netframework-4.7.2). These are not always the same as [CPython's canonical names](https://docs.python.org/3/library/codecs.html?highlight=codecs#standard-encodings), however, all of them are recognized by CPython as at least aliases. I think it is more appropriate to use .NET names here as the code tries to give a name to a .NET object, possibly user-created. Also, it will align the names when run on .NET Core with names from .NET Frm/Mono.

Here are the differences:

| IronPython (and CPython alias) | CPython | .NET Framework |
| --- | --- | --- |
| us-ascii | ascii | us-ascii |
| iso-8859-1 | latin-1 | iso-8859-1 |
| utf-16LE | utf-16-le | utf-16 (note 1) |
| utf-16BE | utf-16-be | unicodeFFFE (note 2) |
| utf-32LE | utf-32-le | utf-32 (note 1) |
| utf-32BE | utf-32-be | utf-32BE |

There are no differences for 'utf-7' and 'utf-8'.

_Note 1_: CPython also has encoding 'utf-16' but it designates a native encoding that generates (or swallows on decoding) the preamble with BOM. .NET Unicode encoding can do the same, so at first I had code detect the preamble in the given encoding and report 'utf-16' or 'utf-16LE' accordingly. However, it turns out that CPython will **always** report the specific codec name in use when throwing an instance of a subclass `UnicodeError` . So 'utf-16' will never be seen in `UnicodeError`, always the specific codec 'utf-16-le' or 'utf-16-be'. It is the same situation for 'utf-32': it is always converted to 'utf-32-le' or 'utf-32-be' and for 'utf-8-sig' converted to 'utf-8'.

_Note 2_: The .NET name is a clear misnomer and better not be used (in fact, the first two bytes generated by this encoding will be FE FF and not what the name suggests). Also `WebName` on this encoding (where defined) will return 'utf-16BE'.

Another noteworthy change is handling of `UnicodeEncodeError` and `UnicodeDecodeError`. These are not so interoperable with `EncoderFallbackException` (EFE) and `DecoderFallbackException` (DFE) as the code originally assumed. .NET exceptions carry the position of the error and the erroneous data itself. Python specification is that the exception carries the full original input, and the `start:end` slice indicates the erroneous data. That is, the following invariant must be satisfied: `ex.object[ex.start:ex.end] == bad_data` One way of getting minimum compliance here is to always set `start` to 0 and `end` to the length of bad data carried in the .NET exception, however, information about the location (index) of the error would be lost. This is actually allowed in Python in the incremental encoding/decoding case, but very unfortunate, as the error position is invaluable in investigating the error. The code in this PR then extends EFE and DFE with extra data that will allow for full Python compliance. To prevent accidental creation of EFE and DFE without data, some overloads if `PythonOps.UnicodeEncodeError` and `PythonOps.UnicodeDecodeError` are removed. The data-less EFE and DFE instances can still be created in the user code so the interop code will handle them correctly, although they may not be as informative.

Fixes #551.