### PR TITLE
Remove comparison operator fallbacks

### DIFF
--- a/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
+++ b/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
@@ -1297,6 +1297,17 @@ namespace IronPython.Runtime.Binding {
             }
 
             return MakeBinaryThrow(binder, op, types).Expression;
+
+            static MethodInfo/*!*/ GetComparisonFallbackMethod(PythonOperationKind op) {
+                string name;
+                switch (op) {
+                    case PythonOperationKind.Equal: name = nameof(PythonOps.CompareTypesEqual); break;
+                    case PythonOperationKind.NotEqual: name = nameof(PythonOps.CompareTypesNotEqual); break;
+                    case PythonOperationKind.Compare: name = nameof(PythonOps.CompareTypes); break;
+                    default: throw new InvalidOperationException();
+                }
+                return typeof(PythonOps).GetMethod(name);
+            }
         }
 
         private static Expression GetCompareTest(PythonOperationKind op, Expression expr, bool reverse) {
@@ -1879,17 +1890,6 @@ namespace IronPython.Runtime.Binding {
             }
 
             return BindingHelpers.AddPythonBoxing(res);
-        }
-
-        private static MethodInfo/*!*/ GetComparisonFallbackMethod(PythonOperationKind op) {
-            string name;
-            switch (op) {
-                case PythonOperationKind.Equal: name = nameof(PythonOps.CompareTypesEqual); break;
-                case PythonOperationKind.NotEqual: name = nameof(PythonOps.CompareTypesNotEqual); break;
-                case PythonOperationKind.Compare: name = nameof(PythonOps.CompareTypes); break;
-                default: throw new InvalidOperationException();
-            }
-            return typeof(PythonOps).GetMethod(name);
         }
 
         internal static Expression/*!*/ CheckMissing(Expression/*!*/ toCheck) {

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -736,31 +736,19 @@ namespace IronPython.Runtime {
             throw PythonOps.TypeErrorForUnIndexableObject(count);
         }
 
-        public static bool operator >(Bytes/*!*/ x, Bytes/*!*/ y) {
-            if (y == null) {
-                throw PythonOps.TypeErrorForBinaryOp(">", x, y);
-            }
+        public static bool operator >([NotNull]Bytes/*!*/ x, [NotNull]Bytes/*!*/ y) {
             return x._bytes.Compare(y._bytes) > 0;
         }
 
-        public static bool operator <(Bytes/*!*/ x, Bytes/*!*/ y) {
-            if (y == null) {
-                throw PythonOps.TypeErrorForBinaryOp("<", x, y);
-            }
+        public static bool operator <([NotNull]Bytes/*!*/ x, [NotNull]Bytes/*!*/ y) {
             return x._bytes.Compare(y._bytes) < 0;
         }
 
-        public static bool operator >=(Bytes/*!*/ x, Bytes/*!*/ y) {
-            if (y == null) {
-                throw PythonOps.TypeErrorForBinaryOp(">=", x, y);
-            }
+        public static bool operator >=([NotNull]Bytes/*!*/ x, [NotNull]Bytes/*!*/ y) {
             return x._bytes.Compare(y._bytes) >= 0;
         }
 
-        public static bool operator <=(Bytes/*!*/ x, Bytes/*!*/ y) {
-            if (y == null) {
-                throw PythonOps.TypeErrorForBinaryOp("<=", x, y);
-            }
+        public static bool operator <=([NotNull]Bytes/*!*/ x, [NotNull]Bytes/*!*/ y) {
             return x._bytes.Compare(y._bytes) <= 0;
         }
 

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -738,28 +738,28 @@ namespace IronPython.Runtime {
 
         public static bool operator >(Bytes/*!*/ x, Bytes/*!*/ y) {
             if (y == null) {
-                return true;
+                throw PythonOps.TypeErrorForBinaryOp(">", x, y);
             }
             return x._bytes.Compare(y._bytes) > 0;
         }
 
         public static bool operator <(Bytes/*!*/ x, Bytes/*!*/ y) {
             if (y == null) {
-                return false;
+                throw PythonOps.TypeErrorForBinaryOp("<", x, y);
             }
             return x._bytes.Compare(y._bytes) < 0;
         }
 
         public static bool operator >=(Bytes/*!*/ x, Bytes/*!*/ y) {
             if (y == null) {
-                return true;
+                throw PythonOps.TypeErrorForBinaryOp(">=", x, y);
             }
             return x._bytes.Compare(y._bytes) >= 0;
         }
 
         public static bool operator <=(Bytes/*!*/ x, Bytes/*!*/ y) {
             if (y == null) {
-                return false;
+                throw PythonOps.TypeErrorForBinaryOp("<=", x, y);
             }
             return x._bytes.Compare(y._bytes) <= 0;
         }

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -607,22 +607,6 @@ namespace IronPython.Runtime.Operations {
             return PythonOps.CompareTypesWorker(context, false, x, y) != 0;
         }
 
-        public static bool CompareTypesGreaterThan(CodeContext/*!*/ context, object x, object y) {
-            return PythonOps.CompareTypes(context, x, y) > 0;
-        }
-
-        public static bool CompareTypesLessThan(CodeContext/*!*/ context, object x, object y) {
-            return PythonOps.CompareTypes(context, x, y) < 0;
-        }
-
-        public static bool CompareTypesGreaterThanOrEqual(CodeContext/*!*/ context, object x, object y) {
-            return PythonOps.CompareTypes(context, x, y) >= 0;
-        }
-
-        public static bool CompareTypesLessThanOrEqual(CodeContext/*!*/ context, object x, object y) {
-            return PythonOps.CompareTypes(context, x, y) <= 0;
-        }
-
         public static int CompareTypesWorker(CodeContext/*!*/ context, bool shouldWarn, object x, object y) {
             if (x == null && y == null) return 0;
             if (x == null) return -1;

--- a/Src/IronPythonTest/Conversions.cs
+++ b/Src/IronPythonTest/Conversions.cs
@@ -70,11 +70,7 @@ namespace IronPythonTest {
         public static IList<object> ToIDictionary(IDictionary dict) {
             List<object> res = new List<object>();
             foreach (DictionaryEntry de in dict) {
-                res.Add(PythonTuple.MakeTuple(de.Key));
-            }
-
-            foreach (DictionaryEntry de in dict) {
-                res.Add(PythonTuple.MakeTuple(de.Value));
+                res.Add(PythonTuple.MakeTuple(de.Key, de.Value));
             }
 
             return res;

--- a/Src/IronPythonTest/Conversions.cs
+++ b/Src/IronPythonTest/Conversions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using IronPython.Runtime;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -69,11 +70,11 @@ namespace IronPythonTest {
         public static IList<object> ToIDictionary(IDictionary dict) {
             List<object> res = new List<object>();
             foreach (DictionaryEntry de in dict) {
-                res.Add(de.Key);
+                res.Add(PythonTuple.MakeTuple(de.Key));
             }
 
             foreach (DictionaryEntry de in dict) {
-                res.Add(de.Value);
+                res.Add(PythonTuple.MakeTuple(de.Value));
             }
 
             return res;

--- a/Tests/modules/misc/test__weakref.py
+++ b/Tests/modules/misc/test__weakref.py
@@ -159,8 +159,15 @@ def %s(self, *args, **kwargs):
                 self.assertEqual(eval('x ' + op + ' 3'), op == '!='); self.assertEqual(called, None)
                 self.assertEqual(eval('3 ' + op + ' x'), op == '!='); self.assertEqual(called, None)
             else:
-                res1, res2 = eval('x ' + op + ' 3'), eval('3 ' + op + ' x')
-                self.assertEqual(called, None)
-                self.assertTrue((res1 == True and res2 == False) or (res1 == False and res2 == True))
+                try:
+                    eval('x ' + op + ' 3')
+                    self.assertUnreachable()
+                except TypeError:
+                    pass
+                try:
+                    eval('3 ' + op + ' x')
+                    self.assertUnreachable()
+                except TypeError:
+                    pass
 
 run_test(__name__)

--- a/Tests/modules/misc/test__weakref.py
+++ b/Tests/modules/misc/test__weakref.py
@@ -140,6 +140,7 @@ class _WeakrefTest(IronPythonTestCase):
         self.assertTrue(not x==3)
         self.assertRaises(ReferenceError, lambda: x==y)
 
+    # https://github.com/IronLanguages/ironpython3/issues/697
     @unittest.expectedFailure
     def test_equals(self):
         global called

--- a/Tests/modules/misc/test__weakref.py
+++ b/Tests/modules/misc/test__weakref.py
@@ -140,6 +140,7 @@ class _WeakrefTest(IronPythonTestCase):
         self.assertTrue(not x==3)
         self.assertRaises(ReferenceError, lambda: x==y)
 
+    @unittest.expectedFailure
     def test_equals(self):
         global called
         class C:
@@ -155,19 +156,6 @@ def %s(self, *args, **kwargs):
         x = _weakref.proxy(a)
         for op in ('==', '>', '<', '>=', '<=', '!='):
             self.assertEqual(eval('a ' + op + ' 3'), True);  self.assertEqual(called, op); called = None
-            if op == '==' or op == '!=':
-                self.assertEqual(eval('x ' + op + ' 3'), op == '!='); self.assertEqual(called, None)
-                self.assertEqual(eval('3 ' + op + ' x'), op == '!='); self.assertEqual(called, None)
-            else:
-                try:
-                    eval('x ' + op + ' 3')
-                    self.assertUnreachable()
-                except TypeError:
-                    pass
-                try:
-                    eval('3 ' + op + ' x')
-                    self.assertUnreachable()
-                except TypeError:
-                    pass
+            self.assertEqual(eval('x ' + op + ' 3'), True);  self.assertEqual(called, op); called = None
 
 run_test(__name__)

--- a/Tests/modules/system_related/test_nt.py
+++ b/Tests/modules/system_related/test_nt.py
@@ -586,10 +586,6 @@ class NtTest(IronPythonTestCase):
         self.assertEqual(x + x, tuple(range(10))*2)
 
         #> (list/object)
-        if is_cli:
-            self.assertTrue(nt.stat_result(range(10)) > None)
-            self.assertTrue(nt.stat_result(range(10)) > 1)
-            self.assertTrue(nt.stat_result(range(10)) > range(10))
         self.assertTrue(nt.stat_result([1 for x in range(10)]) > nt.stat_result(range(10)))
         self.assertTrue(not nt.stat_result(range(10)) > nt.stat_result(range(10)))
         self.assertTrue(not nt.stat_result(range(10)) > nt.stat_result(range(11)))
@@ -597,10 +593,6 @@ class NtTest(IronPythonTestCase):
         self.assertTrue(not nt.stat_result(range(11)) > nt.stat_result(range(10)))
 
         #< (list/object)
-        if is_cli:
-            self.assertTrue(not nt.stat_result(range(10)) < None)
-            self.assertTrue(not nt.stat_result(range(10)) < 1)
-            self.assertTrue(not nt.stat_result(range(10)) < range(10))
         self.assertTrue(not nt.stat_result([1 for x in range(10)]) < nt.stat_result(range(10)))
         self.assertTrue(not nt.stat_result(range(10)) < nt.stat_result(range(10)))
         self.assertTrue(not nt.stat_result(range(10)) < nt.stat_result(range(11)))
@@ -608,10 +600,6 @@ class NtTest(IronPythonTestCase):
         self.assertTrue(not nt.stat_result(range(11)) < nt.stat_result(range(10)))
 
         #>= (list/object)
-        if is_cli:
-            self.assertTrue(nt.stat_result(range(10)) >= None)
-            self.assertTrue(nt.stat_result(range(10)) >= 1)
-            self.assertTrue(nt.stat_result(range(10)) >= range(10))
         self.assertTrue(nt.stat_result([1 for x in range(10)]) >= nt.stat_result(range(10)))
         self.assertTrue(nt.stat_result(range(10)) >= nt.stat_result(range(10)))
         self.assertTrue(nt.stat_result(range(10)) >= nt.stat_result(range(11)))
@@ -619,10 +607,6 @@ class NtTest(IronPythonTestCase):
         self.assertTrue(nt.stat_result(range(11)) >= nt.stat_result(range(10)))
 
         #<= (list/object)
-        if is_cli:
-            self.assertTrue(not nt.stat_result(range(10)) <= None)
-            self.assertTrue(not nt.stat_result(range(10)) <= 1)
-            self.assertTrue(not nt.stat_result(range(10)) <= range(10))
         self.assertTrue(not nt.stat_result([1 for x in range(10)]) <= nt.stat_result(range(10)))
         self.assertTrue(nt.stat_result(range(10)) <= nt.stat_result(range(10)))
         self.assertTrue(nt.stat_result(range(10)) <= nt.stat_result(range(11)))

--- a/Tests/modules/system_related/test_nt.py
+++ b/Tests/modules/system_related/test_nt.py
@@ -591,6 +591,9 @@ class NtTest(IronPythonTestCase):
         self.assertTrue(not nt.stat_result(range(10)) > nt.stat_result(range(11)))
         self.assertTrue(not nt.stat_result(range(10)) > nt.stat_result([1 for x in range(10)]))
         self.assertTrue(not nt.stat_result(range(11)) > nt.stat_result(range(10)))
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) > None)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) > 1)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) > range(10))
 
         #< (list/object)
         self.assertTrue(not nt.stat_result([1 for x in range(10)]) < nt.stat_result(range(10)))
@@ -598,6 +601,9 @@ class NtTest(IronPythonTestCase):
         self.assertTrue(not nt.stat_result(range(10)) < nt.stat_result(range(11)))
         self.assertTrue(nt.stat_result(range(10)) < nt.stat_result([1 for x in range(10)]))
         self.assertTrue(not nt.stat_result(range(11)) < nt.stat_result(range(10)))
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) < None)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) < 1)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) < range(10))
 
         #>= (list/object)
         self.assertTrue(nt.stat_result([1 for x in range(10)]) >= nt.stat_result(range(10)))
@@ -605,6 +611,9 @@ class NtTest(IronPythonTestCase):
         self.assertTrue(nt.stat_result(range(10)) >= nt.stat_result(range(11)))
         self.assertTrue(not nt.stat_result(range(10)) >= nt.stat_result([1 for x in range(10)]))
         self.assertTrue(nt.stat_result(range(11)) >= nt.stat_result(range(10)))
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) >= None)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) >= 1)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) >= range(10))
 
         #<= (list/object)
         self.assertTrue(not nt.stat_result([1 for x in range(10)]) <= nt.stat_result(range(10)))
@@ -612,6 +621,9 @@ class NtTest(IronPythonTestCase):
         self.assertTrue(nt.stat_result(range(10)) <= nt.stat_result(range(11)))
         self.assertTrue(nt.stat_result(range(10)) <= nt.stat_result([1 for x in range(10)]))
         self.assertTrue(nt.stat_result(range(11)) <= nt.stat_result(range(10)))
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) <= None)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) <= 1)
+        self.assertRaises(TypeError, lambda: nt.stat_result(range(10)) <= range(10))
 
         #* (size/stat_result)
         x = nt.stat_result(range(10))

--- a/Tests/test_attr.py
+++ b/Tests/test_attr.py
@@ -56,7 +56,7 @@ class AttrTest(IronPythonTestCase):
             CheckDictionary(mod.__dict__)
 
             mod.__dict__[1] = '1'
-            self.assertEqual(dir(mod).__contains__(1), True)
+            self.assertRaises(TypeError, lambda: dir(mod).__contains__(1))
             del mod.__dict__[1]
 
             # Try to replace __dict__

--- a/Tests/test_builtinfunc.py
+++ b/Tests/test_builtinfunc.py
@@ -339,8 +339,6 @@ class BuiltinsTest2(IronPythonTestCase):
         self.assertTrue(max((), default=1) == 1)
         self.assertTrue(max([], default=None) is None)
 
-        self.assertEqual(max((1,2), None), (1, 2))
-
         self.assertEqual(max(1, 2, 3.0), 3.0)
         self.assertEqual(max(1, 2.0, 3), 3)
         self.assertEqual(max(1.0, 2, 3), 3)
@@ -348,6 +346,7 @@ class BuiltinsTest2(IronPythonTestCase):
         self.assertRaises(TypeError, max)
         self.assertRaises(TypeError, max, 42)
         self.assertRaises(ValueError, max, ())
+        self.assertRaises(TypeError, max, (1, 2), None)
         class BadSeq:
             def __getitem__(self, index):
                 raise ValueError

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -1047,14 +1047,14 @@ class BytesTest(IronPythonTestCase):
 
                 self.assertEqual(testType(ab) == [], False)
 
-                self.assertEqual(testType(a) > None, True)
-                self.assertEqual(testType(a) < None, False)
-                self.assertEqual(testType(a) <= None, False)
-                self.assertEqual(testType(a) >= None, True)
-                self.assertEqual(None > testType(a), False)
-                self.assertEqual(None < testType(a), True)
-                self.assertEqual(None <= testType(a), True)
-                self.assertEqual(None >= testType(a), False)
+                self.assertRaises(TypeError, lambda: testType(a) > None)
+                self.assertRaises(TypeError, lambda: testType(a) < None)
+                self.assertRaises(TypeError, lambda: testType(a) <= None)
+                self.assertRaises(TypeError, lambda: testType(a) >= None)
+                self.assertRaises(TypeError, lambda: None > testType(a))
+                self.assertRaises(TypeError, lambda: None < testType(a))
+                self.assertRaises(TypeError, lambda: None <= testType(a))
+                self.assertRaises(TypeError, lambda: None >= testType(a))
 
 
     def test_bytearray(self):

--- a/Tests/test_dict.py
+++ b/Tests/test_dict.py
@@ -472,17 +472,28 @@ class DictTest(IronPythonTestCase):
         self.load_iron_python_test()
         from IronPythonTest import DictConversion
         class MyDict(dict): pass
+        class KOld: pass
+        class KNew(object): pass
+        class KOldDerived(KOld): pass
+        class KNewDerived(KNew): pass
 
         test_dicts = [
                         {},
                         {1:100},
+                        {None:None},
                         {object:object},
                         {1:100, 2:200},
                         {1:100, 2:200, 3:300, 4:400},
+                        MyDict.__dict__,
+                        KOld.__dict__,
+                        KNew.__dict__,
+                        KOldDerived.__dict__,
+                        KNewDerived.__dict__,
                         ]
 
         for temp_dict in test_dicts:
-            expected = list(temp_dict.keys()) + list(temp_dict.values())
+            expected = list((key,) for key in temp_dict.keys()) + \
+                       list((val,) for val in temp_dict.values())
             expected.sort()
 
             to_idict = list(DictConversion.ToIDictionary(temp_dict))

--- a/Tests/test_dict.py
+++ b/Tests/test_dict.py
@@ -472,23 +472,13 @@ class DictTest(IronPythonTestCase):
         self.load_iron_python_test()
         from IronPythonTest import DictConversion
         class MyDict(dict): pass
-        class KOld: pass
-        class KNew(object): pass
-        class KOldDerived(KOld): pass
-        class KNewDerived(KNew): pass
 
         test_dicts = [
                         {},
                         {1:100},
-                        {None:None},
                         {object:object},
                         {1:100, 2:200},
                         {1:100, 2:200, 3:300, 4:400},
-                        MyDict.__dict__,
-                        KOld.__dict__,
-                        KNew.__dict__,
-                        KOldDerived.__dict__,
-                        KNewDerived.__dict__,
                         ]
 
         for temp_dict in test_dicts:

--- a/Tests/test_dict.py
+++ b/Tests/test_dict.py
@@ -492,8 +492,7 @@ class DictTest(IronPythonTestCase):
                         ]
 
         for temp_dict in test_dicts:
-            expected = list((key,) for key in temp_dict.keys()) + \
-                       list((val,) for val in temp_dict.values())
+            expected = list((key, temp_dict[key]) for key in temp_dict.keys())
             expected.sort()
 
             to_idict = list(DictConversion.ToIDictionary(temp_dict))

--- a/Tests/test_tuple.py
+++ b/Tests/test_tuple.py
@@ -155,21 +155,21 @@ class TupleTest(IronPythonTestCase):
 
 
     def test_compare_to_none(self):
-        self.assertTrue((None,) > None)
-        self.assertTrue(not None >= (None,))
+        self.assertRaises(TypeError, lambda: (None,) > None)
+        self.assertRaises(TypeError, lambda: not None >= (None,))
         self.assertTrue((None,)==(None,))
 
-        self.assertEqual(tuple() > None, True)
-        self.assertEqual(tuple() < None, False)
-        self.assertEqual(tuple() >= None, True)
-        self.assertEqual(tuple() <= None, False)
+        self.assertRaises(TypeError, lambda: tuple() > None)
+        self.assertRaises(TypeError, lambda: tuple() < None)
+        self.assertRaises(TypeError, lambda: tuple() >= None)
+        self.assertRaises(TypeError, lambda: tuple() <= None)
         self.assertTrue(    tuple() != None)
         self.assertTrue(not tuple() == None)
 
-        self.assertEqual(None < tuple(), True)
-        self.assertEqual(None > tuple(), False)
-        self.assertEqual(None <= tuple(), True)
-        self.assertEqual(None >= tuple(), False)
+        self.assertRaises(TypeError, lambda: None < tuple())
+        self.assertRaises(TypeError, lambda: None > tuple())
+        self.assertRaises(TypeError, lambda: None <= tuple())
+        self.assertRaises(TypeError, lambda: None >= tuple())
         self.assertTrue(    None != tuple())
         self.assertTrue(not None == tuple())
 


### PR DESCRIPTION
Remove type comparison fallbacks for the '<', '>', '<=', and '>='
operators and throw a TypeError instead when no suitable comparator is
found between two types.

Listed in #33. 