### PR TITLE
Update documentation to catch up build requirements.

### DIFF
--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -1,12 +1,12 @@
 # Building IronPython3
 
-To build IronPython3 you will need the .NET SDK (minimum 4.5), a .NET Core SDK (minimum 2.0) and if building on Linux/macOS you will need [Mono](https://mono-project.com).
+To build IronPython3 you will need the .NET SDK (minimum 4.5), a [.NET Core SDK (minimum 3.0)](https://dotnet.microsoft.com/download/visual-studio-sdks) and if building on Linux/macOS you will need [Mono](https://mono-project.com).
 
 See [Getting the Sources](getting-the-sources.md) for information on getting the source for IronPython3.
 
 ## Building from Visual Studio
 
-Visual Studio 15.2 or above is required to build IronPython3
+Visual Studio 16.0(2019) or above is required to build IronPython3.
 
  * Open `c:\path\to\ironpython3\IronPython.sln` solution file
  * Select the configuration options (Release,Debug, etc)


### PR DESCRIPTION
Hi.  
I've noticed 'building.md' is out-dated so I wrote a patch to catch up.   
  
Here's description of the changes.
- Submodule [DLR@19ef3b5](https://github.com/IronLanguages/dlr/tree/19ef3b59c9f5a0255ee1286a897095ba00773c3e) requires .NET Core SDK 3.0.100 in its [global.json]( https://github.com/IronLanguages/dlr/blob/19ef3b59c9f5a0255ee1286a897095ba00773c3e/global.json).  
- According to [the Download page](https://dotnet.microsoft.com/download/visual-studio-sdks), .Net Core SDK 3.0 is not supported on Visual Studio 15.x.  