### PR TITLE
Implement codecs.strict_errors

### DIFF
--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1940,19 +1940,22 @@ namespace IronPython.Runtime.Operations {
                 return d;
             }
 
-            internal static readonly Lazy<Dictionary<string, object>> ErrorHandlers = new Lazy<Dictionary<string, object>>(MakeErrorHandlersDict);
-
-            private delegate object ErrorHandler(object unicodeError);
-
-            private static Dictionary<string, object> MakeErrorHandlersDict() {
+            internal static Dictionary<string, object> MakeErrorHandlersDict() {
                 var d = new Dictionary<string, object>();
 
-                d["strict"] = new ErrorHandler(StrictErrors);
+                d["strict"] = BuiltinFunction.MakeFunction(
+                    "strict_errors", 
+                    ReflectionUtils.GetMethodInfos(typeof(StringOps).GetMember(nameof(StrictErrors), BindingFlags.Static | BindingFlags.NonPublic)), 
+                    typeof(StringOps));
+
                 // TODO: Implement remaining error handlers
-                d["ignore"] = new ErrorHandler(StrictErrors);
-                d["replace"] = new ErrorHandler(StrictErrors);
-                d["xmlcharrefreplace"] = new ErrorHandler(StrictErrors);
-                d["backslashreplace"] = new ErrorHandler(StrictErrors);
+                d["ignore"] = null;
+
+                d["replace"] = null;
+
+                d["xmlcharrefreplace"] = null;
+
+                d["backslashreplace"] = null;
 
                 return d;
             }

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1887,7 +1887,11 @@ namespace IronPython.Runtime {
         internal Dictionary<string, object> ErrorHandlers {
             get {
                 if (_errorHandlers == null) {
+#if FEATURE_ENCODING
+                    _errorHandlers = StringOps.CodecsInfo.ErrorHandlers.Value;
+#else
                     Interlocked.CompareExchange(ref _errorHandlers, new Dictionary<string, object>(), null);
+#endif
                 }
 
                 return _errorHandlers;

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1888,7 +1888,7 @@ namespace IronPython.Runtime {
             get {
                 if (_errorHandlers == null) {
 #if FEATURE_ENCODING
-                    _errorHandlers = StringOps.CodecsInfo.ErrorHandlers.Value;
+                    Interlocked.CompareExchange(ref _errorHandlers, StringOps.CodecsInfo.MakeErrorHandlersDict(), null);
 #else
                     Interlocked.CompareExchange(ref _errorHandlers, new Dictionary<string, object>(), null);
 #endif

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -471,6 +471,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaisesRegex(TypeError, "codec must pass exception instance", strict, None)
         self.assertRaisesRegex(TypeError, "\w+\(\) takes exactly (one|1) argument \(0 given\)", strict)
         self.assertRaisesRegex(TypeError, "\w+\(\) takes exactly (one|1) argument \(2 given\)", strict, ude, uee)
+        self.assertRaises(LookupError, codecs.lookup_error, "STRICT")
 
         return # TODO: Implement remaining error handlers
 

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -454,6 +454,47 @@ class CodecTest(IronPythonTestCase):
         for x in ['iso-8859-1', 'iso8859-1', '8859', 'cp819', 'latin', 'latin1', 'L1']:
             self.assertEqual('abc'.encode(x), b'abc')
 
+    def test_error_handlers(self):
+        ude = UnicodeDecodeError('dummy', b"abcdefgh", 3, 5, "decoding testing purposes")
+        uee = UnicodeEncodeError('dummy', "abcdefgh", 2, 6, "encoding testing purposes")
+        unicode_data = "ab\xff\u20ac\U0001f40d"
+        uee_unicode = UnicodeEncodeError('dummy', unicode_data, 2, len(unicode_data), "encoding testing purposes")
+
+        strict = codecs.lookup_error('strict')
+        self.assertEqual(strict, codecs.strict_errors)
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            strict(ude)
+        self.assertEqual(cm.exception, ude)
+        with self.assertRaises(UnicodeEncodeError) as cm:
+            strict(uee)
+        self.assertEqual(cm.exception, uee)
+        self.assertRaisesRegex(TypeError, "codec must pass exception instance", strict, None)
+        self.assertRaisesRegex(TypeError, "\w+\(\) takes exactly (one|1) argument \(0 given\)", strict)
+        self.assertRaisesRegex(TypeError, "\w+\(\) takes exactly (one|1) argument \(2 given\)", strict, ude, uee)
+
+        return # TODO: Implement remaining error handlers
+
+        ignore = codecs.lookup_error('ignore')
+        self.assertEqual(ignore, codecs.ignore_errors)
+        self.assertEqual(ignore(ude), ("", 5))
+        self.assertEqual(ignore(uee), ("", 6))
+
+        replace = codecs.lookup_error('replace')
+        self.assertEqual(replace, codecs.replace_errors)
+        self.assertEqual(replace(ude), ("�", 5))
+        self.assertEqual(replace(uee), ("????", 6))
+
+        backslashreplace = codecs.lookup_error('backslashreplace')
+        self.assertEqual(backslashreplace, codecs.backslashreplace_errors)
+        self.assertRaisesRegex(TypeError, "don't know how to handle UnicodeDecodeError in error callback", backslashreplace, ude)
+        self.assertEqual(backslashreplace(uee), (r"\x63\x64\x65\x66", 6))
+        self.assertEqual(backslashreplace(uee_unicode), (r"\xff\u20ac\U0001f40d", uee_unicode.end))
+
+        xmlcharrefreplace = codecs.lookup_error('xmlcharrefreplace')
+        self.assertEqual(xmlcharrefreplace, codecs.xmlcharrefreplace_errors)
+        self.assertRaisesRegex(TypeError, "don't know how to handle UnicodeDecodeError in error callback", xmlcharrefreplace, ude)
+        self.assertEqual(xmlcharrefreplace(uee), ("&#99;&#100;&#101;&#102;", 6))
+
     #TODO: @skip("multiple_execute")
     def test_lookup_error(self):
         #sanity


### PR DESCRIPTION
Current `codecs` module lacks a number of standalone error handling functions (or, to be exact, the exported symbols are not callable):

```
>>> import codecs
>>> [ f for f in dir(codecs) if f.endswith("errors")]
['backslashreplace_errors', 'ignore_errors', 'replace_errors', 'strict_errors', 'xmlcharrefreplace_errors']
```

This PR implements `strict_errors` as a pilot; if the approach is agreed upon, I will implement the remaining ones in a similar fashion.

I am not quite sure whether using a delegate to put into the error handlers dictionary is the right way; perhaps there is a better, more ironpythonic way of doing it. As it is now, there are some subtle differences between IronPython and CPython regarding the type:

_CPython_:

```
>>> codecs.strict_errors
<built-in function strict_errors>
>>> type(codecs.strict_errors)
<class 'builtin_function_or_method'>
>>> codecs.strict_errors()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: strict_errors() takes exactly one argument (0 given)
```

_IronPython_:

```
>>> codecs.strict_errors
<IronPython.Runtime.Operations.StringOps+CodecsInfo+ErrorHandler object at 0x000000000000008E [IronPython.Runtime.Operations.StringOps+CodecsInfo+ErrorHandler]>
>>> type(codecs.strict_errors)
<class 'ErrorHandler'>
>>> codecs.strict_errors()    
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Invoke() takes exactly 1 argument (0 given)
```

Functionality-wise, they behave the same.