### PR TITLE
Get __class__ keyword works without AST modification

### DIFF
--- a/Src/IronPython/Compiler/Ast/AstMethods.cs
+++ b/Src/IronPython/Compiler/Ast/AstMethods.cs
@@ -60,6 +60,7 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo UnpackIterable = GetMethod((Func<CodeContext, object, int, int, object>)PythonOps.UnpackIterable);
         public static readonly MethodInfo GetGlobalContext = GetMethod((Func<CodeContext, CodeContext>)PythonOps.GetGlobalContext);
         public static readonly MethodInfo GetParentContextFromFunction = GetMethod((Func<PythonFunction, CodeContext>)PythonOps.GetParentContextFromFunction);
+        public static readonly MethodInfo GetGrandParentContextFromFunction = GetMethod((Func<PythonFunction, CodeContext>)PythonOps.GetGrandParentContextFromFunction);
         public static readonly MethodInfo MakeFunction = GetMethod((Func<CodeContext, FunctionCode, object, object[], PythonDictionary, PythonDictionary, object>)PythonOps.MakeFunction);
         public static readonly MethodInfo MakeFunctionDebug = GetMethod((Func<CodeContext/*!*/, FunctionCode, object, object[], PythonDictionary, PythonDictionary, Delegate, object>)PythonOps.MakeFunctionDebug);
         public static readonly MethodInfo MakeClosureCell = GetMethod((Func<ClosureCell>)PythonOps.MakeClosureCell);

--- a/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -629,7 +629,7 @@ namespace IronPython.Compiler.Ast {
                 init.Add(
                     AssignValue(
                         GetVariableExpression(pVar),
-                        Ast.Call(AstMethods.LookupName, parent.Parent.LocalContext, Ast.Constant(parent.Name))
+                        Ast.Call(AstMethods.LookupName, new GetGrandParentContextFromFunctionExpression(), Ast.Constant(parent.Name))
                     )
                 );
             }

--- a/Src/IronPython/Compiler/Ast/GetParentContextFromFunctionExpression.cs
+++ b/Src/IronPython/Compiler/Ast/GetParentContextFromFunctionExpression.cs
@@ -45,4 +45,39 @@ namespace IronPython.Compiler.Ast {
             }
         }
     }
+
+
+    internal class GetGrandParentContextFromFunctionExpression : MSAst.Expression, IInstructionProvider {
+        private static readonly MSAst.Expression _gparentContext = MSAst.Expression.Call(AstMethods.GetGrandParentContextFromFunction, FunctionDefinition._functionParam);
+
+        public override bool CanReduce => true;
+
+        public override MSAst.ExpressionType NodeType => MSAst.ExpressionType.Extension;
+
+        public override Type Type => typeof(CodeContext);
+
+        public override MSAst.Expression Reduce() => _gparentContext;
+
+        #region IInstructionProvider Members
+
+        public void AddInstructions(LightCompiler compiler) {
+            compiler.Compile(FunctionDefinition._functionParam);
+            compiler.Instructions.Emit(GetGrandParentContextFromFunctionInstruction.Instance);
+        }
+
+        #endregion
+
+        private class GetGrandParentContextFromFunctionInstruction : Instruction {
+            public static readonly GetGrandParentContextFromFunctionInstruction Instance = new GetGrandParentContextFromFunctionInstruction();
+
+            public override int ProducedStack => 1;
+
+            public override int ConsumedStack => 1;
+
+            public override int Run(InterpretedFrame frame) {
+                frame.Push(PythonOps.GetGrandParentContextFromFunction((PythonFunction)frame.Pop()));
+                return +1;
+            }
+        }
+    }
 }

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -821,28 +821,10 @@ namespace IronPython.Compiler.Ast {
             node.Parent = _currentScope;
 
             if (node.Target is NameExpression nameExpr && nameExpr.Name == "super" && _currentScope is FunctionDefinition func) {
+                _currentScope.Reference("__class__");
                 if (node.Args.Length == 0 && func.ParameterNames.Length > 0) {
-                    if (ShouldExpandSuperSyntaxSugar(node)) {
-                        // if `super()` is referenced in a class method.
-                        _currentScope.Reference(node.Parent.Parent.Name);
-                        node.ImplicitArgs.Add(new Arg(new NameExpression(node.Parent.Parent.Name)));
-                        node.ImplicitArgs.Add(new Arg(new NameExpression(func.ParameterNames[0])));
-                    } else {
-                        // otherwise, fallback to default implementation.
-                        _currentScope.Reference("__class__");
-                        node.ImplicitArgs.Add(new Arg(new NameExpression("__class__")));
-                        node.ImplicitArgs.Add(new Arg(new NameExpression(func.ParameterNames[0])));
-                    }
-                }
-
-                bool ShouldExpandSuperSyntaxSugar(CallExpression node) {
-                    if (!(node.Parent is FunctionDefinition)) {
-                        return false;
-                    }
-                    if (!(node.Parent.Parent is ClassDefinition)) {
-                        return false;
-                    }
-                    return true;
+                    node.ImplicitArgs.Add(new Arg(new NameExpression("__class__")));
+                    node.ImplicitArgs.Add(new Arg(new NameExpression(func.ParameterNames[0])));
                 }
             }
             return base.Walk(node);

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -1962,28 +1962,8 @@ namespace IronPython.Compiler {
                     NextToken();
                     string name = (string)t.Value;
                     _sink?.StartName(GetSourceSpan(), name);
-                    var fixedName = FixName(name);
-                    if (ShouldReplaceClassKeyword(fixedName)) {
-                        // if `__class__` variable is used in a class method, replace with `name_of_the_class`.
-                        ret = new NameExpression(CurrentClass.Name);
-                    } else {
-                        ret = new NameExpression(fixedName);
-                    }
+                    ret = new NameExpression(FixName(name));
                     ret.SetLoc(_globalParent, GetStart(), GetEnd());
-
-                    bool ShouldReplaceClassKeyword(string fixedName) {
-                        if (CurrentClass == null || CurrentFunction == null) {
-                            return false;
-                        }
-                        if (PeekToken(TokenKind.Assign)) {
-                            // avoid replacing statement like `__class__ = getproperty(...)`.
-                            return false;
-                        }
-                        if (fixedName != "__class__") {
-                            return false;
-                        }
-                        return true;
-                    }
                     return ret;
                 case TokenKind.Constant:        // literal
                     NextToken();

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1802,7 +1802,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             if (locals == null) {
                 localContext = mc.GlobalContext;
             } else {
-                localContext = new CodeContext(PythonDictionary.FromIAC(context, locals), mc);
+                localContext = new CodeContext(PythonDictionary.FromIAC(context, locals), mc, context);
             }
 
             if (!globals.ContainsKey("__builtins__")) {

--- a/Src/IronPython/Runtime/CodeContext.cs
+++ b/Src/IronPython/Runtime/CodeContext.cs
@@ -20,15 +20,17 @@ namespace IronPython.Runtime {
     public sealed class CodeContext {
         private readonly ModuleContext/*!*/ _modContext;
         private readonly PythonDictionary/*!*/ _dict;
+        private readonly CodeContext _maybegrandparent;// can be null.
 
         /// <summary>
         /// Creates a new CodeContext which is backed by the specified Python dictionary.
         /// </summary>
-        public CodeContext(PythonDictionary/*!*/ dict, ModuleContext/*!*/ moduleContext) {
+        public CodeContext(PythonDictionary/*!*/ dict, ModuleContext/*!*/ moduleContext, CodeContext maybegrandparent) {
             ContractUtils.RequiresNotNull(dict, nameof(dict));
             ContractUtils.RequiresNotNull(moduleContext, nameof(moduleContext));
             _dict = dict;
             _modContext = moduleContext;
+            _maybegrandparent = maybegrandparent;
         }
 
         #region Public APIs
@@ -228,6 +230,8 @@ namespace IronPython.Runtime {
                 }
             }
         }
+
+        internal CodeContext GrandParentContext => _maybegrandparent;
 
         #endregion
     }

--- a/Src/IronPython/Runtime/ModuleContext.cs
+++ b/Src/IronPython/Runtime/ModuleContext.cs
@@ -28,7 +28,7 @@ namespace IronPython.Runtime {
 
             _globals = globals;
             _pyContext = creatingContext;
-            _globalContext = new CodeContext(globals, this);
+            _globalContext = new CodeContext(globals, this, null);
             _module = new PythonModule(globals);
             _module.Scope.SetExtension(_pyContext.ContextId, new PythonScopeExtension(_pyContext, _module, this));
         }
@@ -42,7 +42,7 @@ namespace IronPython.Runtime {
 
             _globals = module.__dict__;
             _pyContext = creatingContext;
-            _globalContext = new CodeContext(_globals, this);
+            _globalContext = new CodeContext(_globals, this, null);
             _module = module;
         }
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3443,7 +3443,8 @@ namespace IronPython.Runtime.Operations {
                 new PythonDictionary(
                     new RuntimeVariablesDictionaryStorage(boxes, args)
                 ),
-                outerContext.ModuleContext
+                outerContext.ModuleContext,
+                outerContext
             );
         }
 
@@ -3473,6 +3474,10 @@ namespace IronPython.Runtime.Operations {
 
         public static CodeContext/*!*/ GetParentContextFromFunction(PythonFunction/*!*/ function) {
             return function.Context;
+        }
+
+        public static CodeContext/*!*/ GetGrandParentContextFromFunction(PythonFunction/*!*/ function) {
+            return function.Context.GrandParentContext ?? function.Context;
         }
 
         public static CodeContext/*!*/ GetParentContextFromGenerator(PythonGenerator/*!*/ generator) {

--- a/Src/IronPython/Runtime/PythonFunction.cs
+++ b/Src/IronPython/Runtime/PythonFunction.cs
@@ -65,7 +65,7 @@ namespace IronPython.Runtime {
                 _context = context;
             } else {
                 _module = null;
-                _context = new CodeContext(new PythonDictionary(), new ModuleContext(globals, DefaultContext.DefaultPythonContext));
+                _context = new CodeContext(new PythonDictionary(), new ModuleContext(globals, DefaultContext.DefaultPythonContext), context);
             }
 
             _defaults = defaults == null ? ArrayUtils.EmptyObjects : defaults.ToArray();

--- a/Tests/test_dict.py
+++ b/Tests/test_dict.py
@@ -55,12 +55,10 @@ class DictTest(IronPythonTestCase):
                 super(MyDict, self).__setitem__(*args)
 
         a = MyDict()
-        with self.assertRaises(SystemError): # TODO: remove assertRaises when https://github.com/IronLanguages/ironpython3/issues/456 is fixed
-            a[0] = 'abc'
-            self.assertEqual(a[0], 'abc')
-        with self.assertRaises(SystemError): # TODO: remove assertRaises when https://github.com/IronLanguages/ironpython3/issues/456 is fixed
-            a[None] = 3
-            self.assertEqual(a[None], 3)
+        a[0] = 'abc'
+        self.assertEqual(a[0], 'abc')
+        a[None] = 3
+        self.assertEqual(a[None], 3)
 
         class MyDict(dict):
             def __setitem__(self, *args):

--- a/Tests/test_dict.py
+++ b/Tests/test_dict.py
@@ -55,10 +55,12 @@ class DictTest(IronPythonTestCase):
                 super(MyDict, self).__setitem__(*args)
 
         a = MyDict()
-        a[0] = 'abc'
-        self.assertEqual(a[0], 'abc')
-        a[None] = 3
-        self.assertEqual(a[None], 3)
+        with self.assertRaises(SystemError): # TODO: remove assertRaises when https://github.com/IronLanguages/ironpython3/issues/456 is fixed
+            a[0] = 'abc'
+            self.assertEqual(a[0], 'abc')
+        with self.assertRaises(SystemError): # TODO: remove assertRaises when https://github.com/IronLanguages/ironpython3/issues/456 is fixed
+            a[None] = 3
+            self.assertEqual(a[None], 3)
 
         class MyDict(dict):
             def __setitem__(self, *args):

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -996,16 +996,7 @@ class C:
             super(two, self).__init__()
             self.cnt += 1
 
-        if is_cli:
-            try:
-                self.assertEqual(two().cnt, 3)
-            except SystemError:
-                # https://github.com/IronLanguages/ironpython3/issues/451
-                pass
-            else:
-                self.fail("delete the try/except when https://github.com/IronLanguages/ironpython3/issues/451 is fixed")
-        else:
-            self.assertEqual(two().cnt, 3)
+        self.assertEqual(two().cnt, 3)
 
     def test_ipy2_gh292(self):
         """https://github.com/IronLanguages/ironpython2/issues/292"""
@@ -1448,5 +1439,43 @@ class C:
             thread.join()
             self.assertEqual(thread.thread_executed, 1)
         test_thread()
+
+    def test_ipy3_gh451(self):
+        """https://github.com/IronLanguages/ironpython3/issues/451"""
+        def test():
+            class two(object):
+                def __init__(self):
+                    super().__init__()
+                    self.cnt = 1
+            return two().cnt
+        self.assertEqual(test(), 1)
+
+        class test__class__keyword(object):
+            def __new__(cls):
+                return super().__new__(cls)
+            def __init__(self):
+                super().__init__()
+            def get_self_class(self):
+                return self.__class__
+            def get_class(self):
+                return __class__
+            @classmethod
+            def get_class_class(cls):
+                return cls
+
+        o = test__class__keyword()
+        self.assertEqual(o.get_self_class(), o.get_class())
+        self.assertEqual(o.get_class(), o.get_class_class())
+
+    def test_ipy3_gh723(self):
+        """https://github.com/IronLanguages/ironpython3/issues/723"""
+        import ast
+        x = """
+class test(object):
+    def test(self):
+        return __class__
+        """
+        a = compile(x, "", "exec", flags=0x400)
+        self.assertEqual(a.body[0].body[0].body[0].value.id, "__class__")
 
 run_test(__name__)

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -996,7 +996,16 @@ class C:
             super(two, self).__init__()
             self.cnt += 1
 
-        self.assertEqual(two().cnt, 3)
+        if is_cli:
+            try:
+                self.assertEqual(two().cnt, 3)
+            except SystemError:
+                # https://github.com/IronLanguages/ironpython3/issues/451
+                pass
+            else:
+                self.fail("delete the try/except when https://github.com/IronLanguages/ironpython3/issues/451 is fixed")
+        else:
+            self.assertEqual(two().cnt, 3)
 
     def test_ipy2_gh292(self):
         """https://github.com/IronLanguages/ironpython2/issues/292"""
@@ -1439,33 +1448,5 @@ class C:
             thread.join()
             self.assertEqual(thread.thread_executed, 1)
         test_thread()
-
-    def test_ipy3_gh451(self):
-        """https://github.com/IronLanguages/ironpython3/issues/451"""
-        def test():
-            class two(object):
-                def __init__(self):
-                    super().__init__()
-                    self.cnt = 1
-            return two().cnt
-        self.assertEqual(test(), 1)
-
-        class test__class__keyword(object):
-            def __new__(cls):
-                return super().__new__(cls)
-            def __init__(self):
-                super().__init__()
-            def get_self_class(self):
-                return self.__class__
-            def get_class(self):
-                return __class__
-            @classmethod
-            def get_class_class(cls):
-                return cls
-
-        o = test__class__keyword()
-        self.assertEqual(o.get_self_class(), o.get_class())
-        self.assertEqual(o.get_class(), o.get_class_class())
-
 
 run_test(__name__)


### PR DESCRIPTION
Hi, this resolves #723.    
As the subject says, the AST modification (introduced in #721) has been removed.  
  
Changes are...
1. Reverted #721 
2. Introduced `GetGrandParentContextFromFunction()` to make `__class__` handling code works. c.f.) FunctionDefinition.cs
3. Imported test from #723  