### PR TITLE
Surrogateescape errors

### DIFF
--- a/Src/IronPython/Runtime/PythonEncoding.cs
+++ b/Src/IronPython/Runtime/PythonEncoding.cs
@@ -570,18 +570,14 @@ namespace IronPython.Runtime {
                 char[] fallbackChars = new char[charNum];
 
                 for (int i = 0; i < charNum; i++) {
-                    if (this.EncodingCharWidth == 1) {
-                        // test for value below 128
-                        if (bytesUnknown[i] < 128u) {
-                            throw new DecoderFallbackException(
-                                $"values below 128 cannot be smuggled (PEP 383)",
-                                bytesUnknown,
-                                index
-                            );
-                        }
+                    // test for byte below 128
+                    if (bytesUnknown[i] < 128u) {
+                        throw new DecoderFallbackException(
+                            $"bytes below 128 cannot be smuggled (PEP 383)",
+                            bytesUnknown,
+                            index
+                        );
                     }
-                    // no test for "else" case because all supported wide char encodings (UTF-16LE, UTF-16BE, UTF-32LE, UTF-32BE)
-                    // will never fall back for values under 128
 
                     fallbackChars[i] = (char)(bytesUnknown[i] | LoneSurrogateBase);
                 }

--- a/Src/IronPython/Runtime/PythonEncoding.cs
+++ b/Src/IronPython/Runtime/PythonEncoding.cs
@@ -546,8 +546,16 @@ namespace IronPython.Runtime {
                         index
                     );
                 }
+                byte b = (byte)(charUnknown & 0xff);
+                if (b < 128) {
+                    throw PythonOps.UnicodeEncodeError(
+                        "'surrogateescape' error handler: bytes below 128 cannot be smuggled (PEP 383)",
+                        charUnknown,
+                        index
+                    );
+                }
 
-                return new[] { (byte)(charUnknown & 0xff) };
+                return new[] { b };
             }
 
         }
@@ -570,10 +578,9 @@ namespace IronPython.Runtime {
                 char[] fallbackChars = new char[charNum];
 
                 for (int i = 0; i < charNum; i++) {
-                    // test for byte below 128
-                    if (bytesUnknown[i] < 128u) {
+                    if (bytesUnknown[i] < 128) {
                         throw new DecoderFallbackException(
-                            $"bytes below 128 cannot be smuggled (PEP 383)",
+                            "'surrogateescape' error handler: bytes below 128 cannot be smuggled (PEP 383)",
                             bytesUnknown,
                             index
                         );

--- a/Src/IronPythonTest/EncodingTest.cs
+++ b/Src/IronPythonTest/EncodingTest.cs
@@ -29,10 +29,6 @@ namespace IronPythonTest {
             [Test] public void Test256WithPythonAscii() => TestRoundTrip(PythonAsciiEncoding.Instance, _bytes);
             [Test] public void Test256WithUtf8() => TestRoundTrip(Encoding.UTF8, _bytes);
             [Test] public void Test256WithDefault() => TestRoundTrip(Encoding.Default, _bytes);
-            [Test] public void Test256WithUnicode() => TestRoundTrip(Encoding.Unicode, _bytes);
-            [Test] public void Test256WithBigEndianUnicode() => TestRoundTrip(Encoding.BigEndianUnicode, _bytes);
-            [Test] public void Test256WithUtf32() => TestRoundTrip(Encoding.UTF32, _bytes);
-            [Test] public void Test256WithUtf32BE() => TestRoundTrip(new UTF32Encoding(bigEndian: true, byteOrderMark: false), _bytes);
         }
 
         // Test decoding/encoding a valid UTF-8 sequence
@@ -42,7 +38,7 @@ namespace IronPythonTest {
 
             [SetUp]
             public void SetUp() {
-                // 12 bytes, rounded to multiply of 4 for the sake of UTF-32 test
+                // 12 bytes of: Питон!!
                 _bytes = "\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd!!".AsBytes();
             }
 
@@ -50,10 +46,6 @@ namespace IronPythonTest {
             [Test] public void TestValidUtf8WithPythonAscii() => TestRoundTrip(PythonAsciiEncoding.Instance, _bytes);
             [Test] public void TestValidUtf8WithUtf8() => TestRoundTrip(Encoding.UTF8, _bytes);
             [Test] public void TestValidUtf8WithDefault() => TestRoundTrip(Encoding.Default, _bytes);
-            [Test] public void TestValidUtf8WithUnicode() => TestRoundTrip(Encoding.Unicode, _bytes);
-            [Test] public void TestValidUtf8WithBigEndianUnicode() => TestRoundTrip(Encoding.BigEndianUnicode, _bytes);
-            [Test] public void TestValidUtf8WithUtf32() => TestRoundTrip(Encoding.UTF32, _bytes);
-            [Test] public void TestValidUtf8WithUtf32BE() => TestRoundTrip(new UTF32Encoding(bigEndian: true, byteOrderMark: false), _bytes);
         }
 
         // Test decoding/encoding an invalid UTF-8 sequence
@@ -66,20 +58,16 @@ namespace IronPythonTest {
                 // 12 bytes: two valid UTF-8 2-byte chars, one non-decodable byte, 
                 // one UTF-8 2-byte char with a non-decodable byte inserted in between the UTF-8 bytes
                 // and final valid UTF-8 2-byte char
-                _bytes = "\xd0\x9f\xd0\xb8\x80\xd1\x20\x82\xd0\xbe\xd0\xbd".AsBytes();
+                _bytes = "\xd0\x9f\xd0\xb8\x80\xd1\xff\x82\xd0\xbe\xd0\xbd".AsBytes();
             }
 
             [Test] public void TestBrokenUtf8WithAscii() => TestRoundTrip(Encoding.ASCII, _bytes);
             [Test] public void TestBrokenUtf8WithPythonAscii() => TestRoundTrip(PythonAsciiEncoding.Instance, _bytes);
             [Test] public void TestBrokenUtf8WithUtf8() => TestRoundTrip(Encoding.UTF8, _bytes);
             [Test] public void TestBrokenUtf8WithDefault() => TestRoundTrip(Encoding.Default, _bytes);
-            [Test] public void TestBrokenUtf8WithUnicode() => TestRoundTrip(Encoding.Unicode, _bytes);
-            [Test] public void TestBrokenUtf8WithBigEndianUnicode() => TestRoundTrip(Encoding.BigEndianUnicode, _bytes);
-            [Test] public void TestBrokenUtf8WithUtf32() => TestRoundTrip(Encoding.UTF32, _bytes);
-            [Test] public void TestBrokenUtf8WithUtf32BE() => TestRoundTrip(new UTF32Encoding(bigEndian: true, byteOrderMark: false), _bytes);
         }
 
-        // Note: UTF-7 is not round-trip safe in general
+        // Note: UTF-7, UTF-16, and UTF-32 are not round-trip safe in general
         private static void TestRoundTrip(Encoding enc, byte[] bytes) {
 
             Encoding penc = new PythonSurrogateEscapeEncoding(enc);
@@ -344,13 +332,13 @@ namespace IronPythonTest {
             public void TestEndiannessWithtUtf32LE() {
                 Encoding penc = new PythonSurrogateEscapeEncoding(new UTF32Encoding(bigEndian: false, byteOrderMark: false));
                 Assert.AreEqual("\u000a", penc.GetChars(_bytes1));
-                Assert.AreEqual("\udc00\udc00\udc00\udc0a", penc.GetChars(_bytes2));
+                Assert.Throws<DecoderFallbackException>(() => penc.GetChars(_bytes2));
             }
 
             [Test]
             public void TestEndiannessWithtUtf32BE() {
                 Encoding penc = new PythonSurrogateEscapeEncoding(new UTF32Encoding(bigEndian: true, byteOrderMark: false));
-                Assert.AreEqual("\udc0a\udc00\udc00\udc00", penc.GetChars(_bytes1));
+                Assert.Throws<DecoderFallbackException>(() => penc.GetChars(_bytes1));
                 Assert.AreEqual("\u000a", penc.GetChars(_bytes2));
             }
         }


### PR DESCRIPTION
This PR implements the `codecs.surrogateescape_errors` builtin function with the accompanying tests. The same caveat applies as for the previous error handlers: in case of misconstructed `UnicodeError` the way how the range gets coerced may sometimes differ from CPython, but in no instance will it throw `IndexError`.

During testing I discovered that my original understanding of [PEP 383](https://www.python.org/dev/peps/pep-0383/) was wrong. I thought that PEP 383 forbids smuggling of ASCII characters, but it actually forbids smuggling of ASCII bytes. Consequently, `surrogateescape` cannot be meaningfully used with wide-char encodings, like UTF-16 or UTF-32. The Python documentation doesn't mention it, but the PEP does say it is intended for ASCII-compatible encodings only. On the bright side, the implementation becomes simpler.

For instance, in case of UTF-16, if a lone surrogate (ordinarily an error) has the LSB 0x80 or above, it will be escaped; if that byte is less than 0x80, it will not be escaped but treated as belonging to the next character, resulting in all subsequent bytes misaligned:

```python
>>> b"\xdd\x80".decode('utf-16-be', 'surrogateescape')
'\udcdd\udc80'
>>> b"\xdd\x20".decode('utf-16-be', 'surrogateescape')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Pawel\.conda\envs\py37\lib\encodings\utf_16_be.py", line 16, in decode
    return codecs.utf_16_be_decode(input, errors, True)
UnicodeDecodeError: 'utf-16-be' codec can't decode byte 0x20 in position 1: truncated data
>>> b"\xdd\x20\xac".decode('utf-16-be', 'surrogateescape')
'\udcdd€'
```
In case of UTF-32, no surrogates can be escaped as they invariably contain two zero bytes.

Since it is a security issue, in the second commit of this PR I correct `PythonSurrogateEscapeEncoding` and modify the relevant tests. The change prevents smuggling of ASCII bytes, although the behaviour is still not exactly like CPython: the third statement from the example above will raise an exception rather than misalign the subsequent bytes. I leave it like this for now because I am considering getting rid of `PythonSurrogateEscapeEncoding` altogether at some point in the future.