### PR TITLE
Allow slicing of List<T>

### DIFF
--- a/Src/IronPython/Runtime/Operations/ListOfTOps.cs
+++ b/Src/IronPython/Runtime/Operations/ListOfTOps.cs
@@ -119,8 +119,11 @@ namespace IronPython.Runtime.Operations {
             l.RemoveRange(curr, l.Count - curr);
         }
 
-        [SpecialName]
-        public static List<T> GetItem(List<T> l, Slice slice) {
+        public static T __getitem__(List<T> l, int index) {
+            return l[index];
+        }
+
+        public static List<T> __getitem__(List<T> l, Slice slice) {
             if (slice == null) throw PythonOps.TypeError("List<T> indices must be slices or integers");
             int start, stop, step;
             slice.indices(l.Count, out start, out stop, out step);

--- a/Tests/test_list.py
+++ b/Tests/test_list.py
@@ -50,10 +50,9 @@ class ListTest(IronPythonTestCase):
         lst.Add('Hello')
         lst.Add('World')
         vals = []
-        with self.assertRaises(TypeError): # TODO: remove assertRaises when https://github.com/IronLanguages/ironpython3/issues/456 is fixed
-            for v in lst[1:]:
-                vals.append(v)
-            self.assertEqual(vals, ['World'])
+        for v in lst[1:]:
+            vals.append(v)
+        self.assertEqual(vals, ['World'])
 
     def test_assign_to_empty(self):
         # should all succeed


### PR DESCRIPTION
Resolves #456.

Root cause: After finding an operator with the default operator name, the OperatorResolver bails, and doesn't search for operators with the alternate operator name.

I'm inclined to preserve the current semantics of .NET interop in this case. My understanding of the current policy for member resolution is: find one name for the given member in one class and return only that implementation and its overloads. Standard resolution (ie. looking for the method `__getitem__` itself) has a very high priority, so it it can be used to override most behavior where the underlying class cannot be modified.

That said, I'm also open to going back and solving this by changing member resolution; it's just that I didn't find a reason to do so.

Additional notes:
- `Equals()` is the alternate name for `__eq__`, which would introduce unwanted overloads for the String type if we were to modify the OperatorResolver to always include members of the alternate name (we rely on type coercion instead of overloads here). Something similar occurs for `Add()` with Longs.
- Extension classes have a lower priority than the classes they extend. This is interesting because, as I understand it, the entire purpose of extension classes is to override the behavior of types that can't be modified. However, we still have the ability to override their with standard member resolution.