### PR TITLE
Implement decoding for 'unicode-escape' codec

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -305,17 +305,32 @@ namespace IronPython.Modules {
 
         #endregion
 
+        #region Unicode Escape Encoding Functions
+
+        public static PythonTuple unicode_escape_decode(CodeContext/*!*/ context, string input, string errors = "strict") {
+            // Encoding with UTF-8 is probably a bug or at least a mistake, as it mutilates non-ASCII characters,
+            // but this is what CPython does. Probably encoding with "unicode-escape" would be more reasonable.
+            return unicode_escape_decode(context, DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").Item1, errors);
+        }
+
+        public static PythonTuple unicode_escape_decode(CodeContext/*!*/ context, [BytesConversion]IList<byte> input, string errors = "strict") {
+            return PythonTuple.MakeTuple(
+                StringOps.RawDecode(context, input, "unicode-escape", errors),
+                input.Count
+            );
+        }
+
+        public static PythonTuple unicode_escape_encode(string input) => throw PythonOps.NotImplementedError("unicode_escape_encode");
+
+        #endregion
+
         public static PythonTuple readbuffer_encode(CodeContext/*!*/ context, string input, string errors = null)
             => readbuffer_encode(DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").Item1, errors);
 
         public static PythonTuple readbuffer_encode([BytesConversion]IList<byte> input, string errors = null)
             => PythonTuple.MakeTuple(new Bytes(input), input.Count);
 
-        #region Unicode Escape Encoding Functions
-
-        public static PythonTuple unicode_escape_decode(string input) => throw PythonOps.NotImplementedError("unicode_escape_decode");
-
-        public static PythonTuple unicode_escape_encode(string input) => throw PythonOps.NotImplementedError("unicode_escape_encode");
+        #region Unicode Internal Encoding Functions
 
         public static PythonTuple unicode_internal_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors = "strict") {
             PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "unicode_internal codec has been deprecated");

--- a/Src/IronPython/Modules/unicodedata.cs
+++ b/Src/IronPython/Modules/unicodedata.cs
@@ -137,7 +137,7 @@ namespace IronPython.Modules {
             public string unidata_version { get; private set; }
 
             public string lookup(string name) {
-                return char.ConvertFromUtf32(nameLookup[name.ToUpperInvariant()]);
+                return char.ConvertFromUtf32(nameLookup[name]);
             }
 
             public string name(char unichr, string @default) {
@@ -335,7 +335,7 @@ namespace IronPython.Modules {
             }
 
             private void BuildNameLookup() {
-                nameLookup = database.Where(c => !c.Value.Name.StartsWith("<")).ToDictionary(c => c.Value.Name, c => c.Key);
+                nameLookup = database.Where(c => !c.Value.Name.StartsWith("<")).ToDictionary(c => c.Value.Name, c => c.Key, StringComparer.OrdinalIgnoreCase);
             }
 
             private bool TryGetInfo(char unichr, out CharInfo charInfo) {

--- a/Src/IronPython/Modules/unicodedata.cs
+++ b/Src/IronPython/Modules/unicodedata.cs
@@ -137,7 +137,7 @@ namespace IronPython.Modules {
             public string unidata_version { get; private set; }
 
             public string lookup(string name) {
-                return char.ConvertFromUtf32(nameLookup[name]);
+                return char.ConvertFromUtf32(nameLookup[name.ToUpperInvariant()]);
             }
 
             public string name(char unichr, string @default) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -2243,6 +2243,9 @@ namespace IronPython.Runtime.Operations {
                 }
             }
 
+            public override string GetString(byte[] bytes, int index, int count)
+                => LiteralParser.ParseString(bytes, index, count, _raw);
+
             public override int GetCharCount(byte[] bytes, int index, int count)
                 => LiteralParser.ParseString(bytes, index, count, _raw).Length;
 
@@ -2250,7 +2253,7 @@ namespace IronPython.Runtime.Operations {
                 string res = LiteralParser.ParseString(bytes, byteIndex, byteCount, _raw);
 
                 for (int i = 0; i < res.Length; i++) {
-                    chars[i + charIndex] = (char)res[i];
+                    chars[i + charIndex] = res[i];
                 }
                 return res.Length;
             }

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -218,11 +218,11 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF8Test('test_readline'))
         suite.addTest(test.test_codecs.UTF8Test('test_readlinequeue'))
         #suite.addTest(test.test_codecs.UTF8Test('test_surrogatepass_handler')) # LookupError: unknown error handler name 'surrogatepass'
-        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_decode_errors')) # TypeError: expected str, got bytes
+        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_decode_errors')) # 'ignore' error handler not implemented
         #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_empty')) # NotImplementedError: unicode_escape_encode
-        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_decode')) # TypeError: expected str, got bytes
+        suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_decode'))
         #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_encode')) # NotImplementedError: unicode_escape_encode
-        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_raw_decode')) # TypeError: expected str, got bytes
+        suite.addTest(test.test_codecs.UnicodeEscapeTest('test_raw_decode'))
         #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_raw_encode')) # NotImplementedError: unicode_escape_encode
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_bug1251300'))
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_decode_callback'))


### PR DESCRIPTION
This PR was meant to just implement decoding of `unicode-escape`, but since `unicode-escape` shares code with the literal parser, the latter got dragged in as well. Some subtle bugs in the literal parser got exposed, which I've hopefully fixed now. I have not added any tests for the parser; I've started doing it in `test_syntax`, but it turns out the whole test currently does not pass. I guess there is more work to be done on the parser. I'm wondering whether the parser is not a higher priority than the codecs.