### PR TITLE
Cleanup utf-7

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -432,10 +432,10 @@ namespace IronPython.Modules {
             if (!final) {
                 int blockStart = -1;
                 for (int i = 0; i < numBytes; i++) {
-                    char c = (char)input[i]; // to ASCII
-                    if (blockStart < 0 && c == '+') {
+                    byte b = input[i];
+                    if (blockStart < 0 && b == '+') {
                         blockStart = i;
-                    } else if (blockStart >= 0 && !char.IsLetterOrDigit(c) && c != '+' && c != '/' && !char.IsWhiteSpace(c)) {
+                    } else if (blockStart >= 0 && !b.IsLetter() && !b.IsDigit() && b != '+' && b != '/' && !b.IsWhiteSpace()) {
                         blockStart = -1;
                     }
                 }


### PR DESCRIPTION
Because decoding processes input as sequence of bytes, rather than chars, I think it is cleaner to use byte tests rather than the full-blown Unicode char tests.

The code stays functionally the same. It should have went with #666.