### PR TITLE
Allow IFormattable objects to override __format__

### DIFF
--- a/Tests/test_strformat.py
+++ b/Tests/test_strformat.py
@@ -119,7 +119,6 @@ class StrFormatTest(IronPythonTestCase):
             abc = dt
 
         self.assertEqual(format(dt, 'MM-dd'), '10-26')
-        return
         self.assertEqual('{0:MM-dd}'.format(dt), '10-26')
         self.assertEqual('{abc:MM-dd}'.format(abc=dt), '10-26')
         self.assertEqual('{0.abc:MM-dd}'.format(x), '10-26')

--- a/Tests/test_strformat.py
+++ b/Tests/test_strformat.py
@@ -118,8 +118,7 @@ class StrFormatTest(IronPythonTestCase):
         class x(object):
             abc = dt
 
-        with self.assertRaises(ValueError): # TODO: get rid of the assertRaise+return when https://github.com/IronLanguages/ironpython3/issues/465 is fixed
-            self.assertEqual(format(dt, 'MM-dd'), '10-26')
+        self.assertEqual(format(dt, 'MM-dd'), '10-26')
         return
         self.assertEqual('{0:MM-dd}'.format(dt), '10-26')
         self.assertEqual('{abc:MM-dd}'.format(abc=dt), '10-26')


### PR DESCRIPTION
Do not resolve methods on Object other forms of member resolution have
been exhausted.

Resolves #465.

Root cause:
> values that live on object need to run before the StandardResolver
> which will pick up values off of object.

There are two things I'm trying to address in this pull request:
- We want to allow types to override object's `__format__` by being IFormattable, but we also want a type to be able to define `__format__` in order to override its IFormattable behavior.
- This issue is likely to happen again whenever we add anything else to ObjectOps.

One potential issue here is that this changes the order of member resolution for `__str__` `__new__` `__repr__` `__hash__` and `__iter__` slightly. While it doesn't seem to have caused any failures on currently enabled tests, if we have dead code for methods with these names, the methods are now called with this change.