### PR TITLE
Implement PEP-263 and PEP-3120 (WIP 2)

### DIFF
--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -3100,7 +3100,7 @@ namespace IronPython.Compiler {
 
             } else if (dfe.BytesUnknown != null && dfe.BytesUnknown.Length > 0) {
 
-                if ( _sourceUnit.LanguageContext is PythonContext pc && ReferenceEquals(_sourceReader.Encoding, pc.DefaultEncoding)) {
+                if (_sourceUnit.LanguageContext is PythonContext pc && ReferenceEquals(_sourceReader.Encoding, pc.DefaultEncoding)) {
                     // more specific error message if default encoding is used
                     message = string.Format("Non-UTF-8 code starting with '\\x{0:x2}' in file {1} on line {2}, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details",
                         dfe.BytesUnknown[0],

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -16,6 +16,7 @@ using IronPython.Compiler.Ast;
 using IronPython.Hosting;
 using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
+using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
 
 namespace IronPython.Compiler {
@@ -3089,11 +3090,46 @@ namespace IronPython.Compiler {
             // position where the exception came from.  There are too many levels
             // of buffering below us to re-wind and calculate the actual line number, so
             // we'll give the last line number the tokenizer was at.
-            return Runtime.Operations.PythonOps.BadSourceError(
-                dfe.BytesUnknown[0],
-                new SourceSpan(_tokenizer.CurrentPosition, _tokenizer.CurrentPosition),
-                _sourceUnit.Path
-            );
+            int lineNum = _tokenizer.CurrentPosition.Line;
+
+            string message;
+
+            if (_sourceReader.Encoding == null) {
+                // BUG: source reader reads from a text source so no DecoderFallbackException can originate from there
+                message = "encoding problem";
+
+            } else if (dfe.BytesUnknown != null && dfe.BytesUnknown.Length > 0) {
+
+                if ( _sourceUnit.LanguageContext is PythonContext pc && ReferenceEquals(_sourceReader.Encoding, pc.DefaultEncoding)) {
+                    // more specific error message if default encoding is used
+                    message = string.Format("Non-UTF-8 code starting with '\\x{0:x2}' in file {1} on line {2}, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details",
+                        dfe.BytesUnknown[0],
+                        _sourceUnit.Path,
+                        lineNum
+                    );
+                } else {
+                    // standard message
+                    message = string.Format("'{0}' codec can't decode byte 0x{1:x2} in position {2}: {3}",
+                        StringOps.GetEncodingName(_sourceReader.Encoding),
+                        dfe.BytesUnknown[0],
+                        dfe.Index,
+                        dfe.Message
+                    );
+                }
+
+            } else if (!string.IsNullOrEmpty(dfe.Message)) {
+                message = string.Format("encoding problem: {0}: {1}",
+                    StringOps.GetEncodingName(_sourceReader.Encoding),
+                    dfe.Message
+                );
+
+            } else {
+                message = string.Format("encoding problem: {0}",
+                    StringOps.GetEncodingName(_sourceReader.Encoding)
+                );
+            }
+
+            return PythonOps.BadSourceEncodingError(message, lineNum, _sourceUnit.Path);
         }
 
         private void StartParsing() {

--- a/Src/IronPython/Runtime/MemoryStreamContentProvider.cs
+++ b/Src/IronPython/Runtime/MemoryStreamContentProvider.cs
@@ -15,18 +15,26 @@ namespace IronPython.Runtime {
     internal sealed class MemoryStreamContentProvider : TextContentProvider {
         private readonly PythonContext _context;
         private readonly byte[] _data;
+        private readonly int _index, _count;
         private readonly string _path;
 
-        internal MemoryStreamContentProvider(PythonContext context, byte[] data, string path) {
+        internal MemoryStreamContentProvider(PythonContext context, byte[] data, string path)
+            : this(context, data, 0, data?.Length ?? 0, path) { }
+
+        internal MemoryStreamContentProvider(PythonContext context, byte[] data, int index, int count, string path) {
             ContractUtils.RequiresNotNull(context, nameof(context));
             ContractUtils.RequiresNotNull(data, nameof(data));
+            ContractUtils.RequiresArrayRange(data, index, count, nameof(index), nameof(count));
+
             _context = context;
             _data = data;
+            _index = index;
+            _count = count;
             _path = path;
         }
 
         public override SourceCodeReader GetReader() {
-            return _context.GetSourceReader(new MemoryStream(_data, writable: false), _context.DefaultEncoding, _path);
+            return _context.GetSourceReader(new MemoryStream(_data, _index, _count, writable: false), _context.DefaultEncoding, _path);
         }
     }
 }

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3730,17 +3730,14 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        public static SyntaxErrorException BadSourceError(byte badByte, SourceSpan span, string path) {
+        public static SyntaxErrorException BadSourceEncodingError(string message, int line, string path) {
+            SourceLocation sloc = new SourceLocation(0, line, 1); // index and column will be ignored
             SyntaxErrorException res = new SyntaxErrorException(
-                String.Format("Non-UTF-8 code starting with '\\x{0:x2}' in file {2} on line {1}, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details",
-                    badByte,
-                    span.Start.Line,
-                    path
-                ),
+                message,
                 path,
+                null, 
                 null,
-                null,
-                span,
+                new SourceSpan(sloc, sloc),
                 ErrorCodes.SyntaxError,
                 Severity.FatalError
             );

--- a/Src/IronPython/Runtime/PythonAsciiEncoding.cs
+++ b/Src/IronPython/Runtime/PythonAsciiEncoding.cs
@@ -126,7 +126,7 @@ namespace IronPython.Runtime {
                             while (dfb.GetNextChar() != char.MinValue) { /* empty */ }
                         }
                     } catch (DecoderFallbackException ex) {
-                        var dfe = new DecoderFallbackException("ordinal out of range(128)", ex.BytesUnknown, ex.Index);
+                        var dfe = new DecoderFallbackException("ordinal not in range(128)", ex.BytesUnknown, ex.Index);
                         dfe.Data.Add("encoding", EncodingName);
                         throw dfe;
                     }
@@ -162,7 +162,7 @@ namespace IronPython.Runtime {
                             }
                         }
                     } catch (DecoderFallbackException ex) {
-                        var dfe = new DecoderFallbackException("ordinal out of range(128)", ex.BytesUnknown, ex.Index);
+                        var dfe = new DecoderFallbackException("ordinal not in range(128)", ex.BytesUnknown, ex.Index);
                         dfe.Data.Add("encoding", EncodingName);
                         throw dfe;
                     }
@@ -339,24 +339,4 @@ namespace IronPython.Runtime {
     }
     
 #endif
-
-    [Serializable]
-    internal class BadSourceException : Exception {
-        internal byte _badByte;
-        public BadSourceException(byte b) {
-            _badByte = b;
-        }
-
-        public BadSourceException() : base() { }
-        public BadSourceException(string msg)
-            : base(msg) {
-        }
-        public BadSourceException(string message, Exception innerException)
-            : base(message, innerException) {
-        }
-
-#if FEATURE_SERIALIZATION
-        protected BadSourceException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
-    }
 }

--- a/Tests/encoded_files/cp11334_bad2.py
+++ b/Tests/encoded_files/cp11334_bad2.py
@@ -1,0 +1,3 @@
+# coding: bad-coding-name
+# coding: latin-1
+print('µble')


### PR DESCRIPTION
This PR contains mostly error message improvements (to align them more closely with CPython's) and `eval` changes for the bytes-like overload. Perfect alignment will probably not be practical as CPython may generate different error messages depending whether the code is imported, compiled inline, or run from a file given on the command line.

With these changes, `test.test_source_encoding` from StdLib passes (excluding two minor implementation-dependent incompatibilities with CPython).