### PR TITLE
Get test_compare passing

### DIFF
--- a/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
+++ b/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
@@ -1011,7 +1011,6 @@ namespace IronPython.Runtime.Binding {
 
             SlotOrFunction fop = SlotOrFunction.GetSlotOrFunction(state, opSym, types);
             SlotOrFunction rop = SlotOrFunction.GetSlotOrFunction(state, ropSym, rTypes);
-
             SlotOrFunction cmp = SlotOrFunction.GetSlotOrFunction(state, "__cmp__", types);
             SlotOrFunction rcmp = SlotOrFunction.GetSlotOrFunction(state, "__cmp__", rTypes);
 
@@ -1031,7 +1030,6 @@ namespace IronPython.Runtime.Binding {
                 SlotOrFunction tmp = rop;
                 rop = fop;
                 fop = tmp;
-
                 opReverse = true;
             }
 

--- a/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
+++ b/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
@@ -857,6 +857,11 @@ namespace IronPython.Runtime.Binding {
             }
         }
 
+        private static void MakeNegatedCompareReturn(ConditionalBuilder/*!*/ bodyBuilder, Expression retCondition, Expression/*!*/ retValue, bool isReverse, Type retType) {
+            Expression newRetVal = Ast.Not(Ast.Call(Compiler.Ast.AstMethods.IsTrue, retValue));
+            MakeCompareReturn(bodyBuilder, retCondition, newRetVal, isReverse, retType);
+        }
+
         /// <summary>
         /// Delegate for finishing the comparison.   This takes in a condition and a return value and needs to update the ConditionalBuilder
         /// with the appropriate resulting body.  The condition may be null.
@@ -998,6 +1003,25 @@ namespace IronPython.Runtime.Binding {
 
         #region Comparison Operations
 
+        /// <summary>
+        /// Gets the slot to be used for a given comparison function,
+        /// defaulting to the negated '__eq__' when the '__ne__' slot
+        /// isn't defined.
+        /// </summary>
+        private static SlotOrFunction GetComparisonSlotOrFunction(PythonContext state, string opSym,
+                DynamicMetaObject[] types, out ComparisonHelper helper) {
+
+            SlotOrFunction op = SlotOrFunction.GetSlotOrFunction(state, opSym, types);
+            helper = MakeCompareReturn;
+
+            if ((op == SlotOrFunction.Empty || !op.Success) && opSym == "__ne__") {
+                op = SlotOrFunction.GetSlotOrFunction(state, "__eq__", types);
+                helper = MakeNegatedCompareReturn;
+            }
+
+            return op;
+        }
+
         private static DynamicMetaObject/*!*/ MakeComparisonOperation(DynamicMetaObject/*!*/[]/*!*/ types, DynamicMetaObjectBinder/*!*/ operation, PythonOperationKind op, DynamicMetaObject errorSuggestion) {
             RestrictTypes(types);
 
@@ -1009,8 +1033,9 @@ namespace IronPython.Runtime.Binding {
             // reverse
             DynamicMetaObject[] rTypes = new DynamicMetaObject[] { types[1], types[0] };
 
-            SlotOrFunction fop = SlotOrFunction.GetSlotOrFunction(state, opSym, types);
-            SlotOrFunction rop = SlotOrFunction.GetSlotOrFunction(state, ropSym, rTypes);
+            SlotOrFunction fop = GetComparisonSlotOrFunction(state, opSym, types, out ComparisonHelper fHelper);
+            SlotOrFunction rop = GetComparisonSlotOrFunction(state, ropSym, rTypes, out ComparisonHelper rHelper);
+
             SlotOrFunction cmp = SlotOrFunction.GetSlotOrFunction(state, "__cmp__", types);
             SlotOrFunction rcmp = SlotOrFunction.GetSlotOrFunction(state, "__cmp__", rTypes);
 
@@ -1030,14 +1055,19 @@ namespace IronPython.Runtime.Binding {
                 SlotOrFunction tmp = rop;
                 rop = fop;
                 fop = tmp;
+
+                ComparisonHelper tmpHelper = fHelper;
+                fHelper = rHelper;
+                rHelper = tmpHelper;
+
                 opReverse = true;
             }
 
             // first try __op__ or __rop__ and return the value
             shouldWarn = fop.ShouldWarn(state, out WarningInfo info);
-            if (MakeOneCompareGeneric(fop, opReverse, types, MakeCompareReturn, bodyBuilder, typeof(object))) {
+            if (MakeOneCompareGeneric(fop, opReverse, types, fHelper, bodyBuilder, typeof(object))) {
                 shouldWarn = shouldWarn || rop.ShouldWarn(state, out info);
-                if (MakeOneCompareGeneric(rop, !opReverse, types, MakeCompareReturn, bodyBuilder, typeof(object))) {
+                if (MakeOneCompareGeneric(rop, !opReverse, types, rHelper, bodyBuilder, typeof(object))) {
 
                     // then try __cmp__ or __rcmp__ and compare the resulting int appropriaetly
                     shouldWarn = shouldWarn || cmp.ShouldWarn(state, out info);

--- a/Src/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/Src/IronPython/Runtime/Operations/ObjectOps.cs
@@ -225,6 +225,17 @@ namespace IronPython.Runtime.Operations {
             return NotImplementedType.Value;
         }
 
+        [return: MaybeNotImplemented]
+        public static object __ne__(CodeContext context, object self, object other) {
+            if (PythonTypeOps.TryInvokeBinaryOperator(context, self, other, "__eq__", out object res)) {
+                if (res is NotImplementedType) {
+                    return NotImplementedType.Value;
+                }
+                return !PythonOps.IsTrue(res);
+            }
+            return NotImplementedType.Value;
+        }
+
         public static string __format__(CodeContext/*!*/ context, object self, [NotNull]string/*!*/ formatSpec) {
             string text = PythonOps.ToString(context, self);
 

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -1728,7 +1728,8 @@ namespace IronPython.Runtime.Types {
 
             // numeric types in python don't define equality, just __cmp__
             if (t == typeof(bool) ||
-                (Converter.IsNumeric(t) && t != typeof(Complex) && t != typeof(double) && t != typeof(float))) {
+                (Converter.IsNumeric(t) && t != typeof(Complex) && t != typeof(double) && t != typeof(float)) &&
+                t != typeof(Decimal)) {
                 switch (op) {
                     case PythonOperationKind.Equal:
                     case PythonOperationKind.NotEqual:

--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -160,10 +160,6 @@ Ignore=true
 [AllCPython.test_collections]
 Ignore=true
 
-[AllCPython.test_compare]
-Ignore=true
-Reason=StackOverflowException
-
 [AllCPython.test_compile]
 Ignore=true
 


### PR DESCRIPTION
Default to negating the result of `__eq__` when the `__ne__` slot is not
defined. Enable test_compare.py.

Looks like the earlier issues in this file have been fixed by other changes. According to the definition at `https://docs.python.org/3/reference/datamodel.html#object.__ne__`,

> By default, __ne__() delegates to __eq__() and inverts the result unless it is NotImplemented. There are no other implied relationships among the comparison operators, for example, the truth of (x<y or x==y) does not imply x<=y.

It doesn't look like the behavior the test is looking for has changed in later Python versions; in 3.8,
```
class C:
    def __init__(self):
        pass
    def __ne__(self, other):
        print('A')
        return NotImplemented
    def __eq__(self, other):
        print('B')
        return True

print(C() != 3)
```
Prints
```
A
True
```