### PR TITLE
Make weakref proxies delegate comparison operators

### DIFF
--- a/Src/IronPython.Modules/_weakref.Generated.cs
+++ b/Src/IronPython.Modules/_weakref.Generated.cs
@@ -57,7 +57,12 @@ namespace IronPython.Modules {
 
             #endregion
 
-            //[SlotField] public static PythonTypeSlot __cmp__ = new SlotWrapper(Symbols.Cmp, ProxyType);
+            [SlotField] public static PythonTypeSlot __eq__ = new SlotWrapper("__eq__", ProxyType);
+            [SlotField] public static PythonTypeSlot __ne__ = new SlotWrapper("__ne__", ProxyType);
+            [SlotField] public static PythonTypeSlot __lt__ = new SlotWrapper("__lt__", ProxyType);
+            [SlotField] public static PythonTypeSlot __gt__ = new SlotWrapper("__gt__", ProxyType);
+            [SlotField] public static PythonTypeSlot __le__ = new SlotWrapper("__le__", ProxyType);
+            [SlotField] public static PythonTypeSlot __ge__ = new SlotWrapper("__ge__", ProxyType);
             [SlotField] public static PythonTypeSlot __divmod__ = new SlotWrapper("__divmod__", ProxyType);
             [SlotField] public static PythonTypeSlot __float__ = new SlotWrapper("__float__", ProxyType);
             [SlotField] public static PythonTypeSlot __index__ = new SlotWrapper("__index__", ProxyType);
@@ -126,7 +131,12 @@ namespace IronPython.Modules {
 
             #endregion
 
-            //[SlotField] public static PythonTypeSlot __cmp__ = new SlotWrapper(Symbols.Cmp, CallableProxyType);
+            [SlotField] public static PythonTypeSlot __eq__ = new SlotWrapper("__eq__", CallableProxyType);
+            [SlotField] public static PythonTypeSlot __ne__ = new SlotWrapper("__ne__", CallableProxyType);
+            [SlotField] public static PythonTypeSlot __lt__ = new SlotWrapper("__lt__", CallableProxyType);
+            [SlotField] public static PythonTypeSlot __gt__ = new SlotWrapper("__gt__", CallableProxyType);
+            [SlotField] public static PythonTypeSlot __le__ = new SlotWrapper("__le__", CallableProxyType);
+            [SlotField] public static PythonTypeSlot __ge__ = new SlotWrapper("__ge__", CallableProxyType);
             [SlotField] public static PythonTypeSlot __divmod__ = new SlotWrapper("__divmod__", CallableProxyType);
             [SlotField] public static PythonTypeSlot __float__ = new SlotWrapper("__float__", CallableProxyType);
             [SlotField] public static PythonTypeSlot __index__ = new SlotWrapper("__index__", CallableProxyType);

--- a/Src/IronPython.Modules/_weakref.cs
+++ b/Src/IronPython.Modules/_weakref.cs
@@ -450,23 +450,6 @@ namespace IronPython.Modules {
                 return PythonOps.EqualRetBool(_context, GetObject(), other.GetObject());
             }
 
-            /// <summary>
-            /// Special equality function because IStructuralEquatable.Equals is not allowed to throw.
-            /// </summary>
-            [return: MaybeNotImplemented]
-            public object __eq__(object other) {
-                if (!(other is weakproxy)) return NotImplementedType.Value;
-
-                return ScriptingRuntimeHelpers.BooleanToObject(EqualsWorker((weakproxy)other));
-            }
-
-            [return: MaybeNotImplemented]
-            public object __ne__(object other) {
-                if (!(other is weakproxy)) return NotImplementedType.Value;
-
-                return ScriptingRuntimeHelpers.BooleanToObject(!EqualsWorker((weakproxy)other));
-            }
-
             int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
                 object obj;
                 if (TryGetObject(out obj)) {
@@ -704,20 +687,6 @@ namespace IronPython.Modules {
             #region IStructuralEquatable Members
 
             public const object __hash__ = null;
-
-            /// <summary>
-            /// Special equality function because IStructuralEquatable.Equals is not allowed to throw.
-            /// </summary>
-            public bool __eq__(object other) {
-                weakcallableproxy wrp = other as weakcallableproxy;
-                if (wrp != null) return GetObject().Equals(wrp.GetObject());
-
-                return PythonOps.EqualRetBool(_context, GetObject(), other);
-            }
-
-            public bool __ne__(object other) {
-                return !__eq__(other);
-            }
 
             int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
                 object obj;

--- a/Src/IronPython.Modules/_weakref.cs
+++ b/Src/IronPython.Modules/_weakref.cs
@@ -446,10 +446,6 @@ namespace IronPython.Modules {
 
             public const object __hash__ = null;
 
-            private bool EqualsWorker(weakproxy other) {
-                return PythonOps.EqualRetBool(_context, GetObject(), other.GetObject());
-            }
-
             int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
                 object obj;
                 if (TryGetObject(out obj)) {


### PR DESCRIPTION
Add slots for all comparison operators which delegate to the object
being proxied.

Resolves #697