### PR TITLE
Modify tests in stdlib to account for UTF-16 strings in .NET

### DIFF
--- a/Src/StdLib/Lib/test/test_codecs.py
+++ b/Src/StdLib/Lib/test/test_codecs.py
@@ -682,6 +682,11 @@ class UTF16LETest(ReadTest, unittest.TestCase):
             (b'\x00\xd8A\x00', '\ufffdA'),
             (b'\x00\xdcA\x00', '\ufffdA'),
         ]
+        if sys.implementation.name == 'ironpython':
+            # IronPython's strings are in the UTF-16 form thus decoding
+            # a surrogate pair always results in two characters. Consequently,
+            # decoding a broken surrogate pair results in TWO U+FFFD
+            tests[4] = (b'\x00\xd8A', '\ufffd\ufffd')
         for raw, expected in tests:
             self.assertRaises(UnicodeDecodeError, codecs.utf_16_le_decode,
                               raw, 'strict', True)
@@ -726,6 +731,11 @@ class UTF16BETest(ReadTest, unittest.TestCase):
             (b'\xd8\x00\x00A', '\ufffdA'),
             (b'\xdc\x00\x00A', '\ufffdA'),
         ]
+        if sys.implementation.name == 'ironpython':
+            # IronPython's strings are in the UTF-16 form thus decoding
+            # a surrogate pair always results in two characters. Consequently,
+            # decoding a broken surrogate pair results in TWO U+FFFD
+            tests[4] = (b'\xd8\x00\xdc', '\ufffd\ufffd')
         for raw, expected in tests:
             self.assertRaises(UnicodeDecodeError, codecs.utf_16_be_decode,
                               raw, 'strict', True)

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -114,7 +114,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF16BETest('test_bug1098990_a'))
         suite.addTest(test.test_codecs.UTF16BETest('test_bug1098990_b'))
         suite.addTest(test.test_codecs.UTF16BETest('test_bug1175396'))
-        #suite.addTest(test.test_codecs.UTF16BETest('test_errors')) # AssertionError: '��' != '�' when decoding b'\xd8\x00\xdc' w/ replace
+        suite.addTest(test.test_codecs.UTF16BETest('test_errors'))
         suite.addTest(test.test_codecs.UTF16BETest('test_lone_surrogates'))
         suite.addTest(test.test_codecs.UTF16BETest('test_mixed_readline_and_read'))
         suite.addTest(test.test_codecs.UTF16BETest('test_nonbmp'))
@@ -126,7 +126,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF16LETest('test_bug1098990_a'))
         suite.addTest(test.test_codecs.UTF16LETest('test_bug1098990_b'))
         suite.addTest(test.test_codecs.UTF16LETest('test_bug1175396'))
-        #suite.addTest(test.test_codecs.UTF16LETest('test_errors')) # AssertionError: '��' != '�' when decoding b'\x00\xd8A' w/ replace
+        suite.addTest(test.test_codecs.UTF16LETest('test_errors'))
         suite.addTest(test.test_codecs.UTF16LETest('test_lone_surrogates'))
         suite.addTest(test.test_codecs.UTF16LETest('test_mixed_readline_and_read'))
         suite.addTest(test.test_codecs.UTF16LETest('test_nonbmp'))


### PR DESCRIPTION
IronPython's strings are in the UTF-16 form thus decoding a surrogate pair always results in two characters. Consequently, decoding a broken surrogate pair with a `replace` error handler results in **two** U+FFFD rather than one as it is in case of CPython.