### PR TITLE
Implement error handling for (raw-)unicode-escape codec

### DIFF
--- a/Src/IronPython/Runtime/LiteralParser.cs
+++ b/Src/IronPython/Runtime/LiteralParser.cs
@@ -188,9 +188,13 @@ namespace IronPython.Runtime {
             return buf?.ToString();
 
             void handleError(int start, int end, string reason) {
-                bytesData ??= data is byte[] ba ? new Bytes(ba) : Bytes.Empty;
+                if (bytesData == null) {
+                    var ba = data as byte[];
+                    if (ba == null) throw new NotImplementedException("Error handler for non byte[] data not supported");
+                    bytesData = new Bytes(ba);
+                }
 
-                if (errorHandler == null || start >= bytesData.Count) {
+                if (errorHandler == null) {
                     throw PythonExceptions.CreateThrowable(PythonExceptions.UnicodeDecodeError, isRaw ? "rawunicodeescape" : "unicodeescape", bytesData, start, end, reason);
                 }
                 var substitute = errorHandler(data, start, end);

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -2379,7 +2379,7 @@ namespace IronPython.Runtime.Operations {
                     // call the user function...
                     object res = PythonCalls.Call(_function, exObj);
 
-                    string replacement = CheckReplacementTuple(res, "encoding");
+                    string replacement = CheckReplacementTuple(res, "encoding", index + length);
 
                     // finally process the user's request.
                     _buffer = replacement;
@@ -2465,7 +2465,7 @@ namespace IronPython.Runtime.Operations {
                     // call the user function...
                     object res = PythonCalls.Call(_function, exObj);
 
-                    string replacement = CheckReplacementTuple(res, "decoding");
+                    string replacement = CheckReplacementTuple(res, "decoding", index + bytesUnknown.Length);
 
                     // finally process the user's request.
                     _buffer = replacement;
@@ -2504,11 +2504,12 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        private static string CheckReplacementTuple(object res, string encodeOrDecode) {
+        private static string CheckReplacementTuple(object res, string encodeOrDecode, int cursorPos) {
             // verify the result is sane...
             if (res is PythonTuple tres && tres.__len__() == 2
                     && Converter.TryConvertToString(tres[0], out string replacement)
-                    && Converter.TryConvertToInt32(tres[1], out _)) {
+                    && Converter.TryConvertToInt32(tres[1], out int newPos)) {
+                if (newPos != cursorPos) throw new NotImplementedException($"Moving {encodeOrDecode} cursor not implemented yet");
                 return replacement;
             }
 

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -82,9 +82,9 @@ def load_tests(loader, standard_tests, pattern):
         #suite.addTest(test.test_codecs.NameprepTest('test_nameprep')) # Invalid Unicode code point found at index 0
         #suite.addTest(test.test_codecs.PunycodeTest('test_decode')) # 'Array[Byte]' object has no attribute 'rfind'
         suite.addTest(test.test_codecs.PunycodeTest('test_encode'))
-        #suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_decode_errors')) # UnicodeDecodeError: 'rawunicodeescape' codec can't decode bytes in position 1-1: truncated \uXXXX escape
+        suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_decode_errors'))
         suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_empty'))
-        #suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_escape_encode')) # (b'\\ud834\\udd20', 2) != (b'\\U0001d120', 2)
+        suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_escape_encode'))
         suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_raw_decode'))
         suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_raw_encode'))
         #suite.addTest(test.test_codecs.ReadBufferTest('test_array')) # TypeError: Specified cast is not valid

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -110,7 +110,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.TransformCodecTest('test_text_to_binary_blacklists_text_transforms'))
         suite.addTest(test.test_codecs.TransformCodecTest('test_uu_invalid'))
         suite.addTest(test.test_codecs.TypesTest('test_decode_unicode'))
-        #suite.addTest(test.test_codecs.TypesTest('test_unicode_escape')) # not implemented yet
+        suite.addTest(test.test_codecs.TypesTest('test_unicode_escape'))
         suite.addTest(test.test_codecs.UTF16BETest('test_bug1098990_a'))
         suite.addTest(test.test_codecs.UTF16BETest('test_bug1098990_b'))
         suite.addTest(test.test_codecs.UTF16BETest('test_bug1175396'))
@@ -218,7 +218,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF8Test('test_readline'))
         suite.addTest(test.test_codecs.UTF8Test('test_readlinequeue'))
         #suite.addTest(test.test_codecs.UTF8Test('test_surrogatepass_handler')) # LookupError: unknown error handler name 'surrogatepass'
-        #suite.addTest(test.test_codecs.UnicodeEscapeTest('test_decode_errors')) # 'ignore' error handler not implemented
+        suite.addTest(test.test_codecs.UnicodeEscapeTest('test_decode_errors'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_empty'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_decode'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_encode'))


### PR DESCRIPTION
Similarities to `escape_decode` turned out to be smaller than I expected.