### PR TITLE
Implement codecs.*replace_errors

### DIFF
--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -460,7 +460,7 @@ class CodecTest(IronPythonTestCase):
     def test_error_handlers(self):
         ude = UnicodeDecodeError('dummy', b"abcdefgh", 3, 5, "decoding testing purposes")
         uee = UnicodeEncodeError('dummy', "abcdefgh", 2, 6, "encoding testing purposes")
-        unicode_data = "ab\xff\u20ac\U0001f40d\0z"
+        unicode_data = "ab\xff\u20ac\U0001f40d\0\t\r\nz"
         uee_unicode = UnicodeEncodeError('dummy', unicode_data, 2, len(unicode_data), "encoding testing purposes")
 
         strict = codecs.lookup_error('strict')
@@ -482,8 +482,6 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(ignore(uee), ("", 6))
         self.assertEqual(ignore(uee_unicode), ("", uee_unicode.end))
 
-        return # TODO: Implement remaining error handlers
-
         replace = codecs.lookup_error('replace')
         self.assertEqual(replace, codecs.replace_errors)
         self.assertEqual(replace(ude), ("�", 5))
@@ -494,13 +492,13 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(backslashreplace, codecs.backslashreplace_errors)
         self.assertRaisesRegex(TypeError, "don't know how to handle UnicodeDecodeError in error callback", backslashreplace, ude)
         self.assertEqual(backslashreplace(uee), (r"\x63\x64\x65\x66", 6))
-        self.assertEqual(backslashreplace(uee_unicode), (r"\xff\u20ac\U0001f40d\x00\x7a", uee_unicode.end))
+        self.assertEqual(backslashreplace(uee_unicode), (r"\xff\u20ac\U0001f40d\x00\x09\x0d\x0a\x7a", uee_unicode.end))
 
         xmlcharrefreplace = codecs.lookup_error('xmlcharrefreplace')
         self.assertEqual(xmlcharrefreplace, codecs.xmlcharrefreplace_errors)
         self.assertRaisesRegex(TypeError, "don't know how to handle UnicodeDecodeError in error callback", xmlcharrefreplace, ude)
         self.assertEqual(xmlcharrefreplace(uee), ("&#99;&#100;&#101;&#102;", 6))
-        self.assertEqual(xmlcharrefreplace(uee_unicode), ("&#255;&#8364;&#128013;&#0;&#122;", uee_unicode.end))
+        self.assertEqual(xmlcharrefreplace(uee_unicode), ("&#255;&#8364;&#128013;&#0;&#9;&#13;&#10;&#122;", uee_unicode.end))
 
     #TODO: @skip("multiple_execute")
     def test_lookup_error(self):


### PR DESCRIPTION
This PR implements `replace_errors`, `backslashreplace_errors` and `xmlcharrefreplace_errors` from `codecs`. In the positive cases (i.e. valid `UnicodeError` instances), the functions behave like their CPython counterparts.

Negative cases are more interesting. CPython seems to coerce invalid range values:

```python
>>> import codecs as cd
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", 2, 6, "-"))
('\\x63\\x64', 4)
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", -2, 2, "-"))
('\\x61\\x62', 2)
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", -2, 6, "-"))
('\\x61\\x62\\x63\\x64', 4)
```

However, it does not do it consistently:

```python
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", 4, 4, "-"))
('\\x64', 4)
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", 3, 3, "-"))
('', 3)
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", 2, 2, "-"))
('', 2)
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", 1, 1, "-"))
('', 1)
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", 0, 0, "-"))
('\\x61', 1)
>>> cd.backslashreplace_errors(UnicodeEncodeError("X", "abcd", -1, -1, "-"))
('\\x61', 1)
```
Of course, improperly constructed `UnicodeEncodeError` should not be around in the first place and CPython seems to adapt the "garbage-in, garbage out" approach.
What is important, I believe, is that in no circumstances `IndexError` is thrown. This is what I've implemented in IronPython, whith a little bit more consistent coercing of the `start:end` range.