### PR TITLE
Fix Unicode parse exceptions

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -283,8 +283,11 @@ namespace IronPython.Modules {
 
         #region Raw Unicode Escape Encoding Functions
 
-        public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, string input, string errors = "strict")
-            => raw_unicode_escape_decode(context, DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").Item1, errors);
+        public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, string input, string errors = "strict") {
+            // Encoding with UTF-8 is probably a bug or at least a mistake, as it mutilates non-ASCII characters,
+            // but this is what CPython does. Probably encoding with "raw-unicode-escape" would be more reasonable.
+            return raw_unicode_escape_decode(context, DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").Item1, errors);
+        }
 
         public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [BytesConversion]IList<byte> input, string errors = "strict") {
             return PythonTuple.MakeTuple(

--- a/Src/IronPython/Runtime/LiteralParser.cs
+++ b/Src/IronPython/Runtime/LiteralParser.cs
@@ -35,13 +35,13 @@ namespace IronPython.Runtime {
             return result ?? bytes.MakeString(start, length);
         }
 
-        private static string DoParseString<T>(T[] data, int start, int length, bool isRaw, bool isUniEscape, bool normalizeLineEndings) {
+        private static string DoParseString<T>(T[] data, int start, int length, bool isRaw, bool isUniEscape, bool normalizeLineEndings) where T : IConvertible {
             StringBuilder buf = null;
             int i = start;
             int l = start + length;
             int val;
             while (i < l) {
-                char ch = Convert.ToChar(data[i++]);
+                char ch = data[i++].ToChar(null);
                 if ((!isRaw || isUniEscape) && ch == '\\') {
                     StringBuilderInit(ref buf, data, start, i - start - 1, length);
 
@@ -53,7 +53,7 @@ namespace IronPython.Runtime {
                             throw PythonOps.ValueError("Trailing \\ in string");
                         }
                     }
-                    ch = Convert.ToChar(data[i++]);
+                    ch = data[i++].ToChar(null);
 
                     if (ch == 'u' || ch == 'U') {
                         int len = (ch == 'u') ? 4 : 8;
@@ -105,16 +105,16 @@ namespace IronPython.Runtime {
                             case '\\': buf.Append('\\'); continue;
                             case '\'': buf.Append('\''); continue;
                             case '\"': buf.Append('\"'); continue;
-                            case '\r': if (i < l && Convert.ToChar(data[i]) == '\n') i++; continue;
+                            case '\r': if (i < l && data[i].ToChar(null) == '\n') i++; continue;
                             case '\n': continue;
                             case 'N': {
                                     IronPython.Modules.unicodedata.PerformModuleReload(null, null);
-                                    if (i < l && Convert.ToChar(data[i]) == '{') {
+                                    if (i < l && data[i].ToChar(null) == '{') {
                                         i++;
                                         StringBuilder namebuf = new StringBuilder();
                                         bool namecomplete = false;
                                         while (i < l) {
-                                            char namech = Convert.ToChar(data[i++]);
+                                            char namech = data[i++].ToChar(null);
                                             if (namech != '}') {
                                                 namebuf.Append(namech);
                                             } else {
@@ -155,10 +155,10 @@ namespace IronPython.Runtime {
                             case '7': {
                                     int onechar;
                                     val = ch - '0';
-                                    if (i < l && HexValue(Convert.ToChar(data[i]), out onechar) && onechar < 8) {
+                                    if (i < l && HexValue(data[i].ToChar(null), out onechar) && onechar < 8) {
                                         val = val * 8 + onechar;
                                         i++;
-                                        if (i < l && HexValue(Convert.ToChar(data[i]), out onechar) && onechar < 8) {
+                                        if (i < l && HexValue(data[i].ToChar(null), out onechar) && onechar < 8) {
                                             val = val * 8 + onechar;
                                             i++;
                                         }
@@ -177,7 +177,7 @@ namespace IronPython.Runtime {
                     StringBuilderInit(ref buf, data, start, i - start - 1, length);
 
                     // normalize line endings
-                    if (i < data.Length && Convert.ToChar(data[i]) == '\n') {
+                    if (i < data.Length && data[i].ToChar(null) == '\n') {
                         i++;
                     }
                     buf.Append('\n');
@@ -357,14 +357,14 @@ namespace IronPython.Runtime {
             return true;
         }
 
-        private static bool TryParseInt<T>(T[] text, int start, int length, int b, out int value, out int consumed) {
+        private static bool TryParseInt<T>(T[] text, int start, int length, int b, out int value, out int consumed) where T : IConvertible {
             value = 0;
             if (start + length > text.Length) {
                 consumed = 0;
                 return false;
             }
             for (int i = start, end = start + length; i < end; i++) {
-                if (HexValue(Convert.ToChar(text[i]), out int onechar) && onechar < b) {
+                if (HexValue(text[i].ToChar(null), out int onechar) && onechar < b) {
                     value = value * b + onechar;
                 } else {
                     consumed = i - start;

--- a/Src/IronPython/Runtime/LiteralParser.cs
+++ b/Src/IronPython/Runtime/LiteralParser.cs
@@ -50,7 +50,12 @@ namespace IronPython.Runtime {
                         if (isUniEscape) {
                             if (TryParseInt(text, i, len, max, out val, out int consumed)) {
                                 if (val < 0 || val > 0x10ffff) {
-                                    throw PythonExceptions.CreateThrowable(PythonExceptions.UnicodeDecodeError, isRaw ? "rawunicodeescape" : "unicodeescape", Bytes.Empty, i - start - 2, i - start + consumed, "\\Uxxxxxxxx out of range");
+                                    throw PythonExceptions.CreateThrowable(
+                                        PythonExceptions.UnicodeDecodeError,
+                                        isRaw ? "rawunicodeescape" : "unicodeescape",
+                                        PythonOps.MakeBytes(new String(text)),
+                                        i - start - 2, i - start + consumed,
+                                        "\\Uxxxxxxxx out of range");
                                 }
 
                                 if (val < 0x010000) {
@@ -60,7 +65,13 @@ namespace IronPython.Runtime {
                                 }
                                 i += len;
                             } else {
-                                throw PythonExceptions.CreateThrowable(PythonExceptions.UnicodeDecodeError, isRaw ? "rawunicodeescape" : "unicodeescape", Bytes.Empty, i - start - 2, i - start + consumed, @"truncated \uXXXX escape");
+                                throw PythonExceptions.CreateThrowable(
+                                    PythonExceptions.UnicodeDecodeError,
+                                    isRaw ? "rawunicodeescape" : "unicodeescape",
+                                    PythonOps.MakeBytes(new String(text)),
+                                    i - start - 2,
+                                    i - start + consumed,
+                                    @"truncated \uXXXX escape");
                             }
                         } else {
                             buf.Append('\\');

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3403,9 +3403,16 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static string MakeString(this IList<byte> bytes, int maxBytes) {
+            return MakeString(bytes, 0, maxBytes);
+        }
+
+        internal static string MakeString(this IList<byte> bytes, int startIdx, int maxBytes) {
+            Debug.Assert(startIdx >= 0);
+
             int bytesToCopy = Math.Min(bytes.Count, maxBytes);
             StringBuilder b = new StringBuilder(bytesToCopy);
-            for (int i = 0; i < bytesToCopy; i++) {
+            int endIdx = startIdx + bytesToCopy;
+            for (int i = startIdx; i < endIdx; i++) {
                 b.Append((char)bytes[i]);
             }
             return b.ToString();

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -117,10 +117,48 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(new_str, b'abc')
 
     def test_raw_unicode_escape_decode(self):
-        #sanity
         new_str, num_processed = codecs.raw_unicode_escape_decode("abc")
-        self.assertEqual(new_str, 'abc')
+        self.assertEqual(new_str, "abc")
         self.assertEqual(num_processed, 3)
+
+        new_str, num_processed = codecs.raw_unicode_escape_decode(b"abc")
+        self.assertEqual(new_str, "abc")
+        self.assertEqual(num_processed, 3)
+
+        new_str, num_processed = codecs.raw_unicode_escape_decode("abc\\u20ACxyz")
+        self.assertEqual(new_str, "abc€xyz")
+        self.assertEqual(num_processed, 12)
+
+        new_str, num_processed = codecs.raw_unicode_escape_decode("abc\\U0001F40Dxyz")
+        self.assertEqual(new_str, "abc🐍xyz")
+        self.assertEqual(num_processed, 16)
+
+    def test_raw_unicode_escape_decode_errors(self):
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            codecs.raw_unicode_escape_decode("abc\\u20xyz")
+
+        self.assertEquals(cm.exception.encoding, 'rawunicodeescape')
+        self.assertTrue(cm.exception.reason.startswith("truncated \\uXXXX"))
+        self.assertEquals(cm.exception.start, 3)
+        self.assertEquals(cm.exception.end, 7)
+
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            codecs.raw_unicode_escape_decode("abc\\U0001F44xyz")
+
+        self.assertEquals(cm.exception.encoding, 'rawunicodeescape')
+        if sys.version_info < (3, 6):
+            self.assertTrue(cm.exception.reason.startswith("truncated \\uXXXX"))
+        else:
+            self.assertEquals(cm.exception.reason, "truncated \\UXXXXXXXX sequence")
+        self.assertEquals(cm.exception.start, 3)
+        self.assertEquals(cm.exception.end, 12)
+
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            codecs.raw_unicode_escape_decode("abc\\U00110011xyz")
+
+        self.assertTrue(cm.exception.reason.startswith("\\Uxxxxxxxx out of range"))
+        self.assertEquals(cm.exception.start, 3)
+        self.assertEquals(cm.exception.end, 13)
 
     def test_raw_unicode_escape_encode(self):
         #sanity
@@ -303,6 +341,8 @@ class CodecTest(IronPythonTestCase):
             res = codecs.utf_16_be_decode(b[:i], 'replace')
             self.assertEqual(res, expected[i])
 
+        self.assertRaises(UnicodeDecodeError, codecs.utf_16_be_decode, b"\x41\x00\xd8\x00\xd8\x00", 'strict', False)
+
     def test_utf_16_be_encode(self):
         data, num_processed = codecs.utf_16_be_encode("abc")
         self.assertEqual(data, b'\0a\0b\0c')
@@ -345,6 +385,8 @@ class CodecTest(IronPythonTestCase):
         for i in range(len(b) + 1):
             res = codecs.utf_16_le_decode(b[:i], 'replace')
             self.assertEqual(res, expected[i])
+
+        self.assertRaises(UnicodeDecodeError, codecs.utf_16_le_decode, b"\x00\x41\x00\xd8\x00\xd8", 'strict', False)
 
     def test_utf_16_le_encode(self):
         data, num_processed = codecs.utf_16_le_encode("abc")

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -135,13 +135,13 @@ class CodecTest(IronPythonTestCase):
 
     def test_raw_unicode_escape_decode_errors(self):
         with self.assertRaises(UnicodeDecodeError) as cm:
-            codecs.raw_unicode_escape_decode("abc\\u20xyz\xff") # as Latin-1
+            codecs.raw_unicode_escape_decode("abc\\u20klm\xffxyz\u20ac") # Unicode string
 
         self.assertEquals(cm.exception.encoding, 'rawunicodeescape')
         self.assertTrue(cm.exception.reason.startswith("truncated \\uXXXX"))
         self.assertEquals(cm.exception.start, 3)
         self.assertEquals(cm.exception.end, 7)
-        self.assertEquals(cm.exception.object, b"abc\\u20xyz\xc3\xbf") # in UTF-8
+        self.assertEquals(cm.exception.object, b"abc\\u20klm\xc3\xbfxyz\xe2\x82\xac") # in UTF-8
 
         with self.assertRaises(UnicodeDecodeError) as cm:
             codecs.raw_unicode_escape_decode("abc\\U0001F44xyz")

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -135,12 +135,13 @@ class CodecTest(IronPythonTestCase):
 
     def test_raw_unicode_escape_decode_errors(self):
         with self.assertRaises(UnicodeDecodeError) as cm:
-            codecs.raw_unicode_escape_decode("abc\\u20xyz")
+            codecs.raw_unicode_escape_decode("abc\\u20xyz\xff") # as Latin-1
 
         self.assertEquals(cm.exception.encoding, 'rawunicodeescape')
         self.assertTrue(cm.exception.reason.startswith("truncated \\uXXXX"))
         self.assertEquals(cm.exception.start, 3)
         self.assertEquals(cm.exception.end, 7)
+        self.assertEquals(cm.exception.object, b"abc\\u20xyz\xc3\xbf") # in UTF-8
 
         with self.assertRaises(UnicodeDecodeError) as cm:
             codecs.raw_unicode_escape_decode("abc\\U0001F44xyz")
@@ -152,6 +153,7 @@ class CodecTest(IronPythonTestCase):
             self.assertEquals(cm.exception.reason, "truncated \\UXXXXXXXX sequence")
         self.assertEquals(cm.exception.start, 3)
         self.assertEquals(cm.exception.end, 12)
+        self.assertEquals(cm.exception.object, b"abc\\U0001F44xyz")
 
         with self.assertRaises(UnicodeDecodeError) as cm:
             codecs.raw_unicode_escape_decode("abc\\U00110011xyz")
@@ -159,6 +161,7 @@ class CodecTest(IronPythonTestCase):
         self.assertTrue(cm.exception.reason.startswith("\\Uxxxxxxxx out of range"))
         self.assertEquals(cm.exception.start, 3)
         self.assertEquals(cm.exception.end, 13)
+        self.assertEquals(cm.exception.object, b"abc\\U00110011xyz")
 
     def test_raw_unicode_escape_encode(self):
         #sanity


### PR DESCRIPTION
The exceptions are used by raw-unicode-escape codec.

This PR is part of raw-unicode-escape implementation.