### PR TITLE
Fix usage of deprecated unittest APIs

### DIFF
--- a/Tests/interop/net/field/test_field_misc.py
+++ b/Tests/interop/net/field/test_field_misc.py
@@ -22,7 +22,7 @@ class FieldMiscTest(IronPythonTestCase):
         o.Set()
         self.assertEqual(o.PublicField, 100)
         self.assertTrue(not hasattr(o, 'ProtectedField'))
-        self.assertRaisesRegexp(AttributeError, "'Misc' object has no attribute 'PrivateField'", lambda: o.PrivateField)
+        self.assertRaisesRegex(AttributeError, "'Misc' object has no attribute 'PrivateField'", lambda: o.PrivateField)
         self.assertEqual(o.InterfaceField.PublicStaticField, 500)
         
         o = DerivedMisc()

--- a/Tests/interop/net/field/test_fields_inside_enum.py
+++ b/Tests/interop/net/field/test_fields_inside_enum.py
@@ -21,13 +21,13 @@ class FieldsInsideEnumTest(IronPythonTestCase):
         self.assertEqual(EnumInt32.B, desc)
         
         def f(): o.A = 10
-        self.assertRaisesRegexp(AttributeError, "attribute 'A' of 'EnumInt32' object is read-only", f)
+        self.assertRaisesRegex(AttributeError, "attribute 'A' of 'EnumInt32' object is read-only", f)
         
         def f(): EnumInt32.B = 10
-        self.assertRaisesRegexp(AttributeError, "attribute 'B' of 'EnumInt32' object is read-only", f)
+        self.assertRaisesRegex(AttributeError, "attribute 'B' of 'EnumInt32' object is read-only", f)
 
         def f(): EnumInt32.B = EnumInt32.A
-        self.assertRaisesRegexp(AttributeError, "attribute 'B' of 'EnumInt32' object is read-only", f)
+        self.assertRaisesRegex(AttributeError, "attribute 'B' of 'EnumInt32' object is read-only", f)
 
     def test_enum_bool(self):
         from Merlin.Testing.BaseClass import EmptyEnum

--- a/Tests/interop/net/field/test_initonly_fields.py
+++ b/Tests/interop/net/field/test_initonly_fields.py
@@ -107,7 +107,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
         self.assertEqual(current_type.__dict__['InitOnlySimpleInterfaceField'].__get__(None, current_type).Flag, 50)
 
         for t in [current_type, SimpleStruct, SimpleClass]:
-            self.assertRaisesRegexp(TypeError, "(expected .*, got type)", lambda: current_type.__dict__['InitOnlySimpleGenericClassField'].__get__(t, current_type))
+            self.assertRaisesRegex(TypeError, "(expected .*, got type)", lambda: current_type.__dict__['InitOnlySimpleGenericClassField'].__get__(t, current_type))
         
         for t in [None, o, SimpleClass, SimpleStruct]:
             self.assertEqual(current_type.__dict__['InitOnlyEnumField'].__get__(None, t), EnumInt16.B)
@@ -144,7 +144,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
         def f23(): o.InitOnlySimpleInterfaceField = ClassImplementSimpleInterface(40)
 
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23]:
-            self.assertRaisesRegexp(AttributeError, "attribute .* of .* object is read-only", f)
+            self.assertRaisesRegex(AttributeError, "attribute .* of .* object is read-only", f)
     
     def _test_set_by_type(self, current_type, message="attribute '.*' of '.*' object is read-only"):
         import System
@@ -177,7 +177,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
         def f23(): current_type.InitOnlySimpleInterfaceField = ClassImplementSimpleInterface(40)
 
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23]:
-            self.assertRaisesRegexp(AttributeError, message, f)
+            self.assertRaisesRegex(AttributeError, message, f)
 
     def _test_set_by_descriptor(self, current_type):
         o = current_type()
@@ -189,7 +189,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
         lambda : current_type.__dict__['InitOnlyBooleanField'].__set__(None, False),
         lambda : current_type.__dict__['InitOnlySimpleClassField'].__set__(None, None),
         ]: 
-            self.assertRaisesRegexp(AttributeError, "'.*' object attribute '.*' is read-only", f)  # ???
+            self.assertRaisesRegex(AttributeError, "'.*' object attribute '.*' is read-only", f)  # ???
             
         for f in [
         lambda : current_type.__dict__['InitOnlySByteField'].__set__(o, 3),
@@ -206,7 +206,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
         lambda : current_type.__dict__['InitOnlyEnumField'].__set__(current_type, EnumInt32.C),
         lambda : current_type.__dict__['InitOnlySimpleInterfaceField'].__set__(o, None),
         ]: 
-            self.assertRaisesRegexp(AttributeError, "'.*' object attribute 'InitOnly.*Field' is read-only", f)
+            self.assertRaisesRegex(AttributeError, "'.*' object attribute 'InitOnly.*Field' is read-only", f)
         
     def _test_delete_via_type(self, current_type, message="cannot delete attribute 'InitOnly.*' of builtin type"):
         def f1(): del current_type.InitOnlyByteField
@@ -237,7 +237,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
         def f23(): del current_type.InitOnlySimpleInterfaceField
 
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23]:
-            self.assertRaisesRegexp(AttributeError, message, f)
+            self.assertRaisesRegex(AttributeError, message, f)
 
     def _test_delete_via_instance(self, current_type, message="cannot delete attribute 'InitOnly.*' of builtin type"):
         o = current_type()
@@ -269,7 +269,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
         def f23(): del o.InitOnlySimpleInterfaceField
 
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23]:
-            self.assertRaisesRegexp(AttributeError, message, f)
+            self.assertRaisesRegex(AttributeError, message, f)
 
     def _test_delete_via_descriptor(self, current_type):
         o = current_type()
@@ -285,7 +285,7 @@ class InitOnlyFieldsTest(IronPythonTestCase):
             if i % 4 == 3: arg = SimpleStruct
             i += 1
 
-            self.assertRaisesRegexp(AttributeError, "cannot delete attribute 'InitOnly.*Field' of builtin type", 
+            self.assertRaisesRegex(AttributeError, "cannot delete attribute 'InitOnly.*Field' of builtin type", 
                 lambda : current_type.__dict__['InitOnly%sField' % x].__delete__(arg))
 
     def test_types(self):

--- a/Tests/interop/net/field/test_instance_fields.py
+++ b/Tests/interop/net/field/test_instance_fields.py
@@ -252,9 +252,9 @@ class InstanceFieldsTest(IronPythonTestCase):
             def f2(): t.InstanceCharField.__set__(v, "abc")
             def f3(): t.InstanceEnumField.__set__(v, EnumInt32.B)
 
-            self.assertRaisesRegexp(TypeError, "expected Int16, got str",  f1)
-            self.assertRaisesRegexp(TypeError, "expected string of length 1 when converting to char, got 'abc'", f2)
-            self.assertRaisesRegexp(TypeError, "expected EnumInt64, got EnumInt32",  f3)
+            self.assertRaisesRegex(TypeError, "expected Int16, got str",  f1)
+            self.assertRaisesRegex(TypeError, "expected string of length 1 when converting to char, got 'abc'", f2)
+            self.assertRaisesRegex(TypeError, "expected EnumInt64, got EnumInt32",  f3)
 
     def _test_set_by_descriptor(self, o, vf, t):
         import clr
@@ -333,7 +333,7 @@ class InstanceFieldsTest(IronPythonTestCase):
         
         funcs = [ eval("f%s" % i) for i in range(1, 25) ]
         for f in funcs:
-            self.assertRaisesRegexp(AttributeError, "cannot delete attribute", f)  
+            self.assertRaisesRegex(AttributeError, "cannot delete attribute", f)  
 
     def _test_delete_by_instance(self, current_type):
         o = current_type()
@@ -365,7 +365,7 @@ class InstanceFieldsTest(IronPythonTestCase):
         
         funcs = [ eval("f%s" % i) for i in range(1, 25) ]
         for f in funcs:
-            self.assertRaisesRegexp(AttributeError, "cannot delete attribute", f) 
+            self.assertRaisesRegex(AttributeError, "cannot delete attribute", f) 
 
     def _test_delete_by_descriptor(self, current_type):
         for x in [
@@ -395,7 +395,7 @@ class InstanceFieldsTest(IronPythonTestCase):
             'SimpleInterface',
         ]:
             for o in [None, current_type, current_type()]:
-                self.assertRaisesRegexp(AttributeError, "cannot delete attribute", lambda: current_type.__dict__['Instance%sField' % x].__delete__(o))
+                self.assertRaisesRegex(AttributeError, "cannot delete attribute", lambda: current_type.__dict__['Instance%sField' % x].__delete__(o))
 
     def test_types(self):
         import clr

--- a/Tests/interop/net/field/test_literal_fields.py
+++ b/Tests/interop/net/field/test_literal_fields.py
@@ -105,7 +105,7 @@ class LiteralFieldsTest(IronPythonTestCase):
         def f17(): o.LiteralInterfaceField = None
 
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17]:
-            self.assertRaisesRegexp(AttributeError, "attribute .* of .* object is read-only", f)
+            self.assertRaisesRegex(AttributeError, "attribute .* of .* object is read-only", f)
     
     def _test_set_by_type(self, current_type):
         from Merlin.Testing.TypeSample import EnumUInt32
@@ -130,7 +130,7 @@ class LiteralFieldsTest(IronPythonTestCase):
         def f17(): current_type.LiteralInterfaceField = None
 
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17]:
-            self.assertRaisesRegexp(AttributeError, "attribute '.*' of '.*' object is read-only", f)
+            self.assertRaisesRegex(AttributeError, "attribute '.*' of '.*' object is read-only", f)
 
         
     def _test_delete_via_type(self, current_type):
@@ -155,7 +155,7 @@ class LiteralFieldsTest(IronPythonTestCase):
         def f17(): del current_type.LiteralInterfaceField
         
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17]:
-            self.assertRaisesRegexp(AttributeError, "cannot delete attribute 'Literal.*Field' of builtin type", f)
+            self.assertRaisesRegex(AttributeError, "cannot delete attribute 'Literal.*Field' of builtin type", f)
 
     def _test_delete_via_instance(self, current_type, message="cannot delete attribute 'Literal.*Field' of builtin type"):
         o = current_type()
@@ -180,7 +180,7 @@ class LiteralFieldsTest(IronPythonTestCase):
         def f17(): del o.LiteralInterfaceField
         
         for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17]:
-            self.assertRaisesRegexp(AttributeError, message, f)
+            self.assertRaisesRegex(AttributeError, message, f)
 
     def test_types(self):
         from Merlin.Testing.FieldTest.Literal import ClassWithLiterals, GenericClassWithLiterals, StructWithLiterals, GenericStructWithLiterals

--- a/Tests/interop/net/field/test_static_fields.py
+++ b/Tests/interop/net/field/test_static_fields.py
@@ -464,8 +464,8 @@ class StaticFieldsTest(IronPythonTestCase):
             def f1(): o.StaticByteField = 1
             def f2(): current_type.StaticByteField = 1
 
-            self.assertRaisesRegexp(AttributeError, "'.*' object has no attribute 'StaticByteField'", f1)
-            self.assertRaisesRegexp(AttributeError, "'.*' object has no attribute 'StaticByteField'", f2)
+            self.assertRaisesRegex(AttributeError, "'.*' object has no attribute 'StaticByteField'", f1)
+            self.assertRaisesRegex(AttributeError, "'.*' object has no attribute 'StaticByteField'", f2)
             
             self.assertTrue('StaticByteField' not in current_type.__dict__)
 

--- a/Tests/interop/net/property/test_indexercs.py
+++ b/Tests/interop/net/property/test_indexercs.py
@@ -113,15 +113,15 @@ class IndexerCSTest(IronPythonTestCase):
             self.assertTrue(not hasattr(x, 'get_Item'))
                     
             # bad arg count
-            self.assertRaisesRegexp(TypeError, "expected int, got tuple", lambda: x[()])
-            self.assertRaisesRegexp(TypeError, "__getitem__\(\) takes at most 3 arguments \(4 given\)", lambda: x[1, 2, 3, 4])
+            self.assertRaisesRegex(TypeError, "expected int, got tuple", lambda: x[()])
+            self.assertRaisesRegex(TypeError, "__getitem__\(\) takes at most 3 arguments \(4 given\)", lambda: x[1, 2, 3, 4])
             
             # bad arg type
-            self.assertRaisesRegexp(TypeError, "expected str, got int", lambda: x[1, 2, 3])
+            self.assertRaisesRegex(TypeError, "expected str, got int", lambda: x[1, 2, 3])
             
             # bad value type
             def f(): x[1] = 'abc'
-            self.assertRaisesRegexp(TypeError, "expected int, got str", f)
+            self.assertRaisesRegex(TypeError, "expected int, got str", f)
             
 
     def test_readonly(self):
@@ -130,7 +130,7 @@ class IndexerCSTest(IronPythonTestCase):
         self.assertEqual(x[1], 10)
         
         def f(): x[2] = 20
-        self.assertRaisesRegexp(TypeError, 
+        self.assertRaisesRegex(TypeError, 
             "'ReadOnlyIndexer' object does not support item assignment",
             f)
 
@@ -142,7 +142,7 @@ class IndexerCSTest(IronPythonTestCase):
         x[1] = 10
         Flag.Check(11)
         
-        self.assertRaisesRegexp(TypeError, 
+        self.assertRaisesRegex(TypeError, 
             "'WriteOnlyIndexer' object is not subscriptable",
             lambda: x[1])
 

--- a/Tests/interop/net/property/test_property.py
+++ b/Tests/interop/net/property/test_property.py
@@ -83,10 +83,10 @@ class PropertyTest(IronPythonTestCase):
         ClassWithWriteOnly.StaticProperty = "dlr"
         Flag.Check(12)
         
-        self.assertRaisesRegexp(AttributeError, 
+        self.assertRaisesRegex(AttributeError, 
             "unreadable property", 
             lambda: ClassWithWriteOnly.__dict__['InstanceProperty'].__get__(x))
-        self.assertRaisesRegexp(AttributeError, 
+        self.assertRaisesRegex(AttributeError, 
             "unreadable property", 
             lambda: ClassWithWriteOnly.__dict__['InstanceProperty'].GetValue(x))
     
@@ -178,7 +178,7 @@ class PropertyTest(IronPythonTestCase):
             def w3(): x.StaticSimpleClassProperty = c
             
             for w in [w1, w2, w3]:
-                self.assertRaisesRegexp(AttributeError, 
+                self.assertRaisesRegex(AttributeError, 
                     "static property '.*' of '.*' can only be assigned to through a type, not an instance", 
                     w)
             
@@ -193,16 +193,16 @@ class PropertyTest(IronPythonTestCase):
             #self.assertEqual(a, p.GetValue(None))
 
             # static property against instance        
-            self.assertRaisesRegexp(SystemError, "cannot set property", lambda: p.SetValue(x, a))
-            #self.assertRaisesRegexp(SystemError, "cannot get property", lambda: p.GetValue(x))  # bug 363242
+            self.assertRaisesRegex(SystemError, "cannot set property", lambda: p.SetValue(x, a))
+            #self.assertRaisesRegex(SystemError, "cannot get property", lambda: p.GetValue(x))  # bug 363242
 
             p = t.__dict__['InstanceInt32Property']
             p.SetValue(x, a)
             #self.assertEqual(p.GetValue(x), a)         # value type issue again
 
             # instance property against None
-            self.assertRaisesRegexp(SystemError, "cannot set property", lambda: p.SetValue(None, a))
-            #self.assertRaisesRegexp(SystemError, "cannot get property", lambda: p.GetValue(None))  # bug 363247
+            self.assertRaisesRegex(SystemError, "cannot set property", lambda: p.SetValue(None, a))
+            #self.assertRaisesRegex(SystemError, "cannot get property", lambda: p.GetValue(None))  # bug 363247
             
             p = t.__dict__['StaticSimpleStructProperty']
             p.__set__(None, b)
@@ -231,12 +231,12 @@ class PropertyTest(IronPythonTestCase):
     def test_delete(self):
         from Merlin.Testing.Property import ClassWithProperties, ClassWithReadOnly
         def del_p(): del ClassWithProperties.InstanceSimpleStructProperty
-        self.assertRaisesRegexp(AttributeError, 
+        self.assertRaisesRegex(AttributeError, 
             "cannot delete attribute 'InstanceSimpleStructProperty' of builtin type 'ClassWithProperties'",
             del_p)
 
         def del_p(): del ClassWithReadOnly.InstanceProperty
-        self.assertRaisesRegexp(AttributeError, 
+        self.assertRaisesRegex(AttributeError, 
             "cannot delete attribute 'InstanceProperty' of builtin type 'ClassWithReadOnly'",
             del_p)
 
@@ -249,7 +249,7 @@ class PropertyTest(IronPythonTestCase):
         
         t.StaticInt32Property  # read
         def f(): t.StaticInt32Property = a
-        self.assertRaisesRegexp(AttributeError, 
+        self.assertRaisesRegex(AttributeError, 
             "'DerivedClass' object has no attribute 'StaticInt32Property'", 
             f)   # write
 

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -56,13 +56,13 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(value, b"'")
         self.assertEqual(length, 4)
 
-        self.assertEquals(codecs.escape_decode(b"ab\nc"), (b"ab\nc", 4))
-        self.assertEquals(codecs.escape_decode(b"ab\rc"), (b"ab\rc", 4))
-        self.assertEquals(codecs.escape_decode(b"ab\r\nc"), (b"ab\r\nc", 5))
+        self.assertEqual(codecs.escape_decode(b"ab\nc"), (b"ab\nc", 4))
+        self.assertEqual(codecs.escape_decode(b"ab\rc"), (b"ab\rc", 4))
+        self.assertEqual(codecs.escape_decode(b"ab\r\nc"), (b"ab\r\nc", 5))
 
-        self.assertEquals(codecs.escape_decode(b"ab\\\nc"), (b"abc", 5))
-        self.assertEquals(codecs.escape_decode(b"ab\\\rc"), (b"ab\\\rc", 5))
-        self.assertEquals(codecs.escape_decode(b"ab\\\r\\\nc"), (b"ab\\\rc", 7))
+        self.assertEqual(codecs.escape_decode(b"ab\\\nc"), (b"abc", 5))
+        self.assertEqual(codecs.escape_decode(b"ab\\\rc"), (b"ab\\\rc", 5))
+        self.assertEqual(codecs.escape_decode(b"ab\\\r\\\nc"), (b"ab\\\rc", 7))
 
     def test_escape_decode_errors(self):
         self.assertEqual(codecs.escape_decode("abc", None), (b"abc", 3))
@@ -183,32 +183,32 @@ class CodecTest(IronPythonTestCase):
         with self.assertRaises(UnicodeDecodeError) as cm:
             codecs.raw_unicode_escape_decode("abc\\u20klm\xffxyz\u20ac") # Unicode string
 
-        self.assertEquals(cm.exception.encoding, 'rawunicodeescape')
+        self.assertEqual(cm.exception.encoding, 'rawunicodeescape')
         self.assertTrue(cm.exception.reason.startswith("truncated \\uXXXX"))
-        self.assertEquals(cm.exception.start, 3)
-        self.assertEquals(cm.exception.end, 7)
-        self.assertEquals(cm.exception.object, b"abc\\u20klm\xc3\xbfxyz\xe2\x82\xac") # in UTF-8
+        self.assertEqual(cm.exception.start, 3)
+        self.assertEqual(cm.exception.end, 7)
+        self.assertEqual(cm.exception.object, b"abc\\u20klm\xc3\xbfxyz\xe2\x82\xac") # in UTF-8
 
         with self.assertRaises(UnicodeDecodeError) as cm:
             codecs.raw_unicode_escape_decode("abc\\U0001F44xyz")
 
-        self.assertEquals(cm.exception.encoding, 'rawunicodeescape')
+        self.assertEqual(cm.exception.encoding, 'rawunicodeescape')
         if is_cpython and sys.version_info < (3, 6):
-            self.assertEquals(cm.exception.reason, "truncated \\uXXXX")
+            self.assertEqual(cm.exception.reason, "truncated \\uXXXX")
         else:
-            self.assertEquals(cm.exception.reason, "truncated \\UXXXXXXXX escape")
-        self.assertEquals(cm.exception.start, 3)
-        self.assertEquals(cm.exception.end, 12)
-        self.assertEquals(cm.exception.object, b"abc\\U0001F44xyz")
+            self.assertEqual(cm.exception.reason, "truncated \\UXXXXXXXX escape")
+        self.assertEqual(cm.exception.start, 3)
+        self.assertEqual(cm.exception.end, 12)
+        self.assertEqual(cm.exception.object, b"abc\\U0001F44xyz")
 
         with self.assertRaises(UnicodeDecodeError) as cm:
             codecs.raw_unicode_escape_decode("abc\\U00110011xyz")
 
-        self.assertEquals(cm.exception.encoding, 'rawunicodeescape')
-        self.assertEquals(cm.exception.reason, "\\Uxxxxxxxx out of range")
-        self.assertEquals(cm.exception.start, 3)
-        self.assertEquals(cm.exception.end, 13)
-        self.assertEquals(cm.exception.object, b"abc\\U00110011xyz")
+        self.assertEqual(cm.exception.encoding, 'rawunicodeescape')
+        self.assertEqual(cm.exception.reason, "\\Uxxxxxxxx out of range")
+        self.assertEqual(cm.exception.start, 3)
+        self.assertEqual(cm.exception.end, 13)
+        self.assertEqual(cm.exception.object, b"abc\\U00110011xyz")
 
         new_str, num_processed = codecs.raw_unicode_escape_decode(b"abc\\u20klm\\U0001F44nop\\U00110011xyz",'ignore')
         self.assertEqual(new_str, "abcklmnopxyz")
@@ -276,11 +276,11 @@ class CodecTest(IronPythonTestCase):
             with self.assertRaises(UnicodeDecodeError) as cm:
                 codecs.unicode_escape_decode(data)
 
-            self.assertEquals(cm.exception.encoding, 'unicodeescape')
-            self.assertEquals(cm.exception.reason, msg)
-            self.assertEquals(cm.exception.start, start)
-            self.assertEquals(cm.exception.end, end)
-            self.assertEquals(cm.exception.object, ex_data)
+            self.assertEqual(cm.exception.encoding, 'unicodeescape')
+            self.assertEqual(cm.exception.reason, msg)
+            self.assertEqual(cm.exception.start, start)
+            self.assertEqual(cm.exception.end, end)
+            self.assertEqual(cm.exception.object, ex_data)
 
         test_data = [
             ("abc\\xyz", "truncated \\xXX escape", 3, 5, b"abc\\xyz"), # str to bytes

--- a/Tests/test_datetime.py
+++ b/Tests/test_datetime.py
@@ -13,63 +13,63 @@ class TestDatetime(unittest.TestCase):
     def test_strptime_1(self):
         # cp34706
         d = datetime.datetime.strptime("2013-11-29T16:38:12.507000", "%Y-%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507000))
+        self.assertEqual(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507000))
 
     def test_strptime_2(self):
         d = datetime.datetime.strptime("2013-11-29T16:38:12.507042", "%Y-%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507042))
+        self.assertEqual(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507042))
 
     def test_strptime_3(self):
         d = datetime.datetime.strptime("2013-11-29T16:38:12.5070", "%Y-%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507000))
+        self.assertEqual(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507000))
 
     def test_strptime_4(self):
         d = datetime.datetime.strptime("2013-11-29T16:38:12.507", "%Y-%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507000))
+        self.assertEqual(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 507000))
 
     def test_strptime_5(self):
         d = datetime.datetime.strptime("2013-11-29T16:38:12.50", "%Y-%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 500000))
+        self.assertEqual(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 500000))
 
     def test_strptime_6(self):
         d = datetime.datetime.strptime("2013-11-29T16:38:12.5", "%Y-%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 500000))
+        self.assertEqual(d, datetime.datetime(2013, 11, 29, 16, 38, 12, 500000))
 
     def test_strptime_7(self):
         d = datetime.datetime.strptime("11-29T16:38:12.123", "%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(1900, 11, 29, 16, 38, 12, 123000))
+        self.assertEqual(d, datetime.datetime(1900, 11, 29, 16, 38, 12, 123000))
 
     def test_strptime_8(self):
         d = datetime.datetime.strptime("11-29T16:38:12.123", "%m-%dT%H:%M:%S.%f")
-        self.assertEquals(d, datetime.datetime(1900, 11, 29, 16, 38, 12, 123000))
+        self.assertEqual(d, datetime.datetime(1900, 11, 29, 16, 38, 12, 123000))
 
     def test_strptime_9(self):
         d = datetime.datetime.strptime('Monday 11. March 2002', "%A %d. %B %Y")
-        self.assertEquals(d, datetime.datetime(2002, 3, 11, 0, 0))
+        self.assertEqual(d, datetime.datetime(2002, 3, 11, 0, 0))
     
     def test_strftime_1(self):
         d = datetime.datetime(2013, 11, 29, 16, 38, 12, 507000)
-        self.assertEquals(d.strftime("%Y-%m-%dT%H:%M:%S.%f"), "2013-11-29T16:38:12.507000")
+        self.assertEqual(d.strftime("%Y-%m-%dT%H:%M:%S.%f"), "2013-11-29T16:38:12.507000")
 
     def test_strftime_2(self):
         d = datetime.datetime(2013, 11, 29, 16, 38, 12, 507042)
-        self.assertEquals(d.strftime("%Y-%m-%dT%H:%M:%S.%f"), "2013-11-29T16:38:12.507042")
+        self.assertEqual(d.strftime("%Y-%m-%dT%H:%M:%S.%f"), "2013-11-29T16:38:12.507042")
 
     def test_strftime_3(self):
         # cp32215
         d = datetime.datetime(2012,2,8,4,5,6,12314)
-        self.assertEquals(d.strftime('%f'), "012314")
+        self.assertEqual(d.strftime('%f'), "012314")
 
     def test_cp23965(self):
         # this is locale dependant and assumes test will be run under en_US
-        self.assertEquals(datetime.date(2013, 11, 30).strftime("%Y %A %B"), "2013 Saturday November")
-        self.assertEquals(datetime.date(2013, 11, 30).strftime("%y %a %b"), "13 Sat Nov")
+        self.assertEqual(datetime.date(2013, 11, 30).strftime("%Y %A %B"), "2013 Saturday November")
+        self.assertEqual(datetime.date(2013, 11, 30).strftime("%y %a %b"), "13 Sat Nov")
 
     def test_invalid_strptime(self):
         # cp30047
         self.assertRaises(ValueError, datetime.datetime.strptime, "9 August", "%B %d")
         d = datetime.datetime.strptime("9 August", "%d %B")
-        self.assertEquals(d, datetime.datetime(1900, 8, 9, 0, 0))
+        self.assertEqual(d, datetime.datetime(1900, 8, 9, 0, 0))
 
     def test_strptime_day_of_week(self):
         t = time.strptime("2013", "%Y")

--- a/Tests/test_function.py
+++ b/Tests/test_function.py
@@ -76,7 +76,7 @@ class FunctionTest(IronPythonTestCase):
             class SubType(t): pass
             return SubType
 
-        self.assertRaisesRegexp(TypeError, ".*\n?.* is not an acceptable base type", CreateSubType, type(foo))
+        self.assertRaisesRegex(TypeError, ".*\n?.* is not an acceptable base type", CreateSubType, type(foo))
 
     def test_varargs(self):
         def a(*args): return args

--- a/Tests/test_hash.py
+++ b/Tests/test_hash.py
@@ -12,8 +12,8 @@ class HashTest(IronPythonTestCase):
                 return self is other
 
         x = HashBeforeEq()
-        self.assertNotEquals(x.__hash__, None)
-        self.assertEquals(hash(x), 1)
+        self.assertNotEqual(x.__hash__, None)
+        self.assertEqual(hash(x), 1)
 
     def test_eq_before_hash(self):
         class EqBeforeHash:
@@ -23,8 +23,8 @@ class HashTest(IronPythonTestCase):
                 return 1
 
         x = EqBeforeHash()
-        self.assertNotEquals(x.__hash__, None)
-        self.assertEquals(hash(x), 1)
+        self.assertNotEqual(x.__hash__, None)
+        self.assertEqual(hash(x), 1)
 
     def test_hash_writable_memoryviews(self):
         buffer = array.array('b', [1,2,3])

--- a/Tests/test_methoddispatch.py
+++ b/Tests/test_methoddispatch.py
@@ -1413,7 +1413,7 @@ class MethodDispatchTest(IronPythonTestCase):
 
     def test_max_args(self):
         """verify the correct number of max args are reported, this may need to be updated if file ever takes more args"""
-        self.assertRaisesRegexp(TypeError, '.*takes at most 4 arguments.*', file, 2, 3, 4, 5, 6, 7, 8, 9)
+        self.assertRaisesRegex(TypeError, '.*takes at most 4 arguments.*', file, 2, 3, 4, 5, 6, 7, 8, 9)
 
 
     def test_enumerator_conversions(self):

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -228,21 +228,21 @@ with open(r"%s", "w") as f:
         global andCalled
         andCalled = False
 
-        self.assertRaisesRegexp(_struct.error, "integer out of range for 'L' format code",
+        self.assertRaisesRegex(_struct.error, "integer out of range for 'L' format code",
                             _struct.Struct('L').pack, 4294967296)
-        self.assertRaisesRegexp(_struct.error, "integer out of range for 'L' format code",
+        self.assertRaisesRegex(_struct.error, "integer out of range for 'L' format code",
                             _struct.Struct('L').pack, -1)
-        self.assertRaisesRegexp(Exception, "foo",
+        self.assertRaisesRegex(Exception, "foo",
                             _struct.Struct('L').pack, x(0))
-        self.assertRaisesRegexp(Exception, "foo", _struct.Struct('L').pack, x(-1))
+        self.assertRaisesRegex(Exception, "foo", _struct.Struct('L').pack, x(-1))
 
-        self.assertRaisesRegexp(_struct.error, "integer out of range for 'I' format code",
+        self.assertRaisesRegex(_struct.error, "integer out of range for 'I' format code",
                             _struct.Struct('I').pack, 4294967296)
-        self.assertRaisesRegexp(_struct.error, "integer out of range for 'I' format code",
+        self.assertRaisesRegex(_struct.error, "integer out of range for 'I' format code",
                             _struct.Struct('I').pack, -1)
-        self.assertRaisesRegexp(Exception, "foo",
+        self.assertRaisesRegex(Exception, "foo",
                             _struct.Struct('I').pack, x(0))
-        self.assertRaisesRegexp(Exception, "foo", _struct.Struct('I').pack, x(-1))
+        self.assertRaisesRegex(Exception, "foo", _struct.Struct('I').pack, x(-1))
 
         # __and__ was called in Python2.6 check that this is no longer True
         self.assertTrue(not andCalled)
@@ -513,7 +513,7 @@ with open(r"%s", "w") as f:
         def f(a=None):
             pass
 
-        self.assertRaisesRegexp(TypeError, "f\(\) got multiple values for keyword argument 'a'",
+        self.assertRaisesRegex(TypeError, "f\(\) got multiple values for keyword argument 'a'",
                             lambda: f(1, a=3))
 
     @unittest.skipIf(is_netcoreapp, 'requires System.Drawing.Common dependency')
@@ -1188,7 +1188,7 @@ class C:
         """https://github.com/IronLanguages/ironpython2/issues/463"""
         import plistlib
         x = b'<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>A</key><string>B</string></dict></plist>'
-        self.assertEquals(plistlib.readPlistFromBytes(x), {'A': 'B'})
+        self.assertEqual(plistlib.readPlistFromBytes(x), {'A': 'B'})
 
     def test_gh483(self):
         """https://github.com/IronLanguages/ironpython2/issues/463"""
@@ -1348,7 +1348,7 @@ class C:
         class x(int):
             def __hash__(self): return 42
 
-        self.assertEquals(42, hash(x()))
+        self.assertEqual(42, hash(x()))
 
     def test_main_gh1081(self):
         """https://github.com/IronLanguages/main/issues/1081"""

--- a/Tests/test_struct.py
+++ b/Tests/test_struct.py
@@ -61,8 +61,8 @@ class StructTest(unittest.TestCase):
     def test_ipy2_gh407(self):
         """https://github.com/IronLanguages/ironpython2/issues/407"""
 
-        self.assertRaisesRegexp(struct.error, '^unpack requires', struct.unpack, "H", b"a")
+        self.assertRaisesRegex(struct.error, '^unpack requires', struct.unpack, "H", b"a")
         struct.unpack("H", b"aa")
-        self.assertRaisesRegexp(struct.error, '^unpack requires', struct.unpack, "H", b"aaa")
+        self.assertRaisesRegex(struct.error, '^unpack requires', struct.unpack, "H", b"aaa")
 
 run_test(__name__)


### PR DESCRIPTION
Hi,   
I wrote a patch to resolve #714.  
I looked around `Tests/**.py` and replaced deprecated API aliases as described in [the unittest documentation](https://docs.python.org/3/library/unittest.html#deprecated-aliases).  
  
Here are some descriptions of the changes:   
- Replaced `assertEquals()` to `assertEqual()`
- Replaced `assertNotEquals()` to `assertNotEqual()`
- Replaced `assertRaisesRegexp()` to `assertRaisesRegex()`

