### PR TITLE
Implemented Support pow of negative numbers with fractional powers #504

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ launchSettings.json
 *.o
 /Src/ctypes_test/*.pyd
 /Src/ctypes_test/*.pyd
+/Src/StdLib/Lib/__pycache__
+/Tests/modules/misc/test_data.gz

--- a/Src/IronPython/Runtime/Operations/FloatOps.cs
+++ b/Src/IronPython/Runtime/Operations/FloatOps.cs
@@ -400,7 +400,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static double Power(double x, double y) {
+        public static object Power(double x, double y) {
             if (x == 1.0 || y == 0.0) {
                 return 1.0;
             } else if (double.IsNaN(x) || double.IsNaN(y)) {
@@ -440,7 +440,8 @@ namespace IronPython.Runtime.Operations {
                     return y > 0 ? double.PositiveInfinity : 0.0;
                 }
             } else if (x < 0 && (Math.Floor(y) != y)) {
-                throw PythonOps.ValueError("negative number cannot be raised to fraction");
+                // the return value is complex when x is negative and y is fractional. 
+                return ComplexOps.Power(x, y);
             }
 
             return PythonOps.CheckMath(x, y, Math.Pow(x, y));
@@ -1072,8 +1073,9 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static float Power(float x, float y) {
-            return (float)DoubleOps.Power(x, y);
+        public static object Power(float x, float y) {
+            // the return value is complex when x is negative and y is fractional. 
+            return DoubleOps.Power(x, y);
         }
 
         [StaticExtensionMethod]

--- a/Src/StdLib/Lib/test/test_pow.py
+++ b/Src/StdLib/Lib/test/test_pow.py
@@ -1,6 +1,22 @@
 import test.support, unittest
 
 class PowTest(unittest.TestCase):
+    # taken from test_complex.py
+    # needed for negative real values with a fractional exponent    
+    def assertAlmostEqual(self, a, b):
+        if isinstance(a, complex):
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a.real, b.real)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a.real, b)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, 0.)
+        else:
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a, b.real)
+                unittest.TestCase.assertAlmostEqual(self, 0., b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a, b)
 
     def powtest(self, type):
         if type != float:
@@ -55,6 +71,13 @@ class PowTest(unittest.TestCase):
                             pow(type(i),j,k),
                             pow(type(i),j)% type(k)
                         )
+
+        # sanity check that when the exponent is of the given type the power operation is successful
+        asseq(pow(3, type(3)), 27)
+        asseq(3 ** type(3), 27)
+
+        asseq(pow(type(3), type(3)), 27)
+        asseq(type(3) ** type(3), 27)
 
     def test_powint(self):
         self.powtest(int)
@@ -121,6 +144,22 @@ class PowTest(unittest.TestCase):
             eq(pow(a, fiveto), expected)
             eq(pow(a, -fiveto), expected)
         eq(expected, 1.0)   # else we didn't push fiveto to evenness
+
+    def test_pow_negvaluefractionalexponent(self):
+        # Support pow of negative numbers with fractional powers #504
+        self.assertAlmostEqual((-1)**0.5, 1j)
+        self.assertAlmostEqual(pow(-1, 0.5), 1j)
+
+        self.assertAlmostEqual((-4)**0.5, 2j)
+        self.assertAlmostEqual(pow(-4, 0.5), 2j)
+
+        # 0.7071067811865476 = 0.5**0.5
+        expected = 0.7071067811865476 + 0.7071067811865476j
+        self.assertAlmostEqual((-1)**0.25, expected)
+        self.assertAlmostEqual(pow(-1, 0.25), expected)
+
+        self.assertAlmostEqual(pow(-1, 1/3), 0.5 + 0.8660254037844386j)
+        self.assertAlmostEqual((-1)**(1/3), 0.5 + 0.8660254037844386j)
 
 def test_main():
     test.support.run_unittest(PowTest)

--- a/Src/StdLib/Lib/test/test_pow.py
+++ b/Src/StdLib/Lib/test/test_pow.py
@@ -1,22 +1,6 @@
 import test.support, unittest
 
 class PowTest(unittest.TestCase):
-    # taken from test_complex.py
-    # needed for negative real values with a fractional exponent    
-    def assertAlmostEqual(self, a, b):
-        if isinstance(a, complex):
-            if isinstance(b, complex):
-                unittest.TestCase.assertAlmostEqual(self, a.real, b.real)
-                unittest.TestCase.assertAlmostEqual(self, a.imag, b.imag)
-            else:
-                unittest.TestCase.assertAlmostEqual(self, a.real, b)
-                unittest.TestCase.assertAlmostEqual(self, a.imag, 0.)
-        else:
-            if isinstance(b, complex):
-                unittest.TestCase.assertAlmostEqual(self, a, b.real)
-                unittest.TestCase.assertAlmostEqual(self, 0., b.imag)
-            else:
-                unittest.TestCase.assertAlmostEqual(self, a, b)
 
     def powtest(self, type):
         if type != float:
@@ -71,13 +55,6 @@ class PowTest(unittest.TestCase):
                             pow(type(i),j,k),
                             pow(type(i),j)% type(k)
                         )
-
-        # sanity check that when the exponent is of the given type the power operation is successful
-        asseq(pow(3, type(3)), 27)
-        asseq(3 ** type(3), 27)
-
-        asseq(pow(type(3), type(3)), 27)
-        asseq(type(3) ** type(3), 27)
 
     def test_powint(self):
         self.powtest(int)
@@ -144,22 +121,6 @@ class PowTest(unittest.TestCase):
             eq(pow(a, fiveto), expected)
             eq(pow(a, -fiveto), expected)
         eq(expected, 1.0)   # else we didn't push fiveto to evenness
-
-    def test_pow_negvaluefractionalexponent(self):
-        # Support pow of negative numbers with fractional powers #504
-        self.assertAlmostEqual((-1)**0.5, 1j)
-        self.assertAlmostEqual(pow(-1, 0.5), 1j)
-
-        self.assertAlmostEqual((-4)**0.5, 2j)
-        self.assertAlmostEqual(pow(-4, 0.5), 2j)
-
-        # 0.7071067811865476 = 0.5**0.5
-        expected = 0.7071067811865476 + 0.7071067811865476j
-        self.assertAlmostEqual((-1)**0.25, expected)
-        self.assertAlmostEqual(pow(-1, 0.25), expected)
-
-        self.assertAlmostEqual(pow(-1, 1/3), 0.5 + 0.8660254037844386j)
-        self.assertAlmostEqual((-1)**(1/3), 0.5 + 0.8660254037844386j)
 
 def test_main():
     test.support.run_unittest(PowTest)

--- a/Tests/test_pow.py
+++ b/Tests/test_pow.py
@@ -1,0 +1,62 @@
+import test.support, unittest
+
+class PowTest(unittest.TestCase):
+    # taken from test_complex.py
+    # needed for negative real values with a fractional exponent    
+    def assertAlmostEqual(self, a, b):
+        if isinstance(a, complex):
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a.real, b.real)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a.real, b)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, 0.)
+        else:
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a, b.real)
+                unittest.TestCase.assertAlmostEqual(self, 0., b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a, b)
+
+    def pow_exponent_of_type_test(self, type):
+        asseq = self.assertEqual
+        if type == float:
+            asseq = self.assertAlmostEqual
+
+        # sanity check that when the exponent is of the given type the power operation is successful
+        asseq(pow(3, type(3)), 27)
+        asseq(3 ** type(3), 27)
+
+        asseq(pow(type(3), type(3)), 27)
+        asseq(type(3) ** type(3), 27)
+
+    def test_pow_exponent_of_type_test_int(self):
+        self.pow_exponent_of_type_test(int)
+
+    def test_pow_exponent_of_type_test_long(self):
+        self.pow_exponent_of_type_test(int)
+
+    def test_pow_exponent_of_type_test_float(self):
+        self.pow_exponent_of_type_test(float)
+
+    def test_pow_negvaluefractionalexponent(self):
+        # Support pow of negative numbers with fractional powers #504
+        self.assertAlmostEqual((-1)**0.5, 1j)
+        self.assertAlmostEqual(pow(-1, 0.5), 1j)
+
+        self.assertAlmostEqual((-4)**0.5, 2j)
+        self.assertAlmostEqual(pow(-4, 0.5), 2j)
+
+        # 0.7071067811865476 = 0.5**0.5
+        expected = 0.7071067811865476 + 0.7071067811865476j
+        self.assertAlmostEqual((-1)**0.25, expected)
+        self.assertAlmostEqual(pow(-1, 0.25), expected)
+
+        self.assertAlmostEqual(pow(-1, 1/3), 0.5 + 0.8660254037844386j)
+        self.assertAlmostEqual((-1)**(1/3), 0.5 + 0.8660254037844386j)
+
+def test_main():
+    test.support.run_unittest(PowTest)
+
+if __name__ == "__main__":
+    test_main()


### PR DESCRIPTION
Hopefully this is the right way to do it.

The float path is tested through test_clrnuminterop.py.