### PR TITLE
Fix codecs.escape_decode

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -172,69 +172,14 @@ namespace IronPython.Modules {
         #region Escape Encoding
 
         public static PythonTuple escape_decode(CodeContext/*!*/ context, string data, string errors = "strict")
-            => escape_decode(DoEncode(context, "utf-8", Encoding.UTF8, data, "strict").Item1, errors);
+            => escape_decode(StringOps.DoEncodeUtf8(context, data), errors);
 
         public static PythonTuple escape_decode([BytesConversion]IList<byte> data, string errors = "strict") {
-            var res = new StringBuilder();
-            for (int i = 0; i < data.Count; i++) {
-                if (data[i] == '\\') {
-                    if (i == data.Count - 1) throw PythonOps.ValueError("\\ at end of string");
-
-                    switch ((char)data[++i]) {
-                        case 'a': res.Append((char)0x07); break;
-                        case 'b': res.Append((char)0x08); break;
-                        case 't': res.Append('\t'); break;
-                        case 'n': res.Append('\n'); break;
-                        case 'r': res.Append('\r'); break;
-                        case '\\': res.Append('\\'); break;
-                        case 'f': res.Append((char)0x0c); break;
-                        case 'v': res.Append((char)0x0b); break;
-                        case '\n': break;
-                        case 'x':
-                            if (++i < data.Count && CharToInt((char)data[i], out int dig1)
-                                    && ++i < data.Count && CharToInt((char)data[i], out int dig2)) {
-                                res.Append((char)(dig1 * 16 + dig2));
-                            } else {
-                                switch (errors) {
-                                    case "strict":
-                                        throw PythonOps.ValueError("invalid \\x escape at position {0}", i);
-                                    case "replace":
-                                        res.Append("?");
-                                        i--;
-                                        break;
-                                    default:
-                                        throw PythonOps.ValueError("decoding error; unknown error handling code: " + errors);
-                                }
-                            }
-                            break;
-                        default:
-                            res.Append("\\" + (char)data[i]);
-                            break;
-                    }
-                } else {
-                    res.Append((char)data[i]);
-                }
-
-            }
-            return PythonTuple.MakeTuple(Bytes.Make(res.ToString().MakeByteArray()), data.Count);
+            var res1 = LiteralParser.ParseBytes(data, 0, data.Count, isRaw: false, normalizeLineEndings: false);
+            return PythonTuple.MakeTuple(Bytes.Make(res1.ToArray()), data.Count);
         }
 
-        private static bool CharToInt(char ch, out int val) {
-            if (char.IsDigit(ch)) {
-                val = ch - '0';
-                return true;
-            }
-            ch = char.ToUpper(ch);
-            if (ch >= 'A' && ch <= 'F') {
-                val = ch - 'A' + 10;
-                return true;
-            }
-
-            val = 0;
-            return false;
-        }
-
-        public static PythonTuple/*!*/ escape_encode([BytesConversion]IList<byte> text, string errors = "strict") {
+        public static PythonTuple escape_encode([BytesConversion]IList<byte> text, string errors = "strict") {
             StringBuilder res = new StringBuilder();
             for (int i = 0; i < text.Count; i++) {
                 switch (text[i]) {

--- a/Src/IronPython/Runtime/LiteralParser.cs
+++ b/Src/IronPython/Runtime/LiteralParser.cs
@@ -279,9 +279,7 @@ namespace IronPython.Runtime {
                                 }
                                 var substitute = errorHandler(data, pos, pos + consumed);
                                 if (substitute != null) {
-                                    foreach (var sc in substitute) {
-                                        buf.Add(sc);
-                                    }
+                                    buf.AddRange(substitute);
                                 }
                             } else {
                                 buf.Add((byte)val);

--- a/Src/IronPython/Runtime/LiteralParser.cs
+++ b/Src/IronPython/Runtime/LiteralParser.cs
@@ -251,7 +251,7 @@ namespace IronPython.Runtime {
                     if (i >= l) {
                         throw PythonOps.ValueError("Trailing \\ in string");
                     }
-                    ch = data[i++].ToChar(null); ;
+                    ch = data[i++].ToChar(null);
                     switch (ch) {
                         case 'a': buf.Add((byte)'\a'); continue;
                         case 'b': buf.Add((byte)'\b'); continue;

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1799,7 +1799,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static Bytes DoEncodeUtf8(CodeContext context, string s)
-            => RawEncode(context, s, "utf-8", "strict");
+            => DoEncode(context, s, "strict", "utf-8", Encoding.UTF8, includePreamble: false);
 
         internal static Bytes DoEncode(CodeContext context, string s, string errors, string encoding, Encoding e, bool includePreamble) {
 #if FEATURE_ENCODING

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -26,7 +26,8 @@ from iptest.misc_util import ip_supported_encodings
 
 class CodecTest(IronPythonTestCase):
     def test_escape_decode(self):
-        #sanity checks
+        # escape_decode decodes bytes to bytes, but when given a string it encodes it first with UTF-8
+        self.assertEqual(codecs.escape_decode("abc€ghi🐍xyz"), codecs.escape_decode(b'abc\xe2\x82\xacghi\xf0\x9f\x90\x8dxyz'))
 
         value, length = codecs.escape_decode("ab\a\b\t\n\r\f\vba")
         self.assertEqual(value, b'ab\x07\x08\t\n\r\x0c\x0bba')
@@ -36,14 +37,32 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(value, b'\x07')
         self.assertEqual(length, 2)
 
-        value, length = codecs.escape_decode("ab\a\b\t\n\r\f\vbaab\\a\\b\\t\\n\\r\\f\\vbaab\\\a\\\b\\\t\\\n\\\r\\\f\\\vba")
-        self.assertEqual(value, b'ab\x07\x08\t\n\r\x0c\x0bbaab\x07\x08\t\n\r\x0c\x0bbaab\\\x07\\\x08\\\t\\\r\\\x0c\\\x0bba')
-        self.assertEqual(length, 47)
+        value, length = codecs.escape_decode("ab\a\b\t\n\r\f\v\'\"baab\\a\\b\\t\\n\\r\\f\\v\\'\\\"baab\\\a\\\b\\\t\\\n\\\r\\\f\\\vba")
+        self.assertEqual(value, b'ab\x07\x08\t\n\r\x0c\x0b\'\"baab\x07\x08\t\n\r\x0c\x0b\'\"baab\\\x07\\\x08\\\t\\\r\\\x0c\\\x0bba')
+        self.assertEqual(length, 53)
 
         value, length = codecs.escape_decode("\\\a")
         self.assertEqual(value, b'\\\x07')
         self.assertEqual(length, 2)
 
+        value, length = codecs.escape_decode("\\07")
+        self.assertEqual(value, b'\x07')
+        self.assertEqual(length, 3)
+
+        value, length = codecs.escape_decode("\\047")
+        self.assertEqual(value, b"'")
+        self.assertEqual(length, 4)
+
+        self.assertEquals(codecs.escape_decode(b"ab\nc"), (b"ab\nc", 4))
+        self.assertEquals(codecs.escape_decode(b"ab\rc"), (b"ab\rc", 4))
+        self.assertEquals(codecs.escape_decode(b"ab\r\nc"), (b"ab\r\nc", 5))
+
+        self.assertEquals(codecs.escape_decode(b"ab\\\nc"), (b"abc", 5))
+        self.assertEquals(codecs.escape_decode(b"ab\\\rc"), (b"ab\\\rc", 5))
+        self.assertEquals(codecs.escape_decode(b"ab\\\r\\\nc"), (b"ab\\\rc", 7))
+
+    @unittest.skipIf(is_cli, "TODO")
+    def test_escape_decode_errors(self):
         self.assertEqual(b"abc", codecs.escape_decode("abc", None)[0])
         self.assertEqual(b"?", codecs.escape_decode("\\x", 'replace')[0])
         self.assertEqual(b"?", codecs.escape_decode("\\x2", 'replace')[0])
@@ -51,6 +70,27 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(b"?II", codecs.escape_decode("\\xII", 'replace')[0])
         self.assertEqual(b"?I", codecs.escape_decode("\\x1I", 'replace')[0])
         self.assertEqual(b"?I1", codecs.escape_decode("\\xI1", 'replace')[0])
+
+        self.assertEqual(b"abc", codecs.escape_decode("abc", None)[0])
+        self.assertEqual(b"abc", codecs.escape_decode("abc\\x", 'ignore')[0])
+        self.assertEqual(b"abc", codecs.escape_decode("abc\\x2", 'ignore')[0])
+        self.assertEqual(b"abcI", codecs.escape_decode("abc\\xI", 'ignore')[0])
+        self.assertEqual(b"abcII", codecs.escape_decode("abc\\xII", 'ignore')[0])
+        self.assertEqual(b"abcI", codecs.escape_decode("abc\\x1I", 'ignore')[0])
+        self.assertEqual(b"abcI1", codecs.escape_decode("abc\\xI1", 'ignore')[0])
+
+        self.assertRaisesRegex(ValueError, r"Trailing \\ in string", codecs.escape_decode, b"\\", 'strict')
+        self.assertRaisesRegex(ValueError, r"Trailing \\ in string", codecs.escape_decode, b"\\", 'replace')
+        self.assertRaisesRegex(ValueError, r"Trailing \\ in string", codecs.escape_decode, b"\\", 'ignore')
+        self.assertRaisesRegex(ValueError, r"Trailing \\ in string", codecs.escape_decode, b"\\", 'non-existent')
+
+        self.assertRaisesRegex(ValueError, r"invalid \\x escape at position 3", codecs.escape_decode, b"abc\\xii")
+        self.assertRaisesRegex(ValueError, r"invalid \\x escape at position 3", codecs.escape_decode, b"abc\\x1i")
+        self.assertRaisesRegex(ValueError, r"invalid \\x escape at position 3", codecs.escape_decode, b"abc\\xii", 'strict')
+        self.assertRaisesRegex(ValueError, r"invalid \\x escape at position 3", codecs.escape_decode, b"abc\\x1i", 'strict')
+
+        self.assertRaisesRegex(ValueError, "decoding error; unknown error handling code: non-existent", codecs.escape_decode, b"abc\\xii", 'non-existent')
+        self.assertRaisesRegex(ValueError, "decoding error; unknown error handling code: non-existent", codecs.escape_decode, b"abc\\x1i", 'non-existent')
 
     def test_escape_encode(self):
         #sanity checks

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -59,8 +59,8 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.CodecsModuleTest('test_undefined'))
         suite.addTest(test.test_codecs.EncodedFileTest('test_basic'))
         suite.addTest(test.test_codecs.EscapeDecodeTest('test_empty'))
-        #suite.addTest(test.test_codecs.EscapeDecodeTest('test_errors')) # unknown error handling code: ignore
-        suite.addTest(test.test_codecs.EscapeDecodeTest('test_escape')) # (b'[\\"]', 4) != (b'["]', 4)
+        suite.addTest(test.test_codecs.EscapeDecodeTest('test_errors'))
+        suite.addTest(test.test_codecs.EscapeDecodeTest('test_escape'))
         suite.addTest(test.test_codecs.EscapeDecodeTest('test_raw'))
         suite.addTest(test.test_codecs.ExceptionChainingTest('test_codec_lookup_failure_not_wrapped'))
         suite.addTest(test.test_codecs.ExceptionChainingTest('test_init_override_is_not_wrapped'))

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -60,7 +60,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.EncodedFileTest('test_basic'))
         suite.addTest(test.test_codecs.EscapeDecodeTest('test_empty'))
         #suite.addTest(test.test_codecs.EscapeDecodeTest('test_errors')) # unknown error handling code: ignore
-        #suite.addTest(test.test_codecs.EscapeDecodeTest('test_escape')) # (b'[\\"]', 4) != (b'["]', 4)
+        suite.addTest(test.test_codecs.EscapeDecodeTest('test_escape')) # (b'[\\"]', 4) != (b'["]', 4)
         suite.addTest(test.test_codecs.EscapeDecodeTest('test_raw'))
         suite.addTest(test.test_codecs.ExceptionChainingTest('test_codec_lookup_failure_not_wrapped'))
         suite.addTest(test.test_codecs.ExceptionChainingTest('test_init_override_is_not_wrapped'))


### PR DESCRIPTION
And here [we have it](https://github.com/IronLanguages/ironpython3/pull/676#discussion_r346542744): `LiterslParser.ParseBytes` with `normalizeLineEndings: false`.

This is an RFC at this moment because of a regression: the old code supported `replace` error handler, which is temporarily gone. In the new code, error handlers will be implemented differently and I'd rather have this submission reviewed and agreed on before moving forward.