### PR TITLE
Implement UTF-32 support in codecs module

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -436,34 +436,8 @@ namespace IronPython.Modules {
         }
 
         private static int Utf32DetectByteorder(IList<byte> input) {
-            byte[] lePre = BOM_UTF32_LE;
-            if (input.Count > lePre.Length) {
-                bool match = true;
-                for (int i = 0; i < lePre.Length; i++) {
-                    if (input[i] != lePre[i]) {
-                        match = false;
-                        break;
-                    }
-                }
-                if (match) {
-                    return -1;
-                }
-            }
-
-            byte[] bePre = BOM_UTF32_BE;
-            if (input.Count > bePre.Length) {
-                bool match = true;
-                for (int i = 0; i < bePre.Length; i++) {
-                    if (input[i] != bePre[i]) {
-                        match = false;
-                        break;
-                    }
-                }
-                if (match) {
-                    return 1;
-                }
-            }
-
+            if (input.StartsWith(BOM_UTF32_LE)) return -1;
+            if (input.StartsWith(BOM_UTF32_BE)) return 1;
             return 0;
         }
 

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -414,30 +414,25 @@ namespace IronPython.Modules {
         public static PythonTuple utf_32_encode(CodeContext context, string input, string errors = "strict")
             => DoEncode(context, "utf-32", Utf32LeBomEncoding, input, errors, includePreamble: true).ToPythonTuple();
 
-        public static PythonTuple utf_32_ex_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors, int byteorder = 0, bool final = false) {
+        public static PythonTuple utf_32_ex_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors = "strict", int byteorder = 0, bool final = false) {
 
-            object output;
-            object numBytes;
+            Tuple<string, int> res;
 
             if (byteorder != 0) {
-                var res = (byteorder > 0) ?
-                    utf_32_be_decode(context, input, errors, final)
+                res = (byteorder > 0) ?
+                    DoDecode(context, "utf-32-be", Utf32BeEncoding, input, errors, final)
                 :
-                    utf_32_le_decode(context, input, errors, final);
-                output = res[0];
-                numBytes = res[1];
+                    DoDecode(context, "utf-32-le", Utf32LeEncoding, input, errors, final);
 
             } else {
                 byteorder = Utf32DetectByteorder(input);
-                var res = (byteorder > 0) ?
+                res = (byteorder > 0) ?
                     DoDecode(context, "utf-32-be", Utf32BeBomEncoding, input, errors, final)
                 :
                     DoDecode(context, "utf-32-le", Utf32LeBomEncoding, input, errors, final);
-                output = res.Item1;
-                numBytes = res.Item2;
             }
 
-            return PythonTuple.MakeTuple(output, numBytes, byteorder);
+            return PythonTuple.MakeTuple(res.Item1, res.Item2, byteorder);
         }
 
         private static int Utf32DetectByteorder(IList<byte> input) {
@@ -517,7 +512,7 @@ namespace IronPython.Modules {
         #region Private implementation
 
         private static Tuple<string, int> DoDecode(CodeContext context, string encodingName, Encoding encoding, [BytesConversion]IList<byte> input, string errors, bool final) {
-            var decoded = StringOps.DoDecode(context, input, errors, encodingName, encoding, discountPreamble: false, final, out int numBytes);
+            var decoded = StringOps.DoDecode(context, input, errors, encodingName, encoding, final, out int numBytes);
             return Tuple.Create(decoded, numBytes);
         }
 

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1720,14 +1720,9 @@ namespace IronPython.Runtime.Operations {
 #endif
 
         internal static string DoDecode(CodeContext context, IList<byte> s, string errors, string encoding, Encoding e)
-            => DoDecode(context, s, errors, encoding, e, true, true, out _);
+            => DoDecode(context, s, errors, encoding, e, true, out _);
 
-        internal static string DoDecode(CodeContext context, IList<byte> s, string errors, string encoding, Encoding e, bool final, out int numBytes)
-            => DoDecode(context, s, errors, encoding, e, true, final, out numBytes);
-
-        // If the beginning of input s is the same as the preamble in Encoding e, those bytes are never decoded or passed to output.
-        // However, if discountPreamble is false, the number of those bytes is included in total numBytes reported.
-        internal static string DoDecode(CodeContext context, IList<byte> s, string errors, string encoding, Encoding e, bool discountPreamble, bool final, out int numBytes) {
+        internal static string DoDecode(CodeContext context, IList<byte> s, string errors, string encoding, Encoding e, bool final, out int numBytes) {
             byte[] bytes = s as byte[] ?? ((s is Bytes b) ? b.GetUnsafeByteArray() : s.ToArray());
             int start = GetStartingOffset(e, bytes);
             int length = bytes.Length - start;
@@ -1767,7 +1762,7 @@ namespace IronPython.Runtime.Operations {
                 throw;
             }
 
-            numBytes = bytes.Length - (discountPreamble ? start : 0);
+            numBytes = bytes.Length;
 #if FEATURE_ENCODING
             if (e.DecoderFallback is ExceptionFallBack fallback) {
                 byte[] badBytes = fallback.buffer.badBytes;

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1780,18 +1780,7 @@ namespace IronPython.Runtime.Operations {
         /// </summary>
         private static int GetStartingOffset(Encoding e, byte[] bytes) {
             byte[] preamble = e.GetPreamble();
-
-            if (preamble.Length != 0 && bytes.Length >= preamble.Length) {
-                for (int i = 0; i < preamble.Length; i++) {
-                    if (bytes[i] != preamble[i]) {
-                        return 0;
-                    }
-                }
-
-                return preamble.Length;
-            }
-
-            return 0;
+            return bytes.StartsWith(preamble) ? preamble.Length : 0;
         }
 
         internal static Bytes RawEncode(CodeContext/*!*/ context, string s, string encoding, string errors) {

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -300,6 +300,17 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(num_processed, 4 * 4)
         self.assertGreater(detected, order)
 
+        # When only BOM present, and no order given: the decoded string is empty but the UTF-32 variant is detected
+        string, num_processed, detected = codecs.utf_32_ex_decode(codecs.BOM_UTF32_LE, 'strict', order)
+        self.assertEqual(string, "")
+        self.assertEqual(num_processed, 4)
+        self.assertLess(detected, order)
+
+        string, num_processed, detected = codecs.utf_32_ex_decode(codecs.BOM_UTF32_BE, 'strict', order)
+        self.assertEqual(string, "")
+        self.assertEqual(num_processed, 4)
+        self.assertGreater(detected, order)
+
         # When no BOM, and no order given: on little-endian systems, UTF-32 defaults to UTF-32-LE, but no BOM detection
         string, num_processed, detected = codecs.utf_32_ex_decode(abc_le, 'strict', order)
         self.assertEqual(string, 'abc')

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -86,16 +86,16 @@ class CodecTest(IronPythonTestCase):
 
     def test_utf_16_ex_decode(self):
         #sanity
-        new_str, size, zero = codecs.utf_16_ex_decode(b"abc")
+        new_str, num_processed, zero = codecs.utf_16_ex_decode(b"abc")
         self.assertEqual(new_str, '\u6261')
-        self.assertEqual(size, 2)
+        self.assertEqual(num_processed, 2)
         self.assertEqual(zero, 0)
 
     def test_charmap_decode(self):
         #Sanity
-        new_str, size = codecs.charmap_decode(b"abc")
+        new_str, num_processed = codecs.charmap_decode(b"abc")
         self.assertEqual(new_str, 'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
         self.assertEqual(codecs.charmap_decode(b"a", 'strict', {ord('a') : 'a'})[0], 'a')
         self.assertEqual(codecs.charmap_decode(b"a", "replace", {})[0], '\ufffd')
         self.assertEqual(codecs.charmap_decode(b"a", "replace", {ord('a'): None})[0], '\ufffd')
@@ -125,51 +125,51 @@ class CodecTest(IronPythonTestCase):
 
     def test_raw_unicode_escape_decode(self):
         #sanity
-        new_str, size = codecs.raw_unicode_escape_decode("abc")
+        new_str, num_processed = codecs.raw_unicode_escape_decode("abc")
         self.assertEqual(new_str, 'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_raw_unicode_escape_encode(self):
         #sanity
-        new_str, size = codecs.raw_unicode_escape_encode("abc")
+        new_str, num_processed = codecs.raw_unicode_escape_encode("abc")
         self.assertEqual(new_str, b'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_utf_7_decode(self):
         #sanity
-        new_str, size = codecs.utf_7_decode(b"abc")
+        new_str, num_processed = codecs.utf_7_decode(b"abc")
         self.assertEqual(new_str, 'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_utf_7_encode(self):
         #sanity
-        new_str, size = codecs.utf_7_encode("abc")
+        new_str, num_processed = codecs.utf_7_encode("abc")
         self.assertEqual(new_str, b'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_ascii_decode(self):
         #sanity
-        new_str, size = codecs.ascii_decode(b"abc")
+        new_str, num_processed = codecs.ascii_decode(b"abc")
         self.assertEqual(new_str, 'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_ascii_encode(self):
         #sanity
-        new_str, size = codecs.ascii_encode("abc")
+        new_str, num_processed = codecs.ascii_encode("abc")
         self.assertEqual(new_str, b'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_latin_1_decode(self):
         #sanity
-        new_str, size = codecs.latin_1_decode(b"abc")
+        new_str, num_processed = codecs.latin_1_decode(b"abc")
         self.assertEqual(new_str, 'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_latin_1_encode(self):
         #sanity
-        new_str, size = codecs.latin_1_encode("abc")
+        new_str, num_processed = codecs.latin_1_encode("abc")
         self.assertEqual(new_str, b'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
         # so many ways to express latin 1...
         for x in ['iso-8859-1', 'iso8859-1', '8859', 'cp819', 'latin', 'latin1', 'L1']:
@@ -218,43 +218,162 @@ class CodecTest(IronPythonTestCase):
 
     def test_utf_16_be_decode(self):
         #sanity
-        new_str, size = codecs.utf_16_be_decode(b"abc")
+        new_str, num_processed = codecs.utf_16_be_decode(b"abc")
         self.assertEqual(new_str, '\u6162')
-        self.assertEqual(size, 2)
+        self.assertEqual(num_processed, 2)
 
     def test_utf_16_be_encode(self):
         #sanity
-        new_str, size = codecs.utf_16_be_encode("abc")
+        new_str, num_processed = codecs.utf_16_be_encode("abc")
         self.assertEqual(new_str, b'\x00a\x00b\x00c')
-        self.assertEqual(size, 3)
-
-    def test_utf_16_decode(self):
-        #sanity
-        new_str, size = codecs.utf_16_decode(b"abc")
-        self.assertEqual(new_str, '\u6261')
-        self.assertEqual(size, 2)
+        self.assertEqual(num_processed, 3)
 
     def test_utf_16_le_decode(self):
         #sanity
-        new_str, size = codecs.utf_16_le_decode(b"abc")
+        new_str, num_processed = codecs.utf_16_le_decode(b"abc")
         self.assertEqual(new_str, '\u6261')
-        self.assertEqual(size, 2)
+        self.assertEqual(num_processed, 2)
 
     def test_utf_16_le_encode(self):
         #sanity
-        new_str, size = codecs.utf_16_le_encode("abc")
+        new_str, num_processed = codecs.utf_16_le_encode("abc")
         self.assertEqual(new_str, b'a\x00b\x00c\x00')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
-    def test_utf_16_le_str_encode(self):
-        for x in ('utf_16_le', 'UTF-16LE', 'utf-16le'):
+    def test_utf_16_decode(self):
+        #sanity
+        new_str, num_processed = codecs.utf_16_decode(b"abc")
+        self.assertEqual(new_str, '\u6261')
+        self.assertEqual(num_processed, 2)
+
+    def test_utf_16_encode(self):
+        #Sanity
+        self.assertEqual(codecs.utf_16_encode("abc"), (b'\xff\xfea\x00b\x00c\x00', 3))
+
+    def test_utf_16_le_encode_alias(self):
+        for x in ('utf_16_le', 'UTF-16LE', 'utf-16le', 'utf-16-le'):
             self.assertEqual('abc'.encode(x), b'a\x00b\x00c\x00')
+
+    def test_utf_32_be_decode(self):
+        string, num_processed = codecs.utf_32_be_decode(b'\0\0\0a\0\0\0b\0\0\0c')
+        self.assertEqual(string, "abc")
+        self.assertEqual(num_processed, 3 * 4)
+
+        string, num_processed = codecs.utf_32_be_decode(codecs.BOM_UTF32_BE + b'\0\0\0a\0\0\0b\0\0\0c')
+        self.assertEqual(string, "\uFEFFabc")
+        self.assertEqual(num_processed, 4 * 4)
+
+    def test_utf_32_be_encode(self):
+        data, num_processed = codecs.utf_32_be_encode("abc")
+        self.assertEqual(data, b'\0\0\0a\0\0\0b\0\0\0c')
+        self.assertEqual(num_processed, 3)
+
+    def test_utf_32_le_decode(self):
+        string, num_processed = codecs.utf_32_le_decode(b'a\0\0\0b\0\0\0c\0\0\0')
+        self.assertEqual(string, "abc")
+        self.assertEqual(num_processed, 3 * 4)
+
+        string, num_processed = codecs.utf_32_le_decode(codecs.BOM_UTF32_LE + b'a\0\0\0b\0\0\0c\0\0\0')
+        self.assertEqual(string, "\uFEFFabc")
+        self.assertEqual(num_processed, 4 * 4)
+
+    def test_utf_32_le_encode(self):
+        data, num_processed = codecs.utf_32_le_encode("abc")
+        self.assertEqual(data, b'a\0\0\0b\0\0\0c\0\0\0')
+        self.assertEqual(num_processed, 3)
+
+    def test_utf_32_ex_decode(self):
+        abc_le = b'a\0\0\0b\0\0\0c\0\0\0'
+        abc_be = b'\0\0\0a\0\0\0b\0\0\0c'
+        bom_abc_le = codecs.BOM_UTF32_LE + abc_le
+        bom_abc_be = codecs.BOM_UTF32_BE + abc_be
+
+        order = 0
+        # When BOM present, and no order given: BOM is removed and the proper UTF-32 variant is automatically detected and used
+        string, num_processed, detected = codecs.utf_32_ex_decode(bom_abc_le, 'strict', order)
+        self.assertEqual(string, "abc")
+        self.assertEqual(num_processed, 4 * 4)
+        self.assertLess(detected, order)
+
+        string, num_processed, detected = codecs.utf_32_ex_decode(bom_abc_be, 'strict', order)
+        self.assertEqual(string, "abc")
+        self.assertEqual(num_processed, 4 * 4)
+        self.assertGreater(detected, order)
+
+        # When no BOM, and no order given: on little-endian systems, UTF-32 defaults to UTF-32-LE, but no BOM detection
+        string, num_processed, detected = codecs.utf_32_ex_decode(abc_le, 'strict', order)
+        self.assertEqual(string, 'abc')
+        self.assertEqual(num_processed, 3 * 4)
+        self.assertEqual(detected, order)
+
+        with self.assertRaises(UnicodeDecodeError):
+            codecs.utf_32_ex_decode(abc_be, 'strict', order)
+
+        # When BOM present, and order given: BOM must match order and is passed to output
+        for order in [1, 42]:
+            string, num_processed, detected = codecs.utf_32_ex_decode(bom_abc_be, 'strict', order)
+            self.assertEqual(string, "\uFEFFabc")
+            self.assertEqual(num_processed, 4 * 4)
+            self.assertEqual(detected, order)
+
+            with self.assertRaises(UnicodeDecodeError):
+                codecs.utf_32_ex_decode(bom_abc_be, 'strict', -order)
+
+            string, num_processed, detected = codecs.utf_32_ex_decode(bom_abc_le, 'strict', -order)
+            self.assertEqual(string, "\uFEFFabc")
+            self.assertEqual(num_processed, 4 * 4)
+            self.assertEqual(detected, -order)
+
+            with self.assertRaises(UnicodeDecodeError):
+                codecs.utf_32_ex_decode(bom_abc_le, 'strict', order)
+
+        # When no BOM, and order given: on little-endian systems, UTF-32 defaults to UTF-32-LE
+        for order in [1, 42]:
+            string, num_processed, detected = codecs.utf_32_ex_decode(abc_be, 'strict', order)
+            self.assertEqual(string, "abc")
+            self.assertEqual(num_processed, 3 * 4)
+            self.assertEqual(detected, order)
+
+            with self.assertRaises(UnicodeDecodeError):
+                codecs.utf_32_ex_decode(abc_be, 'strict', -order)
+
+            string, num_processed, detected = codecs.utf_32_ex_decode(abc_le, 'strict', -order)
+            self.assertEqual(string, "abc")
+            self.assertEqual(num_processed, 3 * 4)
+            self.assertEqual(detected, -order)
+
+            with self.assertRaises(UnicodeDecodeError):
+                codecs.utf_32_ex_decode(abc_le, 'strict', order)
+
+    def test_utf_32_decode(self):
+        # When BOM present: it is removed and the proper UTF-32 variant is automatically selected
+        string, num_processed = codecs.utf_32_decode(codecs.BOM_UTF32_LE + b'a\0\0\0b\0\0\0c\0\0\0')
+        self.assertEqual(string, "abc")
+        self.assertEqual(num_processed, 4 * 4)
+
+        string, num_processed = codecs.utf_32_decode(codecs.BOM_UTF32_BE + b'\0\0\0a\0\0\0b\0\0\0c')
+        self.assertEqual(string, "abc")
+        self.assertEqual(num_processed, 4 * 4)
+
+        # When no BOM: on little-endian systems, UTF-32 defaults to UTF-32-LE
+        string, num_processed = codecs.utf_32_decode(b'a\0\0\0b\0\0\0c\0\0\0')
+        self.assertEqual(string, 'abc')
+        self.assertEqual(num_processed, 3 * 4)
+
+        with self.assertRaises(UnicodeDecodeError):
+            codecs.utf_32_decode(b'\0\0\0a\0\0\0b\0\0\0c')
+
+    def test_utf_32_encode(self):
+        # On little-endian systems, UTF-32 encodes in UTF-32-LE prefixed with BOM
+        data, num_processed = codecs.utf_32_encode("abc")
+        self.assertEqual(data, codecs.BOM_UTF32 + b'a\0\0\0b\0\0\0c\0\0\0')
+        self.assertEqual(num_processed, 3)
 
     def test_utf_8_decode(self):
         #sanity
-        new_str, size = codecs.utf_8_decode(b"abc")
+        new_str, num_processed = codecs.utf_8_decode(b"abc")
         self.assertEqual(new_str, 'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_cp34951(self):
         def internal_cp34951(sample1, preamble, bom_len):
@@ -272,9 +391,9 @@ class CodecTest(IronPythonTestCase):
 
     def test_utf_8_encode(self):
         #sanity
-        new_str, size = codecs.utf_8_encode("abc")
+        new_str, num_processed = codecs.utf_8_encode("abc")
         self.assertEqual(new_str, b'abc')
-        self.assertEqual(size, 3)
+        self.assertEqual(num_processed, 3)
 
     def test_charmap_encode(self):
         #Sanity
@@ -331,10 +450,6 @@ class CodecTest(IronPythonTestCase):
     @skipUnlessIronPython()
     def test_unicode_escape_encode(self):
         self.assertRaises(NotImplementedError, codecs.unicode_escape_encode, "abc")
-
-    def test_utf_16_encode(self):
-        #Sanity
-        self.assertEqual(codecs.utf_16_encode("abc"), (b'\xff\xfea\x00b\x00c\x00', 3))
 
     def test_misc_encodings(self):
         self.assertEqual('abc'.encode('utf-16'), b'\xff\xfea\x00b\x00c\x00')

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -169,20 +169,20 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF32LETest('test_readline'))
         suite.addTest(test.test_codecs.UTF32LETest('test_readlinequeue'))
         suite.addTest(test.test_codecs.UTF32LETest('test_simple'))
-        #suite.addTest(test.test_codecs.UTF32Test('test_badbom')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_bug1098990_a')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_bug1098990_b'))# TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_bug1175396')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_decoder_state')) # TypeError: expected str, got bytes
+        #suite.addTest(test.test_codecs.UTF32Test('test_badbom')) # AssertionError: UnicodeError not raised by read; 'strict' error handler in non-final case is too lax
+        suite.addTest(test.test_codecs.UTF32Test('test_bug1098990_a'))
+        suite.addTest(test.test_codecs.UTF32Test('test_bug1098990_b'))
+        suite.addTest(test.test_codecs.UTF32Test('test_bug1175396'))
+        #suite.addTest(test.test_codecs.UTF32Test('test_decoder_state')) # UnicodeError: UTF-32 stream does not start with BOM
         suite.addTest(test.test_codecs.UTF32Test('test_errors'))
         suite.addTest(test.test_codecs.UTF32Test('test_handlers'))
-        #suite.addTest(test.test_codecs.UTF32Test('test_issue8941')) # AssertionError: '\ud800\udc00\ud800\udc00\ud800\udc00\ud80[12243 chars]dc00' != 'ĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀĀ[979 chars]ĀĀĀĀ'
+        suite.addTest(test.test_codecs.UTF32Test('test_issue8941'))
         suite.addTest(test.test_codecs.UTF32Test('test_lone_surrogates'))
-        #suite.addTest(test.test_codecs.UTF32Test('test_mixed_readline_and_read')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_only_one_bom')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_partial')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_readline')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.UTF32Test('test_readlinequeue')) # TypeError: expected str, got bytes
+        suite.addTest(test.test_codecs.UTF32Test('test_mixed_readline_and_read'))
+        suite.addTest(test.test_codecs.UTF32Test('test_only_one_bom'))
+        #suite.addTest(test.test_codecs.UTF32Test('test_partial')) # UnicodeError: UTF-32 stream does not start with BOM
+        suite.addTest(test.test_codecs.UTF32Test('test_readline'))
+        suite.addTest(test.test_codecs.UTF32Test('test_readlinequeue'))
         suite.addTest(test.test_codecs.UTF7Test('test_ascii'))
         suite.addTest(test.test_codecs.UTF7Test('test_bug1098990_a'))
         suite.addTest(test.test_codecs.UTF7Test('test_bug1098990_b'))


### PR DESCRIPTION
Some of the test from stdlib now pass. Additional tests added.

Something like this will have to be done for UTF-16 as well, but in a separate PR.