### PR TITLE
Fix $Env:PATH handling

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -32,13 +32,13 @@ if(!$global:isUnix) {
 
     if([System.IO.File]::Exists([System.IO.Path]::Combine($_VSINSTPATH, 'MSBuild\Current\Bin\MSBuild.exe'))) {
         $_MSBUILDPATH = [System.IO.Path]::Combine($_VSINSTPATH, 'MSBuild\Current\Bin\')
-        if ($env:PATH -notcontains $_MSBUILDPATH) {
+        if ($env:PATH -split ';' -notcontains $_MSBUILDPATH) {
             $env:PATH = [String]::Join(';', $env:PATH, $_MSBUILDPATH)
         }
     }
     elseif([System.IO.File]::Exists([System.IO.Path]::Combine($_VSINSTPATH, 'MSBuild\15.0\Bin\MSBuild.exe'))) {
         $_MSBUILDPATH = [System.IO.Path]::Combine($_VSINSTPATH, 'MSBuild\15.0\Bin\')
-        if ($env:PATH -notcontains $_MSBUILDPATH) {
+        if ($env:PATH -split ';' -notcontains $_MSBUILDPATH) {
             $env:PATH = [String]::Join(';', $env:PATH, $_MSBUILDPATH)
         }
     }
@@ -135,7 +135,7 @@ function Test([String] $target, [String] $configuration, [String[]] $frameworks,
         $runSettings = GenerateRunSettings $framework $platform $configuration $runIgnored
 
         $frameworkSettings = $_FRAMEWORKS[$framework]
-        if ($frameworkSettings -eq $null) { $frameworkSettings = $_defaultFrameworkSettings }
+        if ($null -eq $frameworkSettings) { $frameworkSettings = $_defaultFrameworkSettings }
 
         if ($target -imatch "^ID[=~]") {
             $testquery = $target.Substring(2)


### PR DESCRIPTION
I've finally found the cause for some of the tests failing on my local machine, while they were fine on CI. After a number of local test runs, the PATH variable became too long to successfully spawn subprocesses for tests at PROCCESS isolation level.