### PR TITLE
Make codecs tests runnable under CPython

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -391,11 +391,14 @@ namespace IronPython.Modules {
 
         #region Utf-8 Functions
 
-        public static PythonTuple utf_8_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors = "strict", bool final = false)
-            => DoDecode(context, "utf-8", Encoding.UTF8, input, errors, final).ToPythonTuple();
+        public static PythonTuple utf_8_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors = "strict", bool final = false) {
+            StringOps.TryGetEncoding("utf-8", out Encoding encoding); // no preamble skipping
+            return DoDecode(context, "utf-8", encoding, input, errors, final).ToPythonTuple();
+        }
 
-        public static PythonTuple utf_8_encode(CodeContext context, string input, string errors = "strict")
-            => DoEncode(context, "utf-8", Encoding.UTF8, input, errors).ToPythonTuple();
+        public static PythonTuple utf_8_encode(CodeContext context, string input, string errors = "strict") {
+            return DoEncode(context, "utf-8", Encoding.UTF8, input, errors).ToPythonTuple();
+        }
 
         #endregion
 

--- a/Tests/encoded_files/ok_encoding_nonascii.py
+++ b/Tests/encoded_files/ok_encoding_nonascii.py
@@ -1,2 +1,2 @@
 # coding: latin-1é
-print('µble')
+s = 'µble'

--- a/Tests/encoded_files/ok_encoding_whitespace.py
+++ b/Tests/encoded_files/ok_encoding_whitespace.py
@@ -1,2 +1,2 @@
  	# coding: 	 latin-1
-print('µble')
+s = 'µble'

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -16,11 +16,12 @@ import codecs
 import os
 import re
 import shutil
+import string
 import subprocess
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_mono, is_netcoreapp21, is_posix, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_mono, is_netcoreapp21, is_posix, run_test, skipUnlessIronPython, is_netcoreapp
 from iptest.misc_util import ip_supported_encodings
 
 class CodecTest(IronPythonTestCase):
@@ -258,23 +259,18 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(size, 3)
 
     def test_cp34951(self):
-        def internal_cp34951(sample1):
-            self.assertEqual(codecs.utf_8_decode(sample1), ('12\u20ac\x0a', 6))
+        def internal_cp34951(sample1, preamble, bom_len):
+            self.assertEqual(codecs.utf_8_decode(sample1), (preamble + '12\u20ac\x0a', 6 + bom_len))
             sample1 = sample1[:-1] # 12<euro>
-            self.assertEqual(codecs.utf_8_decode(sample1), ('12\u20ac', 5))
+            self.assertEqual(codecs.utf_8_decode(sample1), (preamble + '12\u20ac', 5 + bom_len))
             sample1 = sample1[:-1] # 12<uncomplete euro>
-            self.assertEqual(codecs.utf_8_decode(sample1), ('12', 2))
+            self.assertEqual(codecs.utf_8_decode(sample1), (preamble + '12', 2 + bom_len))
 
             sample1 = sample1 + b'x7f' # makes it invalid
-            try:
-                r = codecs.utf_8_decode(sample1)
-                self.assertTrue(False, "expected UncodeDecodeError not raised")
-            except Exception as e:
-                self.assertEqual(type(e), UnicodeDecodeError)
+            self.assertRaises(UnicodeDecodeError, codecs.utf_8_decode, sample1)
 
-        internal_cp34951(b'\x31\x32\xe2\x82\xac\x0a') # 12<euro><cr>
-        if is_cli:
-            internal_cp34951(b'\xef\xbb\xbf\x31\x32\xe2\x82\xac\x0a') # <BOM>12<euro><cr>
+        internal_cp34951(b'\x31\x32\xe2\x82\xac\x0a', '', 0) # 12<euro><cr>
+        internal_cp34951(b'\xef\xbb\xbf\x31\x32\xe2\x82\xac\x0a', '\ufeff', 3) # <BOM>12<euro><cr>
 
     def test_utf_8_encode(self):
         #sanity
@@ -345,9 +341,9 @@ class CodecTest(IronPythonTestCase):
     def test_misc_encodings(self):
         self.assertEqual('abc'.encode('utf-16'), b'\xff\xfea\x00b\x00c\x00')
         self.assertEqual('abc'.encode('utf-16-be'), b'\x00a\x00b\x00c')
-        for unicode_escape in ['unicode-escape', 'unicode escape']:
-            self.assertEqual('abc'.encode('unicode-escape'), b'abc')
-            self.assertEqual('abc\\u1234'.encode('unicode-escape'), b'abc\\\\u1234')
+        for unicode_escape in ['unicode-escape', 'unicode escape', 'unicode_escape']:
+            self.assertEqual('abc'.encode(unicode_escape), b'abc')
+            self.assertEqual('abc\\u1234'.encode(unicode_escape), b'abc\\\\u1234')
 
     def test_file_encodings(self):
         '''
@@ -367,19 +363,23 @@ class CodecTest(IronPythonTestCase):
                 # https://www.python.org/dev/peps/pep-0263/#defining-the-encoding
                 if not re.match('[-_.a-zA-Z0-9]+$', coding):
                     continue
-                
+
+                # wide-char Unicode encodings not supported by CPython
+                if not is_cli and re.match('utf[-_](16|32)', coding, re.IGNORECASE):
+                    continue
+
                 temp_mod_name = "test_encoding_" + coding.replace('-','_')
                 with open(os.path.join(self.temporary_dir, "tmp_encodings", temp_mod_name + ".py"), "w", encoding=coding) as f:
                     # wide-char Unicode encodings need a BOM to be recognized
                     if re.match('utf[-_](16|32).', coding, re.IGNORECASE):
                         f.write("\ufeff")
-                    
+
                     # UTF-8 with signature may only use 'utf-8' as coding (PEP-263)
                     if re.match('utf[-_]8[-_]sig$', coding, re.IGNORECASE):
                         coding = 'utf-8'
-                    
+
                     f.write("# coding: %s" % (coding))
-                
+
                 __import__(temp_mod_name)
                 os.remove(os.path.join(self.temporary_dir, "tmp_encodings", temp_mod_name + ".py"))
 
@@ -387,7 +387,7 @@ class CodecTest(IronPythonTestCase):
             #cleanup
             sys.path.remove(os.path.join(self.temporary_dir, "tmp_encodings"))
             shutil.rmtree(os.path.join(self.temporary_dir, "tmp_encodings"), True)
-        
+
 
         # handcrafted positive cases
         sys.path.append(os.path.join(self.test_dir, "encoded_files"))
@@ -398,7 +398,7 @@ class CodecTest(IronPythonTestCase):
 
             # Test that non-ASCII letters in the encoding name are not part of the name
             __import__('ok_encoding_nonascii')
-        
+
         finally:
             sys.path.remove(os.path.join(self.test_dir, "encoded_files"))
 
@@ -418,7 +418,10 @@ class CodecTest(IronPythonTestCase):
             with self.assertRaises(SyntaxError) as cm:
                 __import__("bad_latin1_nodecl")
             # CPython's message differs when importing this file, but is the same when running it
-            self.assertTrue(cm.exception.msg.startswith("Non-UTF-8 code starting with '\\xb5' in file"))
+            if is_cli:
+                self.assertTrue(cm.exception.msg.startswith("Non-UTF-8 code starting with '\\xb5' in file"))
+            else:
+                self.assertTrue(cm.exception.msg.startswith("(unicode error) 'utf-8' codec can't decode byte 0xb5 in position "))
 
             # Test that latin-1 encoded files result in error if a UTF-8 BOM is present
             with self.assertRaises(SyntaxError) as cm:
@@ -440,7 +443,7 @@ class CodecTest(IronPythonTestCase):
 
             # Test that using a non-breaking whitespace inside the magic comment removes the magic
             self.assertRaises(SyntaxError, __import__, "bad_latin1_nbsp")
-        
+
         finally:
             sys.path.remove(os.path.join(self.test_dir, "encoded_files"))
 
@@ -470,10 +473,18 @@ class CodecTest(IronPythonTestCase):
 
         self.assertEqual(len(t_err_lines), 0)
         if is_cli:
-            print("CodePlex 11334")
-            self.assertEqual(t_out_lines[0].rstrip(), b"\xe6ble")
+            # CodePlex 11334: IronPython uses active console codepage for output
+            # The test below assumes cp850, which is default on Western European/Northern American Windows
+            # Check active codepage in cmd.exe by running 'chcp' or 'mode'
+            # Check active codepage in powershell.exe by evaluating [Console]::OutputEncoding
+            import System
+            if not is_netcoreapp and System.Console.OutputEncoding.CodePage == 850:
+                self.assertEqual(t_out_lines[0].rstrip(), b"\xe6ble")
         else:
-            self.assertEqual(t_out_lines[0].rstrip(), b"\xb5ble")
+            # CPython uses Latin-1 for pipe output, unless overriden by PYTHONIOENCODING emvironment vairable
+            # The test below assumes PYTHONIOENCODING not defined, which is default
+            if not 'PYTHONIOENCODING' in os.environ:
+                self.assertEqual(t_out_lines[0].rstrip(), b"\xb5ble")
         self.assertEqual(len(t_out_lines), 1)
 
     def test_cp1214(self):
@@ -493,14 +504,11 @@ class CodecTest(IronPythonTestCase):
 
         codecs.register(my_func)
         allchars = ''.join([chr(i) for i in range(1, 256)])
-        try:
-            codecs.lookup(allchars)
-            self.assertUnreachable()
-        except LookupError:
-            pass
+        self.assertRaises(LookupError, codecs.lookup, allchars)
 
-        lowerchars = allchars.lower().replace(' ', '-')
-        for i in range(1, 255):
+        # Only ASCII chars are set to lowercase for lookup purposes
+        lowerchars = allchars.translate(str.maketrans(' ' + string.ascii_uppercase, '-' + string.ascii_lowercase))
+        for i in range(len(lowerchars)):
             if l[0][i] != lowerchars[i]:
                 self.assertTrue(False, 'bad chars at index %d: %r %r' % (i, l[0][i], lowerchars[i]))
 
@@ -517,9 +525,10 @@ class CodecTest(IronPythonTestCase):
             # make sure we're failing because we don't have encodings
             self.assertRaises(ImportError, __import__, 'encodings')
 
-    @unittest.skipIf(is_cli, 'https://github.com/IronLanguages/main/issues/255')
+    @unittest.skipIf(is_posix, "https://github.com/IronLanguages/ironpython3/issues/541")
     def test_cp1019(self):
         #--Test that bogus encodings fail properly
+        # https://github.com/IronLanguages/main/issues/255
         p = subprocess.Popen([sys.executable, os.path.join(self.test_dir, "encoded_files", "cp1019.py")], shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         t_in, t_out, t_err = (p.stdin, p.stdout, p.stderr)
         t_err_lines = t_err.readlines()
@@ -530,17 +539,16 @@ class CodecTest(IronPythonTestCase):
 
         self.assertEqual(len(t_out_lines), 0)
         self.assertTrue(t_err_lines[0].startswith(b"  File"))
+        # CPython's message differs when running this file, but is the same when importing it
         if is_cli:
-            self.assertTrue(t_err_lines[1].startswith(b"SyntaxError: encoding problem: with BOM"))
+            self.assertTrue(t_err_lines[1].startswith(b"SyntaxError: unknown encoding: garbage"))
         else:
             self.assertTrue(t_err_lines[1].startswith(b"SyntaxError: encoding problem: garbage"))
 
     def test_cp20302(self):
         import _codecs
         for encoding in ip_supported_encodings:
-            if encoding.lower() in ['cp1252']: #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=20302
-                continue
-            temp = _codecs.lookup(encoding)
+            _codecs.lookup(encoding)
 
     def test_charmap_build(self):
         decodemap = ''.join([chr(i).upper() if chr(i).islower() else chr(i).lower() for i in range(256)])
@@ -549,7 +557,9 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(codecs.charmap_encode('Hello World', 'strict', encodemap), (b'hELLO wORLD', 11))
 
     def test_gh16(self):
-        """https://github.com/IronLanguages/ironpython2/issues/16"""
+        """
+        https://github.com/IronLanguages/ironpython2/issues/16
+        """
         # test with a standard error handler
         res = "\xac\u1234\u20ac\u8000".encode("ptcp154", "backslashreplace")
         self.assertEqual(res, b"\xac\\u1234\\u20ac\\u8000")

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -6,7 +6,7 @@
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_mono, is_ironpython, run_test
+from iptest import IronPythonTestCase, is_cli, is_mono, run_test
 
 GETATTRIBUTE_CALLED = False
 class myint(int): pass
@@ -1781,7 +1781,7 @@ class ClassTest(IronPythonTestCase):
         self.assertRaises(TypeError, descr.__get__, None, int)
 
     def test_classmethod(self):
-        if is_ironpython: #http://ironpython.codeplex.com/workitem/27908
+        if is_cli: #http://ironpython.codeplex.com/workitem/27908
             self.assertRaises(TypeError, classmethod, 1)
         else:
             cm = classmethod(1)

--- a/Tests/test_codecs.py
+++ b/Tests/test_codecs.py
@@ -9,14 +9,14 @@
 import unittest
 import codecs
 
-from iptest import run_test, is_ironpython
+from iptest import run_test, is_cli
 
-if is_ironpython:
+if is_cli:
     import System.Text
 
 class CodecsTest(unittest.TestCase):
 
-    @unittest.skipUnless(is_ironpython, "Interop with CLI")
+    @unittest.skipUnless(is_cli, "Interop with CLI")
     def test_interop_ascii(self):
         self.assertEqual("abc".encode(System.Text.Encoding.ASCII), b"abc")
         self.assertEqual(b"abc".decode(System.Text.Encoding.ASCII), "abc")
@@ -26,7 +26,7 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual(b"abc".decode(us_ascii), "abc")
 
     def test_interop_utf8(self):
-        if is_ironpython:
+        if is_cli:
             utf_8 = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True)
             utf_8_sig = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True)
 
@@ -48,7 +48,7 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode('utf_8_sig'), "abć")
 
     def test_interop_utf16(self):
-        if is_ironpython:
+        if is_cli:
             utf_16 = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True)
             utf_16_le = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True)
             utf_16_be = System.Text.UnicodeEncoding(bigEndian=True, byteOrderMark=False, throwOnInvalidBytes=True)
@@ -77,7 +77,7 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual(b"\x00a\x00b\x01\x07".decode('utf_16_be'), "abć")
 
     def test_interop_utf32(self):
-        if is_ironpython:
+        if is_cli:
             utf_32 = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=True, throwOnInvalidCharacters=True)
             utf_32_le = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=False, throwOnInvalidCharacters=True)
             utf_32_be = System.Text.UTF32Encoding(bigEndian=True, byteOrderMark=False, throwOnInvalidCharacters=True)
@@ -126,14 +126,14 @@ class CodecsTest(unittest.TestCase):
             self.assertGreaterEqual(uee.exception.end, 3) # CPython 3 (single character), IronPython 4 (surrogate pair)
             self.assertLessEqual(uee.exception.end, 4)
 
-        if is_ironpython:
+        if is_cli:
             check_error1(System.Text.ASCIIEncoding(), 'us-ascii')
             check_error2(System.Text.ASCIIEncoding(), 'us-ascii')
             check_error1(System.Text.Encoding.ASCII, 'us-ascii')
             check_error2(System.Text.Encoding.ASCII, 'us-ascii')
 
         check_error1('ascii', 'ascii')
-        if not is_ironpython: # TODO: Replace PythonAsciiEncoding with ASCIIEncoding
+        if not is_cli: # TODO: Replace PythonAsciiEncoding with ASCIIEncoding
             check_error2('ascii', 'ascii')
 
     def test_interop_utf8_encode_exeption(self):
@@ -146,13 +146,13 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(uee.exception.start, 3)
             self.assertEqual(uee.exception.end, 4)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
             check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
             check_error(System.Text.Encoding.UTF8, 'utf-8')
 
         check_error('utf-8', 'utf-8')
-        if is_ironpython:
+        if is_cli:
             check_error('utf-8-sig', 'utf-8-sig')
         else:
             check_error('utf-8-sig', 'utf-8')
@@ -167,7 +167,7 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(uee.exception.start, 3)
             self.assertEqual(uee.exception.end, 4)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16LE')
             check_error(System.Text.UnicodeEncoding(bigEndian=True, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16BE')
 
@@ -182,7 +182,7 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 3)
             self.assertEqual(ude.exception.end, 4)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.ASCIIEncoding(), 'us-ascii')
             check_error(System.Text.Encoding.ASCII, 'us-ascii')
 
@@ -199,7 +199,7 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 4)
             self.assertEqual(ude.exception.end, 5)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
             check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
             check_error(System.Text.Encoding.UTF8, 'utf-8')
@@ -218,7 +218,7 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 7)
             self.assertEqual(ude.exception.end, 8)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
 
         check_error('utf-8', 'utf-8')
@@ -235,11 +235,11 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 4)
             self.assertEqual(ude.exception.end, 5)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
             check_error(System.Text.Encoding.UTF8, 'utf-8')
 
-        if is_ironpython:
+        if is_cli:
             check_error('utf-8-sig', 'utf-8-sig')
         else:
             check_error('utf-8-sig', 'utf-8')
@@ -252,7 +252,7 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.encoding, name)
             # regular utf-16 skips BOM
             # NOTE: CPython is not consistent in this behavior, possibly a CPython bug (utf-8-sig behaves correctly)
-            if is_ironpython:
+            if is_cli:
                 self.assertEqual(ude.exception.object, b'a\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00')
                 self.assertEqual(ude.exception.start, 6)
                 self.assertEqual(ude.exception.end, 8)
@@ -261,10 +261,10 @@ class CodecsTest(unittest.TestCase):
                 self.assertEqual(ude.exception.start, 8)
                 self.assertEqual(ude.exception.end, 10)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16LE')
 
-        if is_ironpython:
+        if is_cli:
             check_error('utf-16', 'utf-16') # TODO: should be 'utf-16LE'
         else:
             check_error('utf-16', 'utf-16-le')
@@ -280,10 +280,10 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 8)
             self.assertEqual(ude.exception.end, 10)
 
-        if is_ironpython:
+        if is_cli:
             check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True), 'utf-16LE')
 
-        if is_ironpython:
+        if is_cli:
             check_error('utf-16LE', 'utf-16LE')
         else:
             check_error('utf-16LE', 'utf-16-le')

--- a/Tests/test_codecs.py
+++ b/Tests/test_codecs.py
@@ -9,11 +9,14 @@
 import unittest
 import codecs
 
-import System.Text
+from iptest import run_test, is_ironpython
 
-from iptest import run_test
+if is_ironpython:
+    import System.Text
 
 class CodecsTest(unittest.TestCase):
+
+    @unittest.skipUnless(is_ironpython, "Interop with CLI")
     def test_interop_ascii(self):
         self.assertEqual("abc".encode(System.Text.Encoding.ASCII), b"abc")
         self.assertEqual(b"abc".decode(System.Text.Encoding.ASCII), "abc")
@@ -23,16 +26,17 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual(b"abc".decode(us_ascii), "abc")
 
     def test_interop_utf8(self):
-        utf_8 = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True)
-        utf_8_sig = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True)
+        if is_ironpython:
+            utf_8 = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True)
+            utf_8_sig = System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True)
 
-        self.assertEqual("abć".encode(utf_8), b"ab\xc4\x87")
-        self.assertEqual(b"ab\xc4\x87".decode(utf_8), "abć")
-        self.assertEqual(b"ab\xc4\x87".decode(utf_8_sig), "abć")
+            self.assertEqual("abć".encode(utf_8), b"ab\xc4\x87")
+            self.assertEqual(b"ab\xc4\x87".decode(utf_8), "abć")
+            self.assertEqual(b"ab\xc4\x87".decode(utf_8_sig), "abć")
 
-        self.assertEqual("abć".encode(utf_8_sig), b"\xef\xbb\xbfab\xc4\x87")
-        self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode(utf_8), "\ufeffabć")
-        self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode(utf_8_sig), "abć")
+            self.assertEqual("abć".encode(utf_8_sig), b"\xef\xbb\xbfab\xc4\x87")
+            self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode(utf_8), "\ufeffabć")
+            self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode(utf_8_sig), "abć")
 
         # now for comparison the same but with codec names
         self.assertEqual("abć".encode('utf_8'), b"ab\xc4\x87")
@@ -44,20 +48,21 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual(b"\xef\xbb\xbfab\xc4\x87".decode('utf_8_sig'), "abć")
 
     def test_interop_utf16(self):
-        utf_16 = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True)
-        utf_16_le = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True)
-        utf_16_be = System.Text.UnicodeEncoding(bigEndian=True, byteOrderMark=False, throwOnInvalidBytes=True)
+        if is_ironpython:
+            utf_16 = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True)
+            utf_16_le = System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True)
+            utf_16_be = System.Text.UnicodeEncoding(bigEndian=True, byteOrderMark=False, throwOnInvalidBytes=True)
 
-        self.assertEqual("abć".encode(utf_16), b"\xff\xfea\x00b\x00\x07\x01")
-        self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode(utf_16), "abć")
-        self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode(utf_16_le), "\ufeffabć")
+            self.assertEqual("abć".encode(utf_16), b"\xff\xfea\x00b\x00\x07\x01")
+            self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode(utf_16), "abć")
+            self.assertEqual(b"\xff\xfea\x00b\x00\x07\x01".decode(utf_16_le), "\ufeffabć")
 
-        self.assertEqual("abć".encode(utf_16_le), b"a\x00b\x00\x07\x01")
-        self.assertEqual(b"a\x00b\x00\x07\x01".decode(utf_16), "abć")
-        self.assertEqual(b"a\x00b\x00\x07\x01".decode(utf_16_le), "abć")
+            self.assertEqual("abć".encode(utf_16_le), b"a\x00b\x00\x07\x01")
+            self.assertEqual(b"a\x00b\x00\x07\x01".decode(utf_16), "abć")
+            self.assertEqual(b"a\x00b\x00\x07\x01".decode(utf_16_le), "abć")
 
-        self.assertEqual("abć".encode(utf_16_be), b"\x00a\x00b\x01\x07")
-        self.assertEqual(b"\x00a\x00b\x01\x07".decode(utf_16_be), "abć")
+            self.assertEqual("abć".encode(utf_16_be), b"\x00a\x00b\x01\x07")
+            self.assertEqual(b"\x00a\x00b\x01\x07".decode(utf_16_be), "abć")
 
         # now for comparison the same but with codec names
         self.assertEqual("abć".encode('utf_16'), b"\xff\xfea\x00b\x00\x07\x01")
@@ -72,20 +77,21 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual(b"\x00a\x00b\x01\x07".decode('utf_16_be'), "abć")
 
     def test_interop_utf32(self):
-        utf_32 = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=True, throwOnInvalidCharacters=True)
-        utf_32_le = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=False, throwOnInvalidCharacters=True)
-        utf_32_be = System.Text.UTF32Encoding(bigEndian=True, byteOrderMark=False, throwOnInvalidCharacters=True)
+        if is_ironpython:
+            utf_32 = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=True, throwOnInvalidCharacters=True)
+            utf_32_le = System.Text.UTF32Encoding(bigEndian=False, byteOrderMark=False, throwOnInvalidCharacters=True)
+            utf_32_be = System.Text.UTF32Encoding(bigEndian=True, byteOrderMark=False, throwOnInvalidCharacters=True)
 
-        self.assertEqual("abć".encode(utf_32), b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
-        self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32), "abć")
-        self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32_le), "\ufeffabć")
+            self.assertEqual("abć".encode(utf_32), b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
+            self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32), "abć")
+            self.assertEqual(b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32_le), "\ufeffabć")
 
-        self.assertEqual("abć".encode(utf_32_le), b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
-        self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32), "abć")
-        self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32_le), "abć")
+            self.assertEqual("abć".encode(utf_32_le), b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
+            self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32), "abć")
+            self.assertEqual(b"a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00".decode(utf_32_le), "abć")
 
-        self.assertEqual("abć".encode(utf_32_be), b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07")
-        self.assertEqual(b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07".decode(utf_32_be), "abć")
+            self.assertEqual("abć".encode(utf_32_be), b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07")
+            self.assertEqual(b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07".decode(utf_32_be), "abć")
 
         # now for comparison the same but with codec names
         self.assertEqual("abć".encode('utf_32'), b"\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00\x07\x01\x00\x00")
@@ -105,25 +111,30 @@ class CodecsTest(unittest.TestCase):
             with self.assertRaises(UnicodeEncodeError) as uee:
                 "abćẋyz".encode(encoding)
             self.assertEqual(uee.exception.encoding, name)
-            self.assertEqual(uee.exception.start, 2)
-            self.assertEqual(uee.exception.end, 3)
             self.assertEqual(uee.exception.object, "abćẋyz")
+            self.assertEqual(uee.exception.start, 2)
+            self.assertGreaterEqual(uee.exception.end, 3) # CPython 4 (all bad characers), IronPython 3 (first bad character)
+            self.assertLessEqual(uee.exception.end, 4)
 
         def check_error2(encoding, name):
             # exception on a surrogate pair
             with self.assertRaises(UnicodeEncodeError) as uee:
                 "ab🜋yz".encode(encoding)
             self.assertEqual(uee.exception.encoding, name)
-            self.assertEqual(uee.exception.start, 2)
-            self.assertEqual(uee.exception.end, 4)
             self.assertEqual(uee.exception.object, "ab🜋yz")
+            self.assertEqual(uee.exception.start, 2)
+            self.assertGreaterEqual(uee.exception.end, 3) # CPython 3 (single character), IronPython 4 (surrogate pair)
+            self.assertLessEqual(uee.exception.end, 4)
 
-        check_error1(System.Text.ASCIIEncoding(), 'us-ascii')
-        check_error2(System.Text.ASCIIEncoding(), 'us-ascii')
-        check_error1(System.Text.Encoding.ASCII, 'us-ascii')
-        check_error2(System.Text.Encoding.ASCII, 'us-ascii')
+        if is_ironpython:
+            check_error1(System.Text.ASCIIEncoding(), 'us-ascii')
+            check_error2(System.Text.ASCIIEncoding(), 'us-ascii')
+            check_error1(System.Text.Encoding.ASCII, 'us-ascii')
+            check_error2(System.Text.Encoding.ASCII, 'us-ascii')
+
         check_error1('ascii', 'ascii')
-        #check_error2('ascii', 'ascii') # TODO: Replace PythonAsciiEncoding with ASCIIEncoding
+        if not is_ironpython: # TODO: Replace PythonAsciiEncoding with ASCIIEncoding
+            check_error2('ascii', 'ascii')
 
     def test_interop_utf8_encode_exeption(self):
         def check_error(encoding, name):
@@ -131,15 +142,20 @@ class CodecsTest(unittest.TestCase):
             with self.assertRaises(UnicodeEncodeError) as uee:
                 "abć\uddddẋyz".encode(encoding)
             self.assertEqual(uee.exception.encoding, name)
+            self.assertEqual(uee.exception.object, "abć\uddddẋyz")
             self.assertEqual(uee.exception.start, 3)
             self.assertEqual(uee.exception.end, 4)
-            self.assertEqual(uee.exception.object, "abć\uddddẋyz")
 
-        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
-        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
-        check_error(System.Text.Encoding.UTF8, 'utf-8')
+        if is_ironpython:
+            check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
+            check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
+            check_error(System.Text.Encoding.UTF8, 'utf-8')
+
         check_error('utf-8', 'utf-8')
-        check_error('utf-8-sig', 'utf-8-sig') # TODO: CPython uses 'utf-8' as encoding name in UnicodeDecodeError
+        if is_ironpython:
+            check_error('utf-8-sig', 'utf-8-sig')
+        else:
+            check_error('utf-8-sig', 'utf-8')
 
     def test_interop_utf16_encode_exeption(self):
         def check_error(encoding, name):
@@ -147,13 +163,15 @@ class CodecsTest(unittest.TestCase):
             with self.assertRaises(UnicodeEncodeError) as uee:
                 "abć\uddddẋyz".encode(encoding)
             self.assertEqual(uee.exception.encoding, name)
+            self.assertEqual(uee.exception.object, "abć\uddddẋyz")
             self.assertEqual(uee.exception.start, 3)
             self.assertEqual(uee.exception.end, 4)
-            self.assertEqual(uee.exception.object, "abć\uddddẋyz")
 
-        check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16LE')
-        check_error(System.Text.UnicodeEncoding(bigEndian=True, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16BE')
-        check_error('utf-16', 'utf-16') # TODO: should be 'utf-16LE', CPython uses 'utf-16-le' here
+        if is_ironpython:
+            check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16LE')
+            check_error(System.Text.UnicodeEncoding(bigEndian=True, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16BE')
+
+        check_error('utf-16', 'utf-16') # TODO: should be 'utf-16LE' (CPython: 'utf-16-le')
 
     def test_interop_ascii_decode_exeption(self):
         def check_error(encoding, name):
@@ -164,8 +182,10 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 3)
             self.assertEqual(ude.exception.end, 4)
 
-        check_error(System.Text.ASCIIEncoding(), 'us-ascii')
-        check_error(System.Text.Encoding.ASCII, 'us-ascii')
+        if is_ironpython:
+            check_error(System.Text.ASCIIEncoding(), 'us-ascii')
+            check_error(System.Text.Encoding.ASCII, 'us-ascii')
+
         check_error('ascii', 'ascii')
 
     def test_interop_utf8_decode_exeption(self):
@@ -179,9 +199,11 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 4)
             self.assertEqual(ude.exception.end, 5)
 
-        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
-        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
-        check_error(System.Text.Encoding.UTF8, 'utf-8')
+        if is_ironpython:
+            check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
+            check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
+            check_error(System.Text.Encoding.UTF8, 'utf-8')
+
         check_error('utf-8', 'utf-8')
 
     def test_interop_utf8bom_decode_exeption(self):
@@ -196,7 +218,9 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 7)
             self.assertEqual(ude.exception.end, 8)
 
-        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
+        if is_ironpython:
+            check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=False, throwOnInvalidBytes=True), 'utf-8')
+
         check_error('utf-8', 'utf-8')
 
     def test_interop_utf8sigbom_decode_exeption(self):
@@ -211,9 +235,14 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 4)
             self.assertEqual(ude.exception.end, 5)
 
-        check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
-        check_error(System.Text.Encoding.UTF8, 'utf-8')
-        check_error('utf-8-sig', 'utf-8-sig') # TODO: CPython uses 'utf-8' as encoding name in UnicodeDecodeError
+        if is_ironpython:
+            check_error(System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=True, throwOnInvalidBytes=True), 'utf-8')
+            check_error(System.Text.Encoding.UTF8, 'utf-8')
+
+        if is_ironpython:
+            check_error('utf-8-sig', 'utf-8-sig')
+        else:
+            check_error('utf-8-sig', 'utf-8')
 
     def test_interop_utf16_decode_exception(self):
         def check_error(encoding, name):
@@ -222,13 +251,23 @@ class CodecsTest(unittest.TestCase):
                 b'\xff\xfea\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00'.decode(encoding,'strict')
             self.assertEqual(ude.exception.encoding, name)
             # regular utf-16 skips BOM
-            # NOTE: CPython is not consistent in this behavor, possibly a CPython bug
-            self.assertEqual(ude.exception.object, b'a\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00')
-            self.assertEqual(ude.exception.start, 6)
-            self.assertEqual(ude.exception.end, 8)
+            # NOTE: CPython is not consistent in this behavior, possibly a CPython bug (utf-8-sig behaves correctly)
+            if is_ironpython:
+                self.assertEqual(ude.exception.object, b'a\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00')
+                self.assertEqual(ude.exception.start, 6)
+                self.assertEqual(ude.exception.end, 8)
+            else:
+                self.assertEqual(ude.exception.object, codecs.BOM_UTF16_LE + b'a\x00b\x00\x07\x01\xdd\xdd\x8b\x1ey\x00z\x00')
+                self.assertEqual(ude.exception.start, 8)
+                self.assertEqual(ude.exception.end, 10)
 
-        check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16LE')
-        check_error('utf-16', 'utf-16') # TODO: should be 'utf-16LE', CPython uses 'utf-16-le' here
+        if is_ironpython:
+            check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=True, throwOnInvalidBytes=True), 'utf-16LE')
+
+        if is_ironpython:
+            check_error('utf-16', 'utf-16') # TODO: should be 'utf-16LE'
+        else:
+            check_error('utf-16', 'utf-16-le')
 
     def test_interop_utf16le_decode_exception(self):
         def check_error(encoding, name):
@@ -241,7 +280,12 @@ class CodecsTest(unittest.TestCase):
             self.assertEqual(ude.exception.start, 8)
             self.assertEqual(ude.exception.end, 10)
 
-        check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True), 'utf-16LE')
-        check_error('utf-16LE', 'utf-16LE')
+        if is_ironpython:
+            check_error(System.Text.UnicodeEncoding(bigEndian=False, byteOrderMark=False, throwOnInvalidBytes=True), 'utf-16LE')
+
+        if is_ironpython:
+            check_error('utf-16LE', 'utf-16LE')
+        else:
+            check_error('utf-16LE', 'utf-16-le')
 
 run_test(__name__)

--- a/Tests/test_excinfo.py
+++ b/Tests/test_excinfo.py
@@ -7,7 +7,7 @@
 import sys
 import unittest
 
-from iptest import is_ironpython, run_test
+from iptest import is_cli, run_test
 
 # Rules:
 # 1) thread has a current exception
@@ -477,7 +477,7 @@ class ExcInfoTest(unittest.TestCase):
             # exit is invoked when 'with' body exits (either via exception, branch)
             def __exit__(self, t, v, tb):
                 self.s.assertEqual(v[0], 15)  # exception passed in as local
-                if is_ironpython:  # http://ironpython.codeplex.com/workitem/27990
+                if is_cli:  # http://ironpython.codeplex.com/workitem/27990
                     self.s.A(None)  # but sys.exc_info() should not be set!!
                 else:
                     self.s.A(15)
@@ -524,7 +524,7 @@ class ExcInfoTest(unittest.TestCase):
 
             def __exit__(self, t, v, tb):
                 self.s.assertEqual(v[0], 34)  # gets failure from With block
-                if is_ironpython:  # http://ironpython.codeplex.com/workitem/27990
+                if is_cli:  # http://ironpython.codeplex.com/workitem/27990
                     self.s.A(15)  # gets failure from sys.exc_info() which is from outer except block
                 else:
                     self.s.A(34)
@@ -538,7 +538,7 @@ class ExcInfoTest(unittest.TestCase):
             with M2(self):
                 self.A(15)
                 raise ValueError(34)
-            if is_ironpython:  # http://ironpython.codeplex.com/workitem/27990
+            if is_cli:  # http://ironpython.codeplex.com/workitem/27990
                 self.A(15)
             else:
                 self.A(34)

--- a/Tests/test_exec.py
+++ b/Tests/test_exec.py
@@ -306,7 +306,7 @@ def test_eolns():
     def f3(sep): exec("exec '''x = 3$y = 5$'''".replace('$', sep))
 
     for x in [f1, f2, f3]:
-        if is_ironpython: #http://ironpython.codeplex.com/workitem/27991
+        if is_cli: #http://ironpython.codeplex.com/workitem/27991
             AssertError(SyntaxError, x, '\r\n')
             AssertError(SyntaxError, x, '\r')
         else:


### PR DESCRIPTION
This is primarily making `IronPython.test_codecs` and `IronPython.modules.io_related.test_codecs` runnable under CPython, to make sure that the assumptions made in those tests actually hold. And indeed there was one case where the test was assuming wrong. No practical significance, but still it demonstrated the validity of checking with CPython. Perhaps it would be good to extend the CI to run IronPython tests under CPython on each pull request. The tests can use `@unittest.skipUnlessIronPython` or conditionals `is_ironpython` or `is_cpython` to differentiate behaviour if needed. Any such difference will then be explicit.

Further, I (re)enabled some tests for cases that are no longer problematic or could easily be fixed (fixes included).