### PR TITLE
Clean up str/bytes iterator code

### DIFF
--- a/Src/IronPython/Runtime/Binding/ConversionBinder.cs
+++ b/Src/IronPython/Runtime/Binding/ConversionBinder.cs
@@ -450,7 +450,7 @@ namespace IronPython.Runtime.Binding {
                 return ((CallSite<Func<CallSite, Bytes, IEnumerable>>)site).Update(site, value);
             }
 
-            return PythonOps.BytesIntEnumerable(value);
+            return PythonOps.BytesEnumerable(value);
         }
 
         public IEnumerator BytesToIEnumeratorConversion(CallSite site, Bytes value) {
@@ -458,7 +458,7 @@ namespace IronPython.Runtime.Binding {
                 return ((CallSite<Func<CallSite, Bytes, IEnumerator>>)site).Update(site, value);
             }
 
-            return PythonOps.BytesIntEnumerator(value).Key;
+            return PythonOps.BytesEnumerator(value).Key;
         }
 
         public IEnumerable ObjectToIEnumerableConversion(CallSite site, object value) {
@@ -466,7 +466,7 @@ namespace IronPython.Runtime.Binding {
                 if (value is string) {
                     return PythonOps.StringEnumerable((string)value);
                 } else if (value.GetType() == typeof(Bytes)) {
-                    return PythonOps.BytesIntEnumerable((Bytes)value);
+                    return PythonOps.BytesEnumerable((Bytes)value);
                 }
             }
 
@@ -478,7 +478,7 @@ namespace IronPython.Runtime.Binding {
                 if (value is string) {
                     return PythonOps.StringEnumerator((string)value).Key;
                 } else if (value.GetType() == typeof(Bytes)) {
-                    return PythonOps.BytesIntEnumerator((Bytes)value).Key;
+                    return PythonOps.BytesEnumerator((Bytes)value).Key;
                 }
             }
 

--- a/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
+++ b/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
@@ -456,7 +456,7 @@ namespace IronPython.Runtime.Binding {
 
                 return new DynamicMetaObject(
                     Expression.Call(
-                        typeof(PythonOps).GetMethod(nameof(PythonOps.BytesIntEnumerator)),
+                        typeof(PythonOps).GetMethod(nameof(PythonOps.BytesEnumerator)),
                         self.Expression
                     ),
                     self.Restrictions

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1414,7 +1414,7 @@ namespace IronPython.Runtime {
         #endregion
 
         public IEnumerator __iter__() {
-            return PythonOps.BytesIntEnumerator(this).Key;
+            return PythonOps.BytesEnumerator(this).Key;
         }
 
         #region IEnumerable<byte> Members

--- a/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
+++ b/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
@@ -1236,87 +1236,12 @@ namespace IronPython.Runtime.Operations {
 
         #region Conversion and Enumeration
 
-        [PythonType("bytes_iterator")]
-        private class PythonBytesEnumerator<T> : IEnumerable, IEnumerator<T> {
-            private readonly IList<byte>/*!*/ _bytes;
-            private readonly Func<byte, T>/*!*/ _conversion;
-            private int _index;
-
-            public PythonBytesEnumerator(IList<byte> bytes, Func<byte, T> conversion) {
-                Assert.NotNull(bytes);
-                Assert.NotNull(conversion);
-
-                _bytes = bytes;
-                _conversion = conversion;
-                _index = -1;
-            }
-
-            #region IEnumerator<T> Members
-
-            public T Current {
-                get {
-                    if (_index < 0) {
-                        throw PythonOps.SystemError("Enumeration has not started. Call MoveNext.");
-                    } else if (_index >= _bytes.Count) {
-                        throw PythonOps.SystemError("Enumeration already finished.");
-                    }
-                    return _conversion(_bytes[_index]);
-                }
-            }
-
-            #endregion
-
-            #region IDisposable Members
-
-            public void Dispose() { }
-
-            #endregion
-
-            #region IEnumerator Members
-
-            object IEnumerator.Current {
-                get {
-                    return ((IEnumerator<T>)this).Current;
-                }
-            }
-
-            public bool MoveNext() {
-                if (_index >= _bytes.Count) {
-                    return false;
-                }
-                _index++;
-                return _index != _bytes.Count;
-            }
-
-            public void Reset() {
-                _index = -1;
-            }
-
-            #endregion
-
-            #region IEnumerable Members
-
-            public IEnumerator GetEnumerator() {
-                return this;
-            }
-
-            #endregion
-        }
-
         internal static IEnumerable BytesEnumerable(IList<byte> bytes) {
-            return new PythonBytesEnumerator<Bytes>(bytes, b => Bytes.FromByte(b));
+            return new PythonBytesIterator(bytes);
         }
 
-        internal static IEnumerable BytesIntEnumerable(IList<byte> bytes) {
-            return new PythonBytesEnumerator<int>(bytes, b => (int)b);
-        }
-
-        internal static IEnumerator<Bytes> BytesEnumerator(IList<byte> bytes) {
-            return new PythonBytesEnumerator<Bytes>(bytes, b => Bytes.FromByte(b));
-        }
-
-        internal static IEnumerator<int> BytesIntEnumerator(IList<byte> bytes) {
-            return new PythonBytesEnumerator<int>(bytes, b => (int)b);
+        internal static IEnumerator<int> BytesEnumerator(IList<byte> bytes) {
+            return new PythonBytesIterator(bytes);
         }
 
         #endregion

--- a/Src/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/Src/IronPython/Runtime/Operations/InstanceOps.cs
@@ -189,7 +189,7 @@ namespace IronPython.Runtime.Operations {
 
         // 3.0-only
         public static object IterMethodForBytes(Bytes self) {
-            return IListOfByteOps.BytesIntEnumerator(self);
+            return IListOfByteOps.BytesEnumerator(self);
         }
 
         public static object IterMethodForEnumerator(IEnumerator self) {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1940,10 +1940,6 @@ namespace IronPython.Runtime.Operations {
             return new KeyValuePair<IEnumerator, IDisposable>(IListOfByteOps.BytesEnumerator(bytes), null);
         }
 
-        public static KeyValuePair<IEnumerator, IDisposable> BytesIntEnumerator(IList<byte> bytes) {
-            return new KeyValuePair<IEnumerator, IDisposable>(IListOfByteOps.BytesIntEnumerator(bytes), null);
-        }
-
         public static KeyValuePair<IEnumerator, IDisposable> GetEnumeratorFromEnumerable(IEnumerable enumerable) {
             IEnumerator enumerator = enumerable.GetEnumerator();
             return new KeyValuePair<IEnumerator, IDisposable>(enumerator, enumerator as IDisposable);
@@ -1955,10 +1951,6 @@ namespace IronPython.Runtime.Operations {
 
         public static IEnumerable BytesEnumerable(IList<byte> bytes) {
             return IListOfByteOps.BytesEnumerable(bytes);
-        }
-
-        public static IEnumerable BytesIntEnumerable(IList<byte> bytes) {
-            return IListOfByteOps.BytesIntEnumerable(bytes);
         }
 
         #region Exception handling

--- a/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
@@ -761,10 +761,7 @@ namespace IronPython.Runtime.Operations {
                     nt = NameType.Property;
                 }
 
-                if (!(pt is ExtensionPropertyTracker ept)) {
-                    ReflectedPropertyTracker rpt = pt as ReflectedPropertyTracker;
-                    Debug.Assert(rpt != null);
-
+                if (pt is ReflectedPropertyTracker rpt) {
                     if (PythonBinder.IsExtendedType(pt.DeclaringType) ||
                         PythonHiddenAttribute.IsHidden(rpt.Property, true)) {
                         nt = NameType.Property;
@@ -800,9 +797,10 @@ namespace IronPython.Runtime.Operations {
                         }
                         rp = new ReflectedProperty(rpt.Property, getters.ToArray(), setters.ToArray(), nt);
                     } else {
-                        rp = new ReflectedIndexer(((ReflectedPropertyTracker)pt).Property, NameType.Property, privateBinding);
+                        rp = new ReflectedIndexer(rpt.Property, NameType.Property, privateBinding);
                     }
                 } else {
+                    Debug.Assert(pt is ExtensionPropertyTracker);
                     rp = new ReflectedExtensionProperty(new ExtensionPropertyInfo(pt.DeclaringType, getter ?? setter), nt);
                 }
 

--- a/Src/IronPython/Runtime/PythonBytesIterator.cs
+++ b/Src/IronPython/Runtime/PythonBytesIterator.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+using Microsoft.Scripting.Utils;
+
+using IronPython.Runtime.Operations;
+
+namespace IronPython.Runtime {
+    [PythonType("bytes_iterator")]
+    public class PythonBytesIterator : IEnumerable, IEnumerator<int> {
+        private readonly IList<byte>/*!*/ _bytes;
+        private int _index;
+
+        public PythonBytesIterator(IList<byte> bytes) {
+            Assert.NotNull(bytes);
+
+            _bytes = bytes;
+            _index = -1;
+        }
+
+        #region IEnumerator<T> Members
+
+        [PythonHidden]
+        public int Current {
+            get {
+                if (_index < 0) {
+                    throw PythonOps.SystemError("Enumeration has not started. Call MoveNext.");
+                } else if (_index >= _bytes.Count) {
+                    throw PythonOps.SystemError("Enumeration already finished.");
+                }
+                return _bytes[_index];
+            }
+        }
+
+        #endregion
+
+        #region IDisposable Members
+
+        [PythonHidden]
+        public void Dispose() { }
+
+        #endregion
+
+        #region IEnumerator Members
+
+        object IEnumerator.Current {
+            get {
+                return ((IEnumerator<int>)this).Current;
+            }
+        }
+
+        [PythonHidden]
+        public bool MoveNext() {
+            if (_index >= _bytes.Count) {
+                return false;
+            }
+            _index++;
+            return _index != _bytes.Count;
+        }
+
+        [PythonHidden]
+        public void Reset() {
+            _index = -1;
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        [PythonHidden]
+        public IEnumerator GetEnumerator() {
+            return this;
+        }
+
+        #endregion
+    }
+}

--- a/Src/IronPython/Runtime/PythonHiddenAttribute.cs
+++ b/Src/IronPython/Runtime/PythonHiddenAttribute.cs
@@ -9,7 +9,7 @@ namespace IronPython.Runtime {
     /// <summary>
     /// Marks a member as being hidden from Python code.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public sealed class PythonHiddenAttribute : PlatformsAttribute {
         public PythonHiddenAttribute(params PlatformID[] hiddenPlatforms) {
             ValidPlatforms = hiddenPlatforms;

--- a/Src/IronPython/Runtime/PythonStrIterator.cs
+++ b/Src/IronPython/Runtime/PythonStrIterator.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+using Microsoft.Scripting.Runtime;
+using Microsoft.Scripting.Utils;
+
+using IronPython.Runtime.Types;
+using IronPython.Runtime.Operations;
+
+namespace IronPython.Runtime {
+    // note: any changes in how this iterator works should also be applied in the
+    //       optimized overloads of Builtins.map()
+    [PythonType("str_iterator")]
+    public class PythonStrIterator : IEnumerable, IEnumerator<string> {
+        private readonly string/*!*/ _s;
+        private int _index;
+
+        public PythonStrIterator(string s) {
+            Assert.NotNull(s);
+
+            _index = -1;
+            _s = s;
+        }
+
+        public PythonTuple __reduce__(CodeContext/*!*/ context) {
+            object iter;
+            context.TryLookupBuiltin("iter", out iter);
+            return PythonTuple.MakeTuple(
+                iter,
+                PythonTuple.MakeTuple(_s),
+                _index + 1
+            );
+        }
+
+        public void __setstate__(int index) {
+            _index = index - 1;
+        }
+
+        #region IEnumerable Members
+
+        [PythonHidden]
+        public IEnumerator GetEnumerator() {
+            return this;
+        }
+
+        #endregion
+
+        #region IEnumerator<string> Members
+
+        [PythonHidden]
+        public string Current {
+            get {
+                if (_index < 0) {
+                    throw PythonOps.SystemError("Enumeration has not started. Call MoveNext.");
+                } else if (_index >= _s.Length) {
+                    throw PythonOps.SystemError("Enumeration already finished.");
+                }
+                return ScriptingRuntimeHelpers.CharToString(_s[_index]);
+            }
+        }
+
+        #endregion
+
+        #region IDisposable Members
+
+        [PythonHidden]
+        public void Dispose() { }
+
+        #endregion
+
+        #region IEnumerator Members
+
+        object IEnumerator.Current {
+            get {
+                return ((IEnumerator<string>)this).Current;
+            }
+        }
+
+        [PythonHidden]
+        public bool MoveNext() {
+            if (_index >= _s.Length) {
+                return false;
+            }
+            _index++;
+            return _index != _s.Length;
+        }
+
+        [PythonHidden]
+        public void Reset() {
+            _index = -1;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Renames and moves the `str_iterator` and `bytes_iterator` types to new files and marks its C# members are `PythonHidden`. Also allows `PythonHiddenAttribute` on properties.