### PR TITLE
Enable testing with CPython on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,7 @@ launchSettings.json
 *.o
 /Src/ctypes_test/*.pyd
 /Src/ctypes_test/*.pyd
-/Src/StdLib/Lib/__pycache__
+/Src/StdLib/Lib/**/__pycache__
+/Src/IronPython/Lib/**/__pycache__
+/Tests/**/__pycache__
 /Tests/modules/misc/test_data.gz

--- a/Src/IronPython/Lib/iptest/test_env.py
+++ b/Src/IronPython/Lib/iptest/test_env.py
@@ -11,7 +11,8 @@ import sys, os
 is_cli =         sys.implementation.name == 'ironpython'
 is_ironpython =  is_cli
 is_cpython    =  not is_ironpython
-is_posix      =  sys.platform == 'posix'
+is_windows    =  sys.platform == 'win32'
+is_posix      =  sys.platform == 'posix' or sys.platform == 'linux'
 is_osx        =  sys.platform == 'darwin'
 is_netcoreapp =  False
 is_netcoreapp21 = False
@@ -38,12 +39,9 @@ if is_ironpython:
 
 is_32, is_64 = is_cli32, is_cli64
 if not is_ironpython:
-    cpu = os.environ["PROCESSOR_ARCHITECTURE"]
-    if cpu.lower()=="x86":
-        is_32 = True
-    elif cpu.lower()=="amd64":
-        is_64 = True
-    
+    import struct
+    ptr_size = struct.calcsize('P')
+    is_32, is_64 = (ptr_size == 4), (ptr_size == 8)    
 
 #--CLR version we're running on (if any)
 


### PR DESCRIPTION
The value of `sys.platform` in CPython on Linux is `linux`, while IronPython reports `posix`. Many tests that are not meant to be run on Linux are guarded by `is_posix`, so I have extended the definition of it to include what CPython reports. In this way I am able to verify the tests with CPython while working on Linux.

CPython is apparently more detailed in `sys.platform` than IronPython (which only differentiates `darwin`), and adding only `'linux'` here is not exhaustive for all POSIX systems. CPython will report `posix` as `os.name` (which includes the `darwin` case) and `sys.platform` as `unknown` if not recognized.

Note that the value of `sys.platform` is printed out on REPL start, right after `on`:

<pre><code>Python 3.4.4 (v3.4.4:737efcadf5a6, Dec 20 2015, 20:20:57) [MSC v.1600 64 bit (AMD64)] <strong>on win32</strong>
Type "help", "copyright", "credits" or "license" for more information.
>>>

Python 3.6.9 (default, Nov  7 2019, 10:44:02)
[GCC 8.3.0] <strong>on linux</strong>
Type "help", "copyright", "credits" or "license" for more information.
>>>

Python 3.7.5 (default, Nov  1 2019, 02:16:38)
[Clang 10.0.0 (clang-1000.11.45.5)] <strong>on darwin</strong>
Type "help", "copyright", "credits" or "license" for more information.
>>>
</code></pre>

IronPython does not do it, maybe worth considering adding?

 * * *

The environment variable `PROCESSOR_ARCHITECTURE` is Windows-specific. I have changed the bitness detection for the CPython case to be more portable, based on pointer size, like the IronPython's bitness detection test.