### PR TITLE
Get test_math passing

### DIFF
--- a/Src/IronPython.Modules/math.cs
+++ b/Src/IronPython.Modules/math.cs
@@ -307,7 +307,7 @@ namespace IronPython.Modules {
             }
 
             // Apply correction factor
-            return log(v1) * v0 / (v1 - 1.0);
+            return log(v1) * (v0 / (v1 - 1.0));
         }
 
         public static double log1p(BigInteger value) {

--- a/Src/IronPython.Modules/pyexpat.cs
+++ b/Src/IronPython.Modules/pyexpat.cs
@@ -619,7 +619,12 @@ namespace IronPython.Modules {
                 if (!PythonOps.TryGetBoundAttr(context, file, "read", out object _readMethod))
                     throw PythonOps.TypeError("argument must have 'read' attribute");
 
-                if (!(PythonOps.CallWithContext(context, _readMethod) is string data)) throw PythonOps.TypeError("read() did not return a string object");
+                object readResult = PythonOps.CallWithContext(context, _readMethod);
+                if (readResult is Bytes byteData)
+                    readResult = byteData.MakeString();
+
+                if (!(readResult is string data))
+                    throw PythonOps.TypeError("read() did not return a string object");
 
                 using (var reader = new StringReader(data)) {
                     var settings = new XmlReaderSettings() { DtdProcessing = DtdProcessing.Parse, XmlResolver = null };

--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -514,10 +514,6 @@ Ignore=true
 Ignore=true
 Reason=StackOverflowException
 
-[AllCPython.test_math]
-Ignore=true
-Reason=ValueError: math domain error
-
 [AllCPython.test_memoryio]
 Ignore=true
 


### PR DESCRIPTION
Apply division before mutliplication to avoid getting infinity for
large values passed to math.log1p().

Root cause: 
The term log(v1) * v0 is too large to represent in a double for very large v0.

This affects the results of many inputs to log1p:

```
import math
import random 
log = math.log
for _ in range (100):
    v0 = random.random() * 1024
    v1 = v0 + 1.0
    logA = log(v1) * v0 / (v1 - 1.0)
    logB = log(v1) * (v0 / (v1 - 1.0))
    if (logA != logB):
        print('Differing results on input', v0, '---', logA, '!=', logB)
```

Yields several results, but it seems to be within the acceptable margin for test_math. CPython appears to use `log1p()` from the C standard library, but I'm not completely certain of this claim. I tried some of the results from the above in CPython, and got results that matched neither, so from my perspective, this comes down to a matter of implementation.

Explanation of math domain error:
- The error is validly thrown previously
- This error shows up due to #245