### PR TITLE
Test codecs linux

### DIFF
--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, is_windows, is_osx, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, is_windows, run_test, skipUnlessIronPython
 from iptest.misc_util import ip_supported_encodings
 
 if is_cpython and is_posix:
@@ -885,7 +885,7 @@ class CodecTest(IronPythonTestCase):
         #Sanity Negative
         self.assertRaises(UnicodeEncodeError, codecs.charmap_encode, "abc", "strict", {})
 
-    @unittest.skipIf(is_posix or is_osx, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
+    @unittest.skipIf(is_posix, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
     def test_mbcs_decode(self):
         for mode in ['strict', 'replace', 'ignore', 'badmodethatdoesnotexist']:
             if is_netcoreapp and mode == 'badmodethatdoesnotexist': continue # FallbackBuffer created even if not used
@@ -897,7 +897,7 @@ class CodecTest(IronPythonTestCase):
             # round tripping
             self.assertEqual(codecs.mbcs_encode(codecs.mbcs_decode(allchars, mode)[0])[0], allchars)
 
-    @unittest.skipIf(is_posix or is_osx, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
+    @unittest.skipIf(is_posix, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
     def test_mbcs_encode(self):
         # these are invalid
         invalid = [0x80, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8e, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9e, 0x9f]
@@ -1029,7 +1029,6 @@ class CodecTest(IronPythonTestCase):
 
     @unittest.skipIf(is_posix, "https://github.com/IronLanguages/ironpython3/issues/541")
     @unittest.skipIf(is_mono, "https://github.com/IronLanguages/main/issues/1608")
-    @unittest.skipIf(is_cpython and is_osx, "PIPE.readlines() hangs")
     def test_cp11334(self):
         def run_python(filename):
             p = subprocess.Popen([sys.executable, os.path.join(self.test_dir, "encoded_files", filename)], shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -1112,7 +1111,6 @@ class CodecTest(IronPythonTestCase):
             self.assertRaises(ImportError, __import__, 'encodings')
 
     @unittest.skipIf(is_posix, "https://github.com/IronLanguages/ironpython3/issues/541")
-    @unittest.skipIf(is_cpython and is_osx, "PIPE.readlines() hangs")
     def test_cp1019(self):
         #--Test that bogus encodings fail properly
         # https://github.com/IronLanguages/main/issues/255

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -21,8 +21,11 @@ import subprocess
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, is_windows, run_test, skipUnlessIronPython
 from iptest.misc_util import ip_supported_encodings
+
+if is_cpython and is_posix:
+    import time
 
 class CodecTest(IronPythonTestCase):
     def test_escape_decode(self):
@@ -529,13 +532,19 @@ class CodecTest(IronPythonTestCase):
         # takes one or two parameters, not zero or three
         self.assertRaises(TypeError, codecs.unicode_internal_encode)
         self.assertRaises(TypeError, codecs.unicode_internal_encode, 'abc', 'def', 'qrt')
-        self.assertEqual(codecs.unicode_internal_encode('abc'), (b'a\x00b\x00c\x00', 3))
+        if is_cli or is_windows:
+            self.assertEqual(codecs.unicode_internal_encode('abc'), (b'a\x00b\x00c\x00', 3))
+        else:
+            self.assertEqual(codecs.unicode_internal_encode('abc'), (b'a\x00\x00\x00b\x00\x00\x00c\x00\x00\x00', 3))
 
     def test_unicode_internal_decode(self):
         # takes one or two parameters, not zero or three
         self.assertRaises(TypeError, codecs.unicode_internal_decode)
         self.assertRaises(TypeError, codecs.unicode_internal_decode, 'abc', 'def', 'qrt')
-        self.assertEqual(codecs.unicode_internal_decode(b'ab'), ('\u6261', 2))
+        if is_cli or is_windows:
+            self.assertEqual(codecs.unicode_internal_decode(b'ab'), ('\u6261', 2))
+        else:
+            self.assertEqual(codecs.unicode_internal_decode(b'ab\0\0'), ('\u6261', 4))
 
     def test_utf_16_be_decode(self):
         string, num_processed = codecs.utf_16_be_decode(b'\0a\0b\0c')
@@ -949,6 +958,8 @@ class CodecTest(IronPythonTestCase):
 
                     f.write("# coding: %s" % (coding))
 
+                if is_cpython and is_posix:
+                    time.sleep(0.01)
                 __import__(temp_mod_name)
                 os.remove(os.path.join(self.temporary_dir, "tmp_encodings", temp_mod_name + ".py"))
 

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, is_windows, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, is_windows, is_osx, run_test, skipUnlessIronPython
 from iptest.misc_util import ip_supported_encodings
 
 if is_cpython and is_posix:
@@ -885,7 +885,7 @@ class CodecTest(IronPythonTestCase):
         #Sanity Negative
         self.assertRaises(UnicodeEncodeError, codecs.charmap_encode, "abc", "strict", {})
 
-    @unittest.skipIf(is_posix, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
+    @unittest.skipIf(is_posix or is_osx, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
     def test_mbcs_decode(self):
         for mode in ['strict', 'replace', 'ignore', 'badmodethatdoesnotexist']:
             if is_netcoreapp and mode == 'badmodethatdoesnotexist': continue # FallbackBuffer created even if not used
@@ -897,7 +897,7 @@ class CodecTest(IronPythonTestCase):
             # round tripping
             self.assertEqual(codecs.mbcs_encode(codecs.mbcs_decode(allchars, mode)[0])[0], allchars)
 
-    @unittest.skipIf(is_posix, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
+    @unittest.skipIf(is_posix or is_osx, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
     def test_mbcs_encode(self):
         # these are invalid
         invalid = [0x80, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8e, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9e, 0x9f]
@@ -1029,6 +1029,7 @@ class CodecTest(IronPythonTestCase):
 
     @unittest.skipIf(is_posix, "https://github.com/IronLanguages/ironpython3/issues/541")
     @unittest.skipIf(is_mono, "https://github.com/IronLanguages/main/issues/1608")
+    @unittest.skipIf(is_cpython and is_osx, "PIPE.readlines() hangs")
     def test_cp11334(self):
         def run_python(filename):
             p = subprocess.Popen([sys.executable, os.path.join(self.test_dir, "encoded_files", filename)], shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -1111,6 +1112,7 @@ class CodecTest(IronPythonTestCase):
             self.assertRaises(ImportError, __import__, 'encodings')
 
     @unittest.skipIf(is_posix, "https://github.com/IronLanguages/ironpython3/issues/541")
+    @unittest.skipIf(is_cpython and is_osx, "PIPE.readlines() hangs")
     def test_cp1019(self):
         #--Test that bogus encodings fail properly
         # https://github.com/IronLanguages/main/issues/255

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -21,10 +21,10 @@ import subprocess
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, is_windows, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_cpython, is_mono, is_netcoreapp, is_posix, is_linux, is_windows, run_test, skipUnlessIronPython
 from iptest.misc_util import ip_supported_encodings
 
-if is_cpython and is_posix:
+if is_cpython and is_linux:
     import time
 
 class CodecTest(IronPythonTestCase):
@@ -958,7 +958,7 @@ class CodecTest(IronPythonTestCase):
 
                     f.write("# coding: %s" % (coding))
 
-                if is_cpython and is_posix:
+                if is_cpython and is_linux:
                     time.sleep(0.01)
                 __import__(temp_mod_name)
                 os.remove(os.path.join(self.temporary_dir, "tmp_encodings", temp_mod_name + ".py"))


### PR DESCRIPTION
There seems to be a race condition in `__inport__` in CPython 3.4 on Linux, that a 10 ms delay solves.