### PR TITLE
Deprecate unicode_internal codec

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime;
+using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
 
 [assembly: PythonModule("_codecs", typeof(IronPython.Modules.PythonCodecs))]
@@ -313,14 +314,20 @@ namespace IronPython.Modules {
 
         public static PythonTuple unicode_escape_encode(string input) => throw PythonOps.NotImplementedError("unicode_escape_encode");
 
-        public static PythonTuple unicode_internal_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors = "strict")
-            => DoDecode(context, "unicode-internal", Encoding.Unicode, input, errors, input.Count).ToPythonTuple();
+        public static PythonTuple unicode_internal_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors = "strict") {
+            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "unicode_internal codec has been deprecated");
+            return DoDecode(context, "unicode-internal", Encoding.Unicode, input, errors, input.Count).ToPythonTuple();
+        }
 
-        public static PythonTuple unicode_internal_encode(CodeContext context, string input, string errors = "strict")
-            => DoEncode(context, "unicode-internal", Encoding.Unicode, input, errors, false).ToPythonTuple();
+        public static PythonTuple unicode_internal_encode(CodeContext context, string input, string errors = "strict") {
+            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "unicode_internal codec has been deprecated");
+            return DoEncode(context, "unicode-internal", Encoding.Unicode, input, errors, false).ToPythonTuple();
+        }
 
-        public static PythonTuple unicode_internal_encode([BytesConversion]IList<byte> input, string errors = "strict")
-            => PythonTuple.MakeTuple(new Bytes(input), input.Count);
+        public static PythonTuple unicode_internal_encode(CodeContext context, [BytesConversion]IList<byte> input, string errors = "strict") {
+            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "unicode_internal codec has been deprecated");
+            return PythonTuple.MakeTuple(new Bytes(input), input.Count);
+        }
 
         #endregion
 

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -227,7 +227,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_bug1251300'))
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_decode_callback'))
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_decode_error_attributes'))
-        #suite.addTest(test.test_codecs.UnicodeInternalTest('test_encode_length')) # AssertionError: filter ('unicode_internal codec has been deprecated', DeprecationWarning) did not catch any warning
+        suite.addTest(test.test_codecs.UnicodeInternalTest('test_encode_length'))
         suite.addTest(test.test_codecs.WithStmtTest('test_encodedfile'))
         suite.addTest(test.test_codecs.WithStmtTest('test_streamreaderwriter'))
         return suite


### PR DESCRIPTION
Deprecated since Python 3.3. Removed in Python 3.8.

https://bugs.python.org/issue36297