### PR TITLE
Implement encoding of (raw-)unicode-escape codec

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -320,7 +320,12 @@ namespace IronPython.Modules {
             );
         }
 
-        public static PythonTuple unicode_escape_encode(string input) => throw PythonOps.NotImplementedError("unicode_escape_encode");
+        public static PythonTuple unicode_escape_encode(CodeContext/*!*/ context, string input, string errors = "strict") {
+            return PythonTuple.MakeTuple(
+                StringOps.RawEncode(context, input, "unicode-escape", errors),
+                input.Length
+            );
+        }
 
         #endregion
 

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -219,11 +219,11 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF8Test('test_readlinequeue'))
         #suite.addTest(test.test_codecs.UTF8Test('test_surrogatepass_handler')) # LookupError: unknown error handler name 'surrogatepass'
         #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_decode_errors')) # 'ignore' error handler not implemented
-        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_empty')) # NotImplementedError: unicode_escape_encode
+        suite.addTest(test.test_codecs.UnicodeEscapeTest('test_empty'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_decode'))
-        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_encode')) # NotImplementedError: unicode_escape_encode
+        suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_encode'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_raw_decode'))
-        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_raw_encode')) # NotImplementedError: unicode_escape_encode
+        suite.addTest(test.test_codecs.UnicodeEscapeTest('test_raw_encode'))
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_bug1251300'))
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_decode_callback'))
         suite.addTest(test.test_codecs.UnicodeInternalTest('test_decode_error_attributes'))


### PR DESCRIPTION
Implementation of the class `UnicodeEscapeEncoding` gives priority to the methods accepting `string` rather than the usual `char[]` because this is how we use the encoding and it matches the parameter type of supporting methods. This reduces the number of type conversions needed.