### PR TITLE
Implement cast() on memoryview

### DIFF
--- a/Src/IronPython/Modules/_bytesio.cs
+++ b/Src/IronPython/Modules/_bytesio.cs
@@ -95,7 +95,7 @@ namespace IronPython.Modules {
             public MemoryView getbuffer() {
                 _checkClosed();
 
-                return new MemoryView(new Bytes(_data), 0, _length);
+                return new MemoryView(new Bytes(_data), 0, _length, 1, "B", PythonOps.MakeTuple(_length));
             }
 
             [Documentation("isatty() -> False\n\n"

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -9,13 +9,20 @@ using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
+using System.Collections.Generic;
 
 namespace IronPython.Runtime {
     [PythonType("memoryview")]
     public sealed class MemoryView : ICodeFormattable {
+        private const int MaximumDimensions = 64;
+
         private IBufferProtocol _buffer;
         private readonly int _start;
         private readonly int? _end;
+        private int? _step;
+        private readonly string _format;
+        private readonly PythonTuple _shape;
+        private readonly int? _itemsize;
 
         public MemoryView(IBufferProtocol obj) {
             _buffer = obj;
@@ -28,6 +35,16 @@ namespace IronPython.Runtime {
 
         public MemoryView(MemoryView obj) : this(obj._buffer, obj._start, obj._end) { }
 
+        internal MemoryView(IBufferProtocol @object, int start, int? end, int? step, string format, PythonTuple shape) : this(@object, start, end) {
+            _format = format;
+            _shape = shape;
+            _step = step;
+
+            if (TypecodeOps.IsTypecodeFormat(format)) {
+                _itemsize = TypecodeOps.GetTypecodeWidth(format[0]);
+            }
+        }
+
         private void CheckBuffer() {
             if (_buffer == null) throw PythonOps.ValueError("operation forbidden on released memoryview object");
         }
@@ -35,9 +52,9 @@ namespace IronPython.Runtime {
         public int __len__() {
             CheckBuffer();
             if (_end != null) {
-                return _end.Value - _start;
+                return (_end.Value - _start) / ((int)itemsize * (_step ?? 1));
             }
-            return _buffer.ItemCount;
+            return _buffer.ItemCount * (int)_buffer.ItemSize / ((int)itemsize * (_step ?? 1));
         }
 
         public object obj {
@@ -62,21 +79,21 @@ namespace IronPython.Runtime {
         public string format {
             get {
                 CheckBuffer();
-                return _buffer.Format;
+                return _format ?? _buffer.Format;
             }
         }
 
         public BigInteger itemsize {
             get {
                 CheckBuffer();
-                return _buffer.ItemSize;
+                return _itemsize ?? _buffer.ItemSize;
             }
         }
 
         public BigInteger ndim {
             get {
                 CheckBuffer();
-                return _buffer.NumberDimensions;
+                return (_shape?.__len__()) ?? _buffer.NumberDimensions;
             }
         }
 
@@ -90,6 +107,10 @@ namespace IronPython.Runtime {
         public PythonTuple shape {
             get {
                 CheckBuffer();
+                if (_shape != null) {
+                    return _shape;
+                }
+
                 var shape = _buffer.GetShape(_start, _end);
                 if (shape == null) {
                     return null;
@@ -122,11 +143,209 @@ namespace IronPython.Runtime {
             return _buffer.ToList(_start, _end);
         }
 
+        public MemoryView cast(object format) {
+            return cast(format, null);
+        }
+
+        public MemoryView cast(object format, object shape) {
+            if (!(format is string formatAsString)) {
+                throw PythonOps.TypeError("memoryview: format argument must be a string");
+            }
+
+            if (_step != null && _step != 1) {
+                throw PythonOps.TypeError("memoryview: casts are restricted to C-contiguous views");
+            }
+
+            if ((shape != null || ndim != 0) && this.shape.Contains(0)) {
+                throw PythonOps.TypeError("memoryview: cannot cast view with zeros in shape or strides");
+            }
+
+            int newNDim = 1;
+            PythonTuple shapeAsTuple = null;
+
+            if (shape != null) {
+                if (!(shape is PythonList) && !(shape is PythonTuple)) {
+                    throw PythonOps.TypeError("shape must be a list or a tuple");
+                }
+
+                shapeAsTuple = PythonOps.MakeTupleFromSequence(shape);
+                newNDim = shapeAsTuple.Count;
+
+                if (newNDim > MaximumDimensions) {
+                    throw PythonOps.TypeError("memoryview: number of dimensions must not exceed {0}", MaximumDimensions);
+                }
+
+                if (ndim != 1 && newNDim != 1) {
+                    throw PythonOps.TypeError("memoryview: cast must be 1D -> ND or ND -> 1D");
+                }
+            }
+
+            bool thisIsBytes = this.format == "B" || this.format == "b" || this.format == "c";
+            bool otherIsBytes = formatAsString == "B" || formatAsString == "b" || formatAsString == "c";
+
+            if (!thisIsBytes && !otherIsBytes) {
+                throw PythonOps.TypeError("memoryview: cannot cast between two non-byte formats");
+            }
+
+            int newItemsize = TypecodeOps.GetTypecodeWidth(formatAsString[0]);
+            if (__len__() % newItemsize != 0) {
+                throw PythonOps.TypeError("memoryview: length is not a multiple of itemsize");
+            }
+
+            int newLength = __len__() * (int)itemsize / newItemsize;
+            if (shapeAsTuple != null) {
+                int lengthGivenShape = 1;
+                for (int i = 0; i < shapeAsTuple.Count; i++) {
+                    lengthGivenShape *= (int)shapeAsTuple[i];
+                }
+
+                if (lengthGivenShape != newLength) {
+                    throw PythonOps.TypeError("memoryview: product(shape) * itemsize != buffer size");
+                }
+            }
+
+            return new MemoryView(_buffer, _start, _end, _step, formatAsString, shapeAsTuple ?? PythonOps.MakeTuple(newLength));
+        }
+
+        private byte[] unpackBytes(string format, object o) {
+            if (TypecodeOps.IsTypecodeFormat(format)) {
+                return TypecodeOps.ToBytes(format[0], o);
+            } else if (o is Bytes b) {
+                return b._bytes; // CData returns a bytes object for its type
+            } else {
+                throw PythonOps.NotImplementedError("No conversion for type {0} to byte array", PythonOps.GetPythonTypeName(o));
+            }
+        }
+
+        private object packBytes(string format, byte[] bytes, int offset, int itemsize) {
+            if (TypecodeOps.IsTypecodeFormat(format))
+                return TypecodeOps.FromBytes(format[0], bytes, offset);
+            else {
+                byte[] obj = new byte[itemsize];
+                for (int i = 0; i < obj.Length; i++) {
+                    obj[i] = bytes[offset + i];
+                }
+                return new Bytes(obj);
+            }
+        }
+
+        private void setByteRange(int startByte, byte[] toWrite) {
+            string bufferTypeCode = _buffer.Format;
+            int bufferItemSize = (int)_buffer.ItemSize;
+
+            // Because memoryviews can be cast to bytes, sliced, and then
+            // cast to a different format, we have no guarantee of being aligned
+            // with the underlying buffer.
+            int startAlignmentOffset = startByte % bufferItemSize;
+            int endAlignmentOffset = (startByte + toWrite.Length) % bufferItemSize;
+
+            int indexInBuffer = startByte / bufferItemSize;
+
+            // Special case: when the bytes we set fall within the boundary
+            // of a single item, we have to worry about both the start and
+            // end offsets
+            if (startAlignmentOffset + toWrite.Length < bufferItemSize) {
+                byte[] existingBytes = unpackBytes(bufferTypeCode, _buffer.GetItem(indexInBuffer));
+
+                for (int i = 0; i < toWrite.Length; i++) {
+                    existingBytes[i + startAlignmentOffset] = toWrite[i];
+                }
+
+                _buffer.SetItem(indexInBuffer, packBytes(bufferTypeCode, existingBytes, 0, bufferItemSize));
+                return;
+            }
+
+            // If we aren't aligned at the start, we have to preserve the first x bytes as
+            // they already are in the buffer, and overwrite the last (size - x) bytes
+            if (startAlignmentOffset != 0) {
+                byte[] existingBytes = unpackBytes(bufferTypeCode, _buffer.GetItem(indexInBuffer));
+
+                for (int i = startAlignmentOffset; i < existingBytes.Length; i++) {
+                    existingBytes[i] = toWrite[i - startAlignmentOffset];
+                }
+
+                _buffer.SetItem(indexInBuffer, packBytes(bufferTypeCode, existingBytes, 0, bufferItemSize));
+                indexInBuffer++;
+            }
+
+            for (int i = startAlignmentOffset; i + bufferItemSize <= toWrite.Length; i += bufferItemSize, indexInBuffer++) {
+                _buffer.SetItem(indexInBuffer, packBytes(bufferTypeCode, toWrite, i, bufferItemSize));
+            }
+
+            // Likewise at the end, we may have to overwrite the first x bytes, but
+            // preserve the last (size - x) bytes
+            if (endAlignmentOffset != 0) {
+                byte[] existingBytes = unpackBytes(bufferTypeCode, _buffer.GetItem(indexInBuffer));
+
+                for (int i = 0; i < endAlignmentOffset; i++) {
+                    existingBytes[i] = toWrite[toWrite.Length - startAlignmentOffset + i];
+                }
+                _buffer.SetItem(indexInBuffer, packBytes(bufferTypeCode, existingBytes, 0, bufferItemSize));
+            }
+        }
+
+        private byte[] getByteRange(int startByte, int length) {
+            string bufferTypeCode = _buffer.Format;
+            int bufferItemsize = (int)_buffer.ItemSize;
+
+            byte[] bytes = new byte[length];
+            int startAlignmentOffset = startByte % bufferItemsize;
+            int indexInBuffer = startByte / bufferItemsize;
+
+            for (int i = -startAlignmentOffset; i < length; i += bufferItemsize, indexInBuffer++) {
+                byte[] currentBytes = unpackBytes(bufferTypeCode, _buffer.GetItem(indexInBuffer));
+
+                for (int j = 0; j < currentBytes.Length; j++) {
+                    // Because we don't have a guarantee that we are aligned with the
+                    // the buffer's data, we may potentially read extra bits to the left
+                    // and write of what we want, so we must ignore these bytes.
+                    if (j + i < 0) {
+                        continue;
+                    }
+
+                    if (j + i >= bytes.Length) {
+                        continue;
+                    }
+
+                    bytes[i + j] = currentBytes[j];
+                }
+            }
+
+            return bytes;
+        }
+
+        /// <summary>
+        /// Treats the memoryview as if it were a flattened array, instead
+        /// of having multiple dimensions. So, for a memoryview with the shape
+        /// (2,2,2), retrieving at index 6 would be equivalent to getting at the
+        /// index (1,1,0).
+        /// </summary>
+        private object getAtFlatIndex(int index) {
+            int firstByteIndex = _start + index * (int)itemsize * (_step ?? 1);
+            object result = packBytes(format, getByteRange(firstByteIndex, (int)itemsize), 0, (int)_buffer.ItemSize);
+
+            // TODO: BigInteger should also be merged into an integer once the int/long merge occurs
+            if (result is BigInteger || result is double || result is float || result is Bytes) {
+                return result;
+            } else {
+                return Convert.ToInt32(result);
+            }
+        }
+
+        private void setAtFlatIndex(int index, object value) {
+            int firstByteIndex = _start + index * (int)itemsize * (_step ?? 1);
+            setByteRange(firstByteIndex, unpackBytes(format, value));
+        }
+
         public object this[int index] {
             get {
                 CheckBuffer();
                 index = PythonOps.FixIndex(index, __len__());
-                return _buffer.GetItem(index + _start);
+                if (ndim > 1) {
+                    throw PythonOps.NotImplementedError("multi-dimensional sub-views are not implemented");
+                }
+
+                return getAtFlatIndex(index);
             }
             set {
                 CheckBuffer();
@@ -134,7 +353,11 @@ namespace IronPython.Runtime {
                     throw PythonOps.TypeError("cannot modify read-only memory");
                 }
                 index = PythonOps.FixIndex(index, __len__());
-                _buffer.SetItem(index + _start, value);
+                if (ndim > 1) {
+                    throw PythonOps.NotImplementedError("multi-dimensional sub-views are not implemented");
+                }
+
+                setAtFlatIndex(index, value);
             }
         }
 
@@ -157,10 +380,26 @@ namespace IronPython.Runtime {
         public object this[[NotNull]Slice slice] {
             get {
                 CheckBuffer();
-                int start, stop;
-                FixSlice(slice, __len__(), out start, out stop);
+                int start, stop, step;
+                FixSlice(slice, __len__(), out start, out stop, out step);
 
-                return new MemoryView(_buffer, _start + start, _start + stop);
+                int newStart = _start + (start * (int)itemsize);
+                int newEnd = _start + (stop * (int)itemsize);
+                int newStep = (_step ?? 1) * step;
+
+                List<int> dimensions = new List<int>();
+
+                // When a multidimensional memoryview is sliced, the slice
+                // applies to only the first dimension. Therefore, other
+                // dimensions are inherited.
+                dimensions.Add((stop - start) / step);
+                for (int i = 1; i < shape.__len__(); i++) {
+                    dimensions.Add((int)shape[i]);
+                }
+
+                PythonTuple newShape = PythonOps.MakeTupleFromSequence(dimensions);
+
+                return new MemoryView(_buffer, newStart, newEnd, newStep, format, newShape);
             }
             set {
                 CheckBuffer();
@@ -168,31 +407,33 @@ namespace IronPython.Runtime {
                     throw PythonOps.TypeError("cannot modify read-only memory");
                 }
 
-                int start, stop;
-                FixSlice(slice, __len__(), out start, out stop);
+                int start, stop, step;
+                FixSlice(slice, __len__(), out start, out stop, out step);
+
+                slice = new Slice(start, stop, step);
 
                 int newLen = PythonOps.Length(value);
                 if (stop - start != newLen) {
                     throw PythonOps.ValueError("cannot resize memory view");
                 }
 
-                _buffer.SetSlice(new Slice(_start + start, _start + stop), value);
+                slice.DoSliceAssign(SliceAssign, __len__(), value);
             }
+        }
+
+        private void SliceAssign(int index, object value) {
+            setAtFlatIndex(index, value);
         }
 
         /// <summary>
         /// MemoryView slicing is somewhat different and more restricted than
         /// standard slicing.
         /// </summary>
-        private static void FixSlice(Slice slice, int len, out int start, out int stop) {
-            if (slice.step != null) {
-                throw PythonOps.NotImplementedError("");
-            }
+        private static void FixSlice(Slice slice, int len, out int start, out int stop, out int step) {
+            slice.indices(len, out start, out stop, out step);
 
-            slice.indices(len, out start, out stop, out _);
-
-            if (stop < start) {
-                // backwards iteration is interpreted as empty slice
+            if (stop < start && step >= 0) {
+                // wrapped iteration is interpreted as empty slice
                 stop = start;
             }
         }

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -337,6 +337,10 @@ namespace IronPython.Runtime {
         /// index (1,1,0).
         /// </summary>
         private object getAtFlatIndex(int index) {
+            if (_matchesBuffer) {
+                return _buffer.GetItem((_start / _itemsize) + (index * _step));
+            }
+
             int firstByteIndex = _start + index * (int)itemsize * _step;
             object result = packBytes(format, getByteRange(firstByteIndex, (int)itemsize), 0, (int)_buffer.ItemSize);
 
@@ -349,6 +353,11 @@ namespace IronPython.Runtime {
         }
 
         private void setAtFlatIndex(int index, object value) {
+            if (_matchesBuffer) {
+                _buffer.SetItem((_start / _itemsize) + (index * _step), value);
+                return;
+            }
+
             int firstByteIndex = _start + index * (int)itemsize * _step;
             setByteRange(firstByteIndex, unpackBytes(format, value));
         }

--- a/Src/IronPython/Runtime/TypecodeOps.cs
+++ b/Src/IronPython/Runtime/TypecodeOps.cs
@@ -1,0 +1,105 @@
+﻿using IronPython.Runtime.Operations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IronPython.Runtime {
+    class TypecodeOps {
+
+        public static bool IsTypecodeFormat(string format) {
+            switch (format) {
+                case "c": // char
+                case "b": // signed byte
+                case "B": // unsigned byte
+                case "x": // pad byte
+                case "s": // null-terminated string
+                case "p": // Pascal string
+                case "u": // unicode char
+                case "h": // signed short
+                case "H": // unsigned short
+                case "i": // signed int
+                case "I": // unsigned int
+                case "l": // signed long
+                case "L": // unsigned long
+                case "f": // float
+                case "P": // pointer
+                case "q": // signed long long
+                case "Q": // unsigned long long
+                case "d": // double
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static int GetTypecodeWidth(char typecode) {
+            switch (typecode) {
+                case 'c': // char
+                case 'b': // signed byte
+                case 'B': // unsigned byte
+                case 'x': // pad byte
+                case 's': // null-terminated string
+                case 'p': // Pascal string
+                    return 1;
+                case 'u': // unicode char
+                case 'h': // signed short
+                case 'H': // unsigned short
+                    return 2;
+                case 'i': // signed int
+                case 'I': // unsigned int
+                case 'l': // signed long
+                case 'L': // unsigned long
+                case 'f': // float
+                    return 4;
+                case 'P': // pointer
+                    return IntPtr.Size;
+                case 'q': // signed long long
+                case 'Q': // unsigned long long
+                case 'd': // double
+                    return 8;
+                default:
+                    throw PythonOps.ValueError("Bad type code (expected one of 'c', 'b', 'B', 'u', 'H', 'h', 'i', 'I', 'l', 'L', 'f', 'd')");
+            }
+        }
+
+        public static object FromBytes(char typecode, byte[] bytes, int offset) {
+            switch (typecode) {
+                case 'c': return (char)bytes[offset];
+                case 'b': return (sbyte)bytes[offset];
+                case 'B': return bytes[offset];
+                case 'u': return BitConverter.ToChar(bytes, offset);
+                case 'h': return BitConverter.ToInt16(bytes, offset);
+                case 'H': return BitConverter.ToUInt16(bytes, offset);
+                case 'l':
+                case 'i': return BitConverter.ToInt32(bytes, offset);
+                case 'L':
+                case 'I': return BitConverter.ToUInt32(bytes, offset);
+                case 'f': return BitConverter.ToSingle(bytes, offset);
+                case 'd': return BitConverter.ToDouble(bytes, offset);
+                default:
+                    throw PythonOps.ValueError("Bad type code (expected one of 'c', 'b', 'B', 'u', 'H', 'h', 'i', 'I', 'l', 'L', 'f', 'd')");
+            }
+        }
+
+        public static byte[] ToBytes(char typecode, object obj) {
+            switch (typecode) {
+                case 'c': return new[] { (byte)Convert.ToChar(obj) };
+                case 'b': return new[] { (byte)Convert.ToSByte(obj) };
+                case 'B': return new[] { Convert.ToByte(obj) };
+                case 'u': return BitConverter.GetBytes((byte)Convert.ToChar(obj));
+                case 'h': return BitConverter.GetBytes(Convert.ToInt16(obj));
+                case 'H': return BitConverter.GetBytes(Convert.ToUInt16(obj));
+                case 'l':
+                case 'i': return BitConverter.GetBytes(Convert.ToInt32(obj));
+                case 'L':
+                case 'I': return BitConverter.GetBytes(Convert.ToUInt32(obj));
+                case 'f': return BitConverter.GetBytes(Convert.ToSingle(obj));
+                case 'd': return BitConverter.GetBytes(Convert.ToDouble(obj));
+                default:
+                    throw PythonOps.ValueError("Bad type code (expected one of 'c', 'b', 'B', 'u', 'H', 'h', 'i', 'I', 'l', 'L', 'f', 'd')");
+            }
+        }
+    }
+}

--- a/Tests/test_memoryview.py
+++ b/Tests/test_memoryview.py
@@ -6,7 +6,8 @@ import array
 import itertools
 import unittest
 
-from iptest import run_test
+#from iptest import run_test
+import test.support
 
 class SliceTests(unittest.TestCase):
     def testGet(self):
@@ -20,14 +21,20 @@ class SliceTests(unittest.TestCase):
     def testUpdate(self):
         b = bytearray(range(4))
         m = memoryview(b)
-        m[1:3] = [11, 22]
+        m[1:3] = bytes([11, 22])
         self.assertEqual(bytearray([0,11,22,3]), b)
 
     def testUpdateNested(self):
         b = bytearray(range(4))
         m = memoryview(b)
-        m[1:][1:3] = [11, 22]
+        m[1:][1:3] = bytes([11, 22])
         self.assertEqual(bytearray([0,1,11,22]), b)
+
+    def testUpdateStrided(self):
+        b = bytearray(range(8))
+        m = memoryview(b)
+        m[::2][1:3] = bytes([11, 22])
+        self.assertEqual(bytearray([0, 1, 11, 3, 22, 5, 6, 7]), b)
 
 class TestGH1387(unittest.TestCase):
     # from https://github.com/IronLanguages/main/issues/1387
@@ -117,4 +124,109 @@ class MemoryViewTests(unittest.TestCase):
         for x, y in itertools.product((a, mv), repeat=2):
             self.assertFalse(x != y, "{} {}".format(x, y))
 
-run_test(__name__)
+class CastTests(unittest.TestCase):
+    def test_get_int_alignment(self):
+        a = array.array('b', range(8))
+        mv = memoryview(a)
+        slices_answers = [
+            (slice(0,4,1), 50462976),
+            (slice(1,5,1), 67305985),
+            (slice(2,6,1), 84148994),
+            (slice(3,7,1), 100992003),
+            (slice(4,8,1), 117835012)
+            ]
+
+        for (s, answer) in slices_answers:
+            mv2 = mv[s].cast('i')
+            self.assertEqual(mv2[0], answer)
+
+    def test_set_int_alignment(self):
+        a = array.array('i', [50462976, 117835012])
+        mv = memoryview(a)
+
+        slice_newval_highint_lowint = [
+            (slice(0,4,1), 105491832, 105491832,   117835012),
+            (slice(1,5,1), 105491832, 1236105216,  117835014),
+            (slice(2,6,1), 105491832, -1384644352, 117835337),
+            (slice(3,7,1), 105491832, 2013397248,  117852589),
+            (slice(4,8,1), 105491832, 50462976,    105491832)
+            ]
+
+        for (s, newval, highint, lowint) in slice_newval_highint_lowint:
+            a[0] = 50462976
+            a[1] = 117835012
+            mv2 = (memoryview(a).cast('b'))[s].cast('i')
+            mv2[0] = newval
+            self.assertEqual(mv2[0], newval)
+            self.assertEqual(mv[0], highint)
+            self.assertEqual(mv[1], lowint)
+
+    def test_alignment_inside_item(self):
+        a = array.array('i', [50462976])
+        mv = memoryview(a).cast('b')[1:3].cast('h')
+        self.assertEqual(mv[0], 513)
+        mv[0] = 32767
+        self.assertEqual(mv[0], 32767)
+        self.assertEqual(a[0], 58720000)
+
+    def test_cast_wrong_size(self):
+        a = array.array('b', [1,2,3,4,5])
+        mv = memoryview(a)
+        typecodes = ['h', 'H', 'i', 'I', 'L', 'f', 'P', 'q', 'Q', 'd']
+        for tc in typecodes:
+            self.assertRaises(TypeError, lambda: mv.cast(tc))
+
+    def test_cast_wrong_shape(self):
+        a = array.array('b', range(16))
+        mv = memoryview(a)
+        self.assertRaises(TypeError, lambda: mv.cast('b', (2,2,2)))
+        self.assertRaises(TypeError, lambda: mv.cast('i', (2,2,2)))
+        mv.cast('h', (2,2,2))
+
+    # WIP: fails because this[PythonTuple] is not implemented,
+    # and __len__ captures the total number of elements instead
+    # of the first dimension
+    @unittest.expectedFailure
+    def test_cast_reshape(self):
+        a = array.array('b', range(16))
+        mv = memoryview(a).cast('b', (2,2,2,2))
+
+        self.assertEqual(len(mv), 2)
+
+        self.assertEqual(mv[(0,0,0,0)], 0)
+        self.assertEqual(mv[(0,0,0,1)], 1)
+        self.assertEqual(mv[(0,0,1,0)], 2)
+        self.assertEqual(mv[(0,0,1,1)], 3)
+        self.assertEqual(mv[(0,1,0,0)], 4)
+        self.assertEqual(mv[(0,1,0,1)], 5)
+        self.assertEqual(mv[(0,1,1,0)], 6)
+        self.assertEqual(mv[(0,1,1,1)], 7)
+        self.assertEqual(mv[(1,0,0,0)], 8)
+        self.assertEqual(mv[(1,0,0,1)], 9)
+        self.assertEqual(mv[(1,0,1,0)], 10)
+        self.assertEqual(mv[(1,0,1,1)], 11)
+        self.assertEqual(mv[(1,1,0,0)], 12)
+        self.assertEqual(mv[(1,1,0,1)], 13)
+        self.assertEqual(mv[(1,1,1,0)], 14)
+        self.assertEqual(mv[(1,1,1,1)], 15)
+
+    # WIP: fails because this[PythonTuple] is not implemented
+    # and 
+    @unittest.expectedFailure
+    def test_cast_reshape_then_slice(self):
+        a = array.array('b', range(16))
+        mv = memoryview(a).cast('b', (4,2,2))
+        mv2 = mv[2:]
+        self.assertEqual(len(mv2), 2)
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    self.assertEqual(mv[(i + 2, j, k)], mv2[(i, j, k)])
+
+#run_test(__name__)
+
+def test_main():
+    test.support.run_unittest(__name__)
+
+if __name__ == "__main__":
+    test_main()

--- a/Tests/test_memoryview.py
+++ b/Tests/test_memoryview.py
@@ -211,7 +211,6 @@ class CastTests(unittest.TestCase):
         self.assertEqual(mv[(1,1,1,1)], 15)
 
     # WIP: fails because this[PythonTuple] is not implemented
-    # and 
     @unittest.expectedFailure
     def test_cast_reshape_then_slice(self):
         a = array.array('b', range(16))

--- a/Tests/test_memoryview.py
+++ b/Tests/test_memoryview.py
@@ -6,8 +6,7 @@ import array
 import itertools
 import unittest
 
-#from iptest import run_test
-import test.support
+from iptest import run_test
 
 class SliceTests(unittest.TestCase):
     def testGet(self):
@@ -222,10 +221,4 @@ class CastTests(unittest.TestCase):
                 for k in range(2):
                     self.assertEqual(mv[(i + 2, j, k)], mv2[(i, j, k)])
 
-#run_test(__name__)
-
-def test_main():
-    test.support.run_unittest(__name__)
-
-if __name__ == "__main__":
-    test_main()
+run_test(__name__)


### PR DESCRIPTION
Refactor MemoryView to refer to the beginning and ending byte of the
underlying buffer rather than the index of the underlying buffer.
Implement cast() to change the shape and format of the memoryview. Add
tests in IronPython.test_memoryview for this behavior.

Hi, sorry for showing up with such a large commit. I understand if this isn't a high priority since we don't have much by way of C buffers. In any case, I want to get some feedback on whether this change is warranted at the moment and whether the approach is sufficiently clear and/or acceptable before proceeding.

Motivating behavior: with cast() it's possible to have a memoryview that is not aligned with the underlying buffer.

General approach: make `_start` and `_end` refer to the actual byte locations in the buffer. When getting any item or setting any item, always convert the objects of the buffer/memoryview to bytes, and then convert those bytes into the format of the memoryview/buffer.

Here are the specific questions I have:
1) Is this behavior worth supporting at the moment?
2) What do you think about the approach of directing everything to these getByteRange()/setByteRange() methods?
3) As implemented, I have a ton of fields on the memoryview that are null at first and get set after slicing/casting. Is it better to just initialize these to the underlying or default values in the first constructor?
4) The itemsize is a BigInteger, but I treat it exclusively as an integer here, opting to cast to an int for everything. This simplified things for me, but also I think that for any size not in the int range, we will run up against C#'s maximum array size. Is this something that can stay if we do proceed with this change? 

I intend to enable test_memoryview (the CPythonTest) in this PR. I got it working except for some stuff having to do with `sys.getrefcount()` and a weakref that wouldn't release on net45 (in a way that didn't break the other active tests -- this change is currently on master in my fork). I just don't want to show up asking for you to review with an even larger, more disorganized changeset before getting your opinion on the approach for this.