### PR TITLE
Making `test_winreg` passes.

### DIFF
--- a/Src/IronPython.Modules/winreg.cs
+++ b/Src/IronPython.Modules/winreg.cs
@@ -218,13 +218,17 @@ namespace IronPython.Modules {
             // the .NET APIs don't work with a key name of length 256, use a PInvoke instead
             // unlike in CreateKey(), `subKeyName.Length` on deletion can be greater than 256 if combined with parent key name.
             if (sub_key.Length >= 256) {
+                int result = RegDeleteKey(rootKey.GetKey().Handle, sub_key);
+                if (result != ERROR_SUCCESS) {
+                    throw PythonExceptions.CreateThrowable(PythonExceptions.OSError, result);
+                }
                 return;
             }
 
             try {
                 rootKey.GetKey().DeleteSubKey(sub_key);
             } catch (ArgumentException e) {
-                throw new ExternalException(e.Message);
+                throw PythonExceptions.CreateThrowable(PythonExceptions.OSError, e.HResult);
             }
         }
 

--- a/Src/IronPython.Modules/winreg.cs
+++ b/Src/IronPython.Modules/winreg.cs
@@ -95,18 +95,18 @@ namespace IronPython.Modules {
             key.Close();
         }
 
-        public static HKEYType CreateKey(object key, string subKeyName) {
+        public static HKEYType CreateKey(object key, string sub_key) {
             // the .NET APIs don't work with a key name of length 256, use CreateKeyEx which PInvokes instead
-            if (subKeyName.Length == 256)
-                return CreateKeyEx(key, subKeyName, 0, KEY_ALL_ACCESS);
+            if (sub_key.Length == 256)
+                return CreateKeyEx(key, sub_key, 0, KEY_ALL_ACCESS);
 
             HKEYType rootKey = GetRootKey(key);
 
             //if key is a system key and no subkey is specified return that.
-            if (key is BigInteger && string.IsNullOrEmpty(subKeyName))
+            if (key is BigInteger && string.IsNullOrEmpty(sub_key))
                 return rootKey;
             
-            HKEYType subKey = new HKEYType(rootKey.GetKey().CreateSubKey(subKeyName));
+            HKEYType subKey = new HKEYType(rootKey.GetKey().CreateSubKey(sub_key));
             return subKey;
         }
 
@@ -114,11 +114,11 @@ namespace IronPython.Modules {
             return new Win32Exception(errorCode).Message;
         }
 
-        public static HKEYType CreateKeyEx(object key, string subKeyName, int res = 0, int sam = KEY_ALL_ACCESS) {
+        public static HKEYType CreateKeyEx(object key, string sub_key, int reserved = 0, int access = KEY_ALL_ACCESS) {
             HKEYType rootKey = GetRootKey(key);
 
             //if key is a system key and no subkey is specified return that.
-            if (key is BigInteger && string.IsNullOrEmpty(subKeyName))
+            if (key is BigInteger && string.IsNullOrEmpty(sub_key))
                 return rootKey;
 
             SafeRegistryHandle handle;
@@ -126,11 +126,11 @@ namespace IronPython.Modules {
             
             int result = RegCreateKeyEx(
                 rootKey.GetKey().Handle,
-                subKeyName,
+                sub_key,
                 0,
                 null,
                 RegistryOptions.None,
-                (RegistryRights)sam,
+                (RegistryRights)access,
                 IntPtr.Zero,
                 out handle,
                 out disposition
@@ -209,10 +209,10 @@ namespace IronPython.Modules {
             SafeRegistryHandle hBase,
             out bool bIsReflectionDisabled);
 
-        public static void DeleteKey(object key, string subKeyName) {
+        public static void DeleteKey(object key, string sub_key) {
             HKEYType rootKey = GetRootKey(key);
 
-            if (key is BigInteger && string.IsNullOrEmpty(subKeyName))
+            if (key is BigInteger && string.IsNullOrEmpty(sub_key))
                 throw new InvalidCastException("DeleteKey() argument 2 must be string, not None");
 
             // the .NET APIs don't work with a key name of length 256, use a PInvoke instead
@@ -222,7 +222,7 @@ namespace IronPython.Modules {
             }
 
             try {
-                rootKey.GetKey().DeleteSubKey(subKeyName);
+                rootKey.GetKey().DeleteSubKey(sub_key);
             } catch (ArgumentException e) {
                 throw new ExternalException(e.Message);
             }
@@ -380,11 +380,11 @@ namespace IronPython.Modules {
             rootKey.GetKey().Flush();
         }
 
-        public static HKEYType OpenKey(object key, string subKeyName) {
-            return OpenKey(key, subKeyName, 0, KEY_READ);
+        public static HKEYType OpenKey(object key, string sub_key) {
+            return OpenKey(key, sub_key, 0, KEY_READ);
         }
 
-        public static HKEYType OpenKey(object key, string subKeyName, int res=0, int sam=KEY_READ) {
+        public static HKEYType OpenKey(object key, string sub_key, int reserved=0, int access=KEY_READ) {
             HKEYType rootKey = GetRootKey(key);
             RegistryKey newKey = null;
 
@@ -398,20 +398,20 @@ namespace IronPython.Modules {
 
             var nativeRootKey = rootKey.GetKey();
             try {
-                if ((sam & KEY_SET_VALUE) == KEY_SET_VALUE ||
-                    (sam & KEY_CREATE_SUB_KEY) == KEY_CREATE_SUB_KEY) {
-                        if (res != 0) {
-                            newKey = nativeRootKey.OpenSubKey(subKeyName, RegistryKeyPermissionCheck.Default, (RegistryRights)res);
+                if ((access & KEY_SET_VALUE) == KEY_SET_VALUE ||
+                    (access & KEY_CREATE_SUB_KEY) == KEY_CREATE_SUB_KEY) {
+                        if (reserved != 0) {
+                            newKey = nativeRootKey.OpenSubKey(sub_key, RegistryKeyPermissionCheck.Default, (RegistryRights)reserved);
                         } else {
-                            newKey = nativeRootKey.OpenSubKey(subKeyName, true);
+                            newKey = nativeRootKey.OpenSubKey(sub_key, true);
                         }
-                } else if ((sam & KEY_QUERY_VALUE) == KEY_QUERY_VALUE ||
-                           (sam & KEY_ENUMERATE_SUB_KEYS) == KEY_ENUMERATE_SUB_KEYS ||
-                           (sam & KEY_NOTIFY) == KEY_NOTIFY) {
-                               if (res != 0) {
-                                   newKey = nativeRootKey.OpenSubKey(subKeyName, RegistryKeyPermissionCheck.ReadSubTree, (RegistryRights)res);
+                } else if ((access & KEY_QUERY_VALUE) == KEY_QUERY_VALUE ||
+                           (access & KEY_ENUMERATE_SUB_KEYS) == KEY_ENUMERATE_SUB_KEYS ||
+                           (access & KEY_NOTIFY) == KEY_NOTIFY) {
+                               if (reserved != 0) {
+                                   newKey = nativeRootKey.OpenSubKey(sub_key, RegistryKeyPermissionCheck.ReadSubTree, (RegistryRights)reserved);
                                } else {
-                                   newKey = nativeRootKey.OpenSubKey(subKeyName, false);
+                                   newKey = nativeRootKey.OpenSubKey(sub_key, false);
                                }
                 } else {
                     throw new Win32Exception("Unexpected mode");
@@ -428,8 +428,8 @@ namespace IronPython.Modules {
             return new HKEYType(newKey);
         }
 
-        public static HKEYType OpenKeyEx(object key, string subKeyName, int res=0, int sam=KEY_READ) {
-            return OpenKey(key, subKeyName, res, sam);
+        public static HKEYType OpenKeyEx(object key, string sub_key, int reserved=0, int access=KEY_READ) {
+            return OpenKey(key, sub_key, reserved, access);
         }
 
         public static PythonTuple QueryInfoKey(object key) {
@@ -457,12 +457,12 @@ namespace IronPython.Modules {
             }
         }
 
-        public static object QueryValue(object key, string subKeyName) {
-            HKEYType pyKey = OpenKey(key, subKeyName);
+        public static object QueryValue(object key, string sub_key) {
+            HKEYType pyKey = OpenKey(key, sub_key);
             return pyKey.GetKey().GetValue(null);
         }
 
-        public static PythonTuple QueryValueEx(object key, string valueName) {
+        public static PythonTuple QueryValueEx(object key, string value_name) {
             HKEYType rootKey = GetRootKey(key);
 
             // it looks like rootKey.GetKey().Handle fails on HKEY_PERFORMANCE_DATA so manually create the handle instead
@@ -470,23 +470,23 @@ namespace IronPython.Modules {
 
             int valueKind;
             object value;
-            QueryValueExImpl(handle, valueName, out valueKind, out value);
+            QueryValueExImpl(handle, value_name, out valueKind, out value);
 
             return PythonTuple.MakeTuple(value, valueKind);
         }
 
-        public static void SetValue(object key, string subKeyName, int type, string value) {
-            HKEYType pyKey = CreateKey(key, subKeyName);
+        public static void SetValue(object key, string sub_key, int type, string value) {
+            HKEYType pyKey = CreateKey(key, sub_key);
             pyKey.GetKey().SetValue(null, value);
         }
 
-        public static void SetValueEx(object key, string valueName, object reserved, int type, object value) {
+        public static void SetValueEx(object key, string value_name, object reserved, int type, object value) {
             HKEYType rootKey = GetRootKey(key);
             RegistryValueKind regKind = (RegistryValueKind)type;
 
             // null is a valid value but RegistryKey.SetValue doesn't like it so PInvoke to set it
             if (value == null) {
-                RegSetValueEx(rootKey.GetKey().Handle, valueName, 0, type, null, 0);
+                RegSetValueEx(rootKey.GetKey().Handle, value_name, 0, type, null, 0);
                 return;
             }
 
@@ -494,7 +494,7 @@ namespace IronPython.Modules {
                 int size = ((PythonList)value)._size;
                 string[] strArray = new string[size];
                 Array.Copy(((PythonList)value)._data, strArray, size);
-                rootKey.GetKey().SetValue(valueName, strArray, regKind);
+                rootKey.GetKey().SetValue(value_name, strArray, regKind);
             } else if (regKind == RegistryValueKind.Binary) {
                 byte[] byteArr = null;
                 if (value is string) {
@@ -502,38 +502,38 @@ namespace IronPython.Modules {
                     ASCIIEncoding encoding = new ASCIIEncoding();
                     byteArr = encoding.GetBytes(strValue);
                 }
-                rootKey.GetKey().SetValue(valueName, byteArr, regKind);
+                rootKey.GetKey().SetValue(value_name, byteArr, regKind);
             } else if (regKind == RegistryValueKind.DWord) {
                 // DWORDs are uint but the .NET API requires int
                 if (value is BigInteger) {
                     var val = (uint)(BigInteger)value;
                     value = unchecked((int)val);
                 }
-                rootKey.GetKey().SetValue(valueName, value, regKind);
+                rootKey.GetKey().SetValue(value_name, value, regKind);
             } else if (regKind == RegistryValueKind.QWord) {
                 // QWORDs are ulong but the .NET API requires long
                 if (value is BigInteger) {
                     var val = (ulong)(BigInteger)value;
                     value = unchecked((long)val);
                 }
-                rootKey.GetKey().SetValue(valueName, value, regKind);
+                rootKey.GetKey().SetValue(value_name, value, regKind);
             } else {
-                rootKey.GetKey().SetValue(valueName, value, regKind);
+                rootKey.GetKey().SetValue(value_name, value, regKind);
             }
 
         }
 
-        public static HKEYType ConnectRegistry(string computerName, BigInteger key) {
-            if (string.IsNullOrEmpty(computerName))
-                computerName = string.Empty;
+        public static HKEYType ConnectRegistry(string computer_name, BigInteger key) {
+            if (string.IsNullOrEmpty(computer_name))
+                computer_name = string.Empty;
 
             RegistryKey newKey = null;
             try {
-                if (computerName == string.Empty) {
+                if (computer_name == string.Empty) {
                     newKey = RegistryKey.OpenBaseKey(MapSystemKey(key), RegistryView.Default);
                 }
                 else {
-                    newKey = RegistryKey.OpenRemoteBaseKey(MapSystemKey(key), computerName);
+                    newKey = RegistryKey.OpenRemoteBaseKey(MapSystemKey(key), computer_name);
                 }
             }
             catch (IOException ioe) {

--- a/Src/IronPython.Modules/winreg.cs
+++ b/Src/IronPython.Modules/winreg.cs
@@ -216,8 +216,8 @@ namespace IronPython.Modules {
                 throw new InvalidCastException("DeleteKey() argument 2 must be string, not None");
 
             // the .NET APIs don't work with a key name of length 256, use a PInvoke instead
-            if (subKeyName.Length == 256) {
-                RegDeleteKey(rootKey.GetKey().Handle, subKeyName);
+            // unlike in CreateKey(), `subKeyName.Length` on deletion can be greater than 256 if combined with parent key name.
+            if (sub_key.Length >= 256) {
                 return;
             }
 

--- a/Src/IronPython.Modules/winreg.cs
+++ b/Src/IronPython.Modules/winreg.cs
@@ -336,7 +336,11 @@ namespace IronPython.Modules {
                     value = list;
                     break;
                 case REG_BINARY:
-                    value = length == 0 ? null : PythonOps.MakeString(data, (int)length);
+                    var tight_fit_data = new byte[length];
+                    for (int i = 0; i < length; i++) {
+                        tight_fit_data[i] = data[i];
+                    }
+                    value = length == 0 ? null : new Bytes(tight_fit_data);
                     break;
                 case REG_EXPAND_SZ:
                 case REG_SZ:
@@ -505,6 +509,8 @@ namespace IronPython.Modules {
                     string strValue = value as string;
                     ASCIIEncoding encoding = new ASCIIEncoding();
                     byteArr = encoding.GetBytes(strValue);
+                } else if (value is Bytes ibytes) {
+                    byteArr = ibytes.UnsafeByteArray;
                 }
                 rootKey.GetKey().SetValue(value_name, byteArr, regKind);
             } else if (regKind == RegistryValueKind.DWord) {

--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -1049,8 +1049,6 @@ Reason=https://github.com/IronLanguages/ironpython3/issues/489
 
 [AllCPython.test_winreg]
 RunCondition=$(IS_WINDOWS)
-Ignore=true
-Reason=https://github.com/IronLanguages/ironpython3/issues/410
 
 [AllCPython.test_winsound]
 RunCondition=$(IS_WINDOWS)

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1435,4 +1435,18 @@ class C:
             result = ET.tostring(ET.fromstring(txt))
             self.assertEqual(txt, result)
 
+    def test_ipy3_gh410(self):
+        """https://github.com/IronLanguages/ironpython3/issues/410"""
+        import threading
+        def test_thread():
+            class Thread(threading.Thread):
+                def run(self):
+                    self.thread_executed = 1
+
+            thread = Thread()
+            thread.start()
+            thread.join()
+            self.assertEqual(thread.thread_executed, 1)
+        test_thread()
+
 run_test(__name__)


### PR DESCRIPTION
Hi, 
I wrote a patch to resolve #410.  

The code shown in #410 causes a deadlock because `_set_sentinel()` is not implemented as `threading.py` expects; an lock object returned by `_set_sentinel()` should be released on its thread exit.  
  
I also implemented a lacking feature, timeout for `acquire()` as well. 
According to [the documentation](https://docs.python.org/3/library/threading.html#threading.Lock.acquire), timeout is only supported on blocking acquire.
