### PR TITLE
Implement codecs.surrogatepass_errors

### DIFF
--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1978,6 +1978,11 @@ namespace IronPython.Runtime.Operations {
                     ReflectionUtils.GetMethodInfos(typeof(StringOps).GetMember(nameof(SurrogateEscapeErrors), BindingFlags.Static | BindingFlags.NonPublic)),
                     typeof(StringOps));
 
+                d["surrogatepass"] = BuiltinFunction.MakeFunction(
+                    "surrogatepass_errors",
+                    ReflectionUtils.GetMethodInfos(typeof(StringOps).GetMember(nameof(SurrogatePassErrors), BindingFlags.Static | BindingFlags.NonPublic)),
+                    typeof(StringOps));
+
                 return d;
             }
         }
@@ -2784,6 +2789,102 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
+        private static object SurrogatePassErrors(object unicodeError) {
+            const byte Utf8LeadByte = 0b_1110_0000;
+            const byte Utf8LeadBytePayload = 0b_1111;
+            const byte Utf8ContByte = 0b_10_000000;
+            const byte Utf8ContBytePayload = 0b_111111;
+
+            int charWidth = 1;
+            bool isBigEndian = false;
+            if (unicodeError is PythonExceptions._UnicodeDecodeError ude) {
+                if (ude.encoding is string encodingName) {
+                    IdentifyUtfEncoding(encodingName, out charWidth, out isBigEndian);
+                }
+            } else if (unicodeError is PythonExceptions._UnicodeEncodeError uee) {
+                if (uee.encoding is string encodingName) {
+                    IdentifyUtfEncoding(encodingName, out charWidth, out isBigEndian);
+                }
+            }
+            return SurrogateErrorsImpl(unicodeError, surrogatePassDecode, surrogatePassEncode);
+
+            string surrogatePassDecode(IList<byte> bytes, int start, ref int end) {
+                end = start + (charWidth == 1 ? 3 : charWidth); // UTF-8 uses 3 bytes to encode a surrogate
+                if (end > bytes.Count) return null;
+
+                char c;
+                // decode one character only
+                if (charWidth == 1) {  // UTF-8
+                    byte b;
+                    int codepoint;
+
+                    b = bytes[start++];
+                    if ((b & ~Utf8LeadBytePayload) != Utf8LeadByte) return null;
+                    codepoint = b & Utf8LeadBytePayload;
+
+                    b = bytes[start++];
+                    if ((b & ~Utf8ContBytePayload) != Utf8ContByte) return null;
+                    codepoint = (b & Utf8ContBytePayload) | (codepoint << 6);
+
+                    b = bytes[start++];
+                    if ((b & ~Utf8ContBytePayload) != Utf8ContByte) return null;
+                    codepoint = (b & Utf8ContBytePayload) | (codepoint << 6);
+
+                    c = (char)codepoint;
+
+                } else if (isBigEndian) {
+                    if (charWidth == 4) {  // UTF-32BE
+                        if (bytes[start++] != 0) return null;
+                        if (bytes[start++] != 0) return null;
+                    }
+                    c = (char)(bytes[start++] << 8 | bytes[start++]);
+
+                } else {
+                    c = (char)(bytes[start++] | bytes[start++] << 8);
+                    if (charWidth == 4) {  // UTF-32LE
+                        if (bytes[start++] != 0) return null;
+                        if (bytes[start++] != 0) return null;
+                    }
+                }
+                Debug.Assert(start == end);
+
+                if (!char.IsSurrogate(c)) return null;
+                return new string(c, 1);
+            }
+
+            Bytes surrogatePassEncode(string text, int start, ref int end) {
+                var lst = new List<byte>((end - start) * (charWidth == 1 ? 3 : charWidth)); // UTF-8 uses 3 bytes to encode a surrogate
+
+                for (int i = start; i < end; i++) {
+                    char c = text[i];
+                    if (!char.IsSurrogate(c)) return null;
+
+                    if (charWidth == 1) { // UTF-8
+                        lst.Add((byte)(Utf8LeadByte | c >> 12));
+                        lst.Add((byte)(Utf8ContByte | ((c >> 6) & Utf8ContBytePayload)));
+                        lst.Add((byte)(Utf8ContByte | (c & Utf8ContBytePayload)));
+                    } else { // UTF-16 or UTF-32
+                        if (isBigEndian) {
+                            if (charWidth == 4) { // UTF-32
+                                lst.Add(0);
+                                lst.Add(0);
+                            }
+                            lst.Add((byte)(c >> 8));
+                            lst.Add((byte)(c & 0xFF));
+                        } else {
+                            lst.Add((byte)(c & 0xFF));
+                            lst.Add((byte)(c >> 8));
+                            if (charWidth == 4) { // UTF-32
+                                lst.Add(0);
+                                lst.Add(0);
+                            }
+                        }
+                    }
+                }
+                return new Bytes(lst);
+            }
+        }
+
         private static object SurrogateErrorsImpl(object unicodeError, DecodeErrorHandler decodeFallback, EncodeErrorHandler encodeFallback) {
             switch (unicodeError) {
                 case PythonExceptions._UnicodeDecodeError ude:
@@ -2823,6 +2924,44 @@ namespace IronPython.Runtime.Operations {
 
                 default:
                     throw PythonOps.TypeError("codec must pass exception instance");
+            }
+        }
+
+        internal static void IdentifyUtfEncoding(string encodingName, out int charWidth, out bool isBigEndian) {
+            charWidth = 1;
+            isBigEndian = false;
+            if (encodingName != null && encodingName.StartsWith("utf", StringComparison.OrdinalIgnoreCase)) {
+                int idx = 3;
+                int end = encodingName.Length;
+                if (idx < end && (encodingName[idx] == '-' || encodingName[idx] == '_')) {
+                    idx++;
+                }
+                if (idx + 1 < end) {
+                    if (encodingName[idx] == '3' && encodingName[idx + 1] == '2') {
+                        charWidth = 4;
+                        idx += 2;
+                    } else if (encodingName[idx] == '1' && encodingName[idx + 1] == '6') {
+                        charWidth = 2;
+                        idx += 2;
+                    } else {
+                        return; // UTF-8, UTF-7, or unrecognized
+                    }
+                    if (idx < end && (encodingName[idx] == '-' || encodingName[idx] == '_')) {
+                        idx++;
+                        if (idx + 2 > end) { // missing endianness suffix
+                            charWidth = 1; // fall back to single character
+                            return;
+                        }
+                    }
+                    if (idx < end) {
+                        if (encodingName.Substring(idx).Equals("be", StringComparison.OrdinalIgnoreCase)) {
+                            isBigEndian = true;
+                        } else if (!encodingName.Substring(idx).Equals("le", StringComparison.OrdinalIgnoreCase)) { // incorect suffix
+                            charWidth = 1; // fall back to single character
+                            return;
+                        }
+                    }
+                }
             }
         }
 #endif

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -560,6 +560,122 @@ class CodecTest(IronPythonTestCase):
         ude = UnicodeEncodeError('utf-16-le', "a\udcff\udcdcz", 1, 2, "one byte at a time for widechar encoding")
         self.assertEqual(surrogateescape(ude), (b"\xff", 2))
 
+    def test_error_handlers_surrogatepass(self):
+        surrogatepass = codecs.lookup_error('surrogatepass')
+
+        # Decoding with surrogatepass
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xaez', 1, 4, "encoding testing purposes")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('dummy', b'a\xed\xb7\xaez', 1, 4, "for unrecognized encoding fall back to utf-8")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16-lex', b'a\xed\xb7\xaez', 1, 4, "for misspelled encoding fall back to utf-8")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16--le', b'a\xed\xb7\xaez', 1, 4, "for misspelled encoding fall back to utf-8")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf--16-le', b'a\xed\xb7\xaez', 1, 4, "for misspelled encoding fall back to utf-8")), ("\uddee", 4))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 4, "only one surrogate at a time")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 7, "only one surrogate at a time")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 4, 7, "only one surrogate at a time")), ("\uddff", 7))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\0\xff\xdcz\0", 2, 4, "various names for UTF-16")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf16', b"a\0\xff\xdcz\0", 2, 4, "various names for UTF-16")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16-le', b"a\0\xff\xdcz\0", 2, 4, "various names for UTF-16")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf-16LE', b"a\0\xff\xdcz\0", 2, 4, "various names for UTF-16")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf_16LE', b"a\0\xff\xdcz\0", 2, 4, "various names for UTF-16s")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf_16_LE', b"a\0\xff\xdcz\0", 2, 4, "various names for UTF-16s")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf16Le', b"a\0\xff\xdcz\0", 2, 4, "various names for UTF-16")), ("\udcff", 4))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16-be', b"\0a\xdc\xff\0z", 2, 4, "various names for UTF-16BE")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf-16BE', b"\0a\xdc\xff\0z", 2, 4, "various names for UTF-16BE")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf_16BE', b"\0a\xdc\xff\0z", 2, 4, "various names for UTF-16BE")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf16Be', b"\0a\xdc\xff\0z", 2, 4, "various names for UTF-16BE")), ("\udcff", 4))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf32', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32-le', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf-32LE', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf_32LE', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf_32_LE', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf32Le', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32-be', b"\0\0\0a\0\0\xdc\xff\0\0\0z", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf-32BE', b"\0\0\0a\0\0\xdc\xff\0\0\0z", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf_32BE', b"\0\0\0a\0\0\xdc\xff\0\0\0z", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('Utf32Be', b"\0\0\0a\0\0\xdc\xff\0\0\0z", 4, 8, "various names for UTF-32")), ("\udcff", 8))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 0, "end index ignored")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 1, "end index ignored")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 2, "end index ignored")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 3, "end index ignored")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 5, "end index ignored")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, 50, "end index ignored")), ("\uddee", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-8', b'a\xed\xb7\xae\xed\xb7\xbfz', 1, -50, "end index ignored")), ("\uddee", 4))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\0\xff\xdcz\0", 2, 0, "end index ignored")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\0\xff\xdcz\0", 2, 2, "end index ignored")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\0\xff\xdcz\0", 2, 3, "end index ignored")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\0\xff\xdcz\0", 2, 5, "end index ignored")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\0\xff\xdcz\0", 2, 50, "end index ignored")), ("\udcff", 4))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\0\xff\xdcz\0", 2, -50, "end index ignored")), ("\udcff", 4))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 0, "end index ignored")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 2, "end index ignored")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, 22, "end index ignored")), ("\udcff", 8))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32', b"a\0\0\0\xff\xdc\0\0z\0\0\0", 4, -22, "end index ignored")), ("\udcff", 8))
+
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-16', b"a\xff\xdcz", 1, 0, "misaligned bytes")), ("\udcff", 3))
+        self.assertEqual(surrogatepass(UnicodeDecodeError('utf-32', b"a\xff\xdc\0\0z", 1, 0, "misaligned bytes")), ("\udcff", 5))
+
+        ude = UnicodeDecodeError('utf-8', b"abcde", 1, 4, "no surrogate present")
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            surrogatepass(ude)
+        self.assertEqual(cm.exception, ude)
+
+        ude = UnicodeDecodeError('utf-8', b'a\xed\xb7\xed\xb7\xbfz', 1, 4, "incomplete surogate")
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            surrogatepass(ude)
+        self.assertEqual(cm.exception, ude)
+
+        ude = UnicodeDecodeError('utf-8', b'a\xed\xb7', 1, 4, "incomplete surogate")
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            surrogatepass(ude)
+        self.assertEqual(cm.exception, ude)
+
+        ude = UnicodeDecodeError('utf-16', b"abcde", 2, 4, "no surrogate present")
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            surrogatepass(ude)
+        self.assertEqual(cm.exception, ude)
+
+        ude = UnicodeDecodeError('utf-32', b"abcde", 2, 4, "no surrogate present")
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            surrogatepass(ude)
+        self.assertEqual(cm.exception, ude)
+
+        # Encoding with surrogatepass
+
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-8', "a\udcff\ud880z", 1, 2, "encoding testing purposes")), (b'\xed\xb3\xbf', 2))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-8', "a\udcff\ud880z", 1, 3, "encoding testing purposes")), (b'\xed\xb3\xbf\xed\xa2\x80', 3))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-8', "a\udcff\ud880\udc81z", 1, 3, "encoding testing purposes")), (b'\xed\xb3\xbf\xed\xa2\x80', 3))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('dummy', "a\udcff\udc80z", 1, 2, "for unrecognized encoding fall back to utf-8")), (b'\xed\xb3\xbf', 2))
+
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-16', "a\udcff\ud880z", 1, 2, "encoding testing purposes")), (b'\xff\xdc', 2))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-16', "a\udcff\ud880z", 1, 3, "encoding testing purposes")), (b'\xff\xdc\x80\xd8', 3))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-16', "a\udcff\ud880\udc81z", 1, 3, "encoding testing purposes")), (b'\xff\xdc\x80\xd8', 3))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-16', "a\ud800\udc00z", 1, 3, "encoding testing purposes")), (b'\x00\xd8\x00\xdc', 3))
+
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-32', "a\udcff\ud880z", 1, 2, "encoding testing purposes")), (b'\xff\xdc\0\0', 2))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-32', "a\udcff\ud880z", 1, 3, "encoding testing purposes")), (b'\xff\xdc\0\0\x80\xd8\0\0', 3))
+        self.assertEqual(surrogatepass(UnicodeEncodeError('utf-32', "a\udcff\ud880\udc81z", 1, 3, "encoding testing purposes")), (b'\xff\xdc\0\0\x80\xd8\0\0', 3))
+
+        for encoding in ['utf-8', 'utf-16', 'utf-16-le', 'utf-16-be' 'utf-32', 'utf-32-le', 'utf-32-be']:
+            uee = UnicodeEncodeError(encoding, "abcd", 1, 3, "no surrogates to pass")
+            with self.assertRaises(UnicodeEncodeError) as cm:
+                surrogatepass(uee)
+            self.assertEqual(cm.exception, uee)
+
+            uee = UnicodeEncodeError(encoding, "a\uddddcd", 1, 3, "not all surrogates")
+            with self.assertRaises(UnicodeEncodeError) as cm:
+                surrogatepass(uee)
+            self.assertEqual(cm.exception, uee)
+
     #TODO: @skip("multiple_execute")
     def test_lookup_error(self):
         #sanity


### PR DESCRIPTION
This PR implements the `codecs.surrogatepass_errors` builtin function with the accompanying tests. It completes the implementation of `codecs.*_errors` builtins. There are still a few loose ends in those error handlers, which I will fix up in separate PRs (e.g., support for `UnicodeTranslateError`).

But a bigger issue is that there is now quite some duplicate error handling code:

* `codecs.strict_errors` and `StringOps.ExceptionFallback`
* `codecs.replace_errors` and `StringOps.ReplacementFallback`
* `codecs.ignore_errors` and `StringOps.PythonDecoderFallback`
* `codecs.xmlcharrefreplace_errors` and `StringOps.XmlCharRefEncoderReplaceFallback`
* `codecs.backslashreplace_errors` and `StringOps.BackslashEncoderReplaceFallback`
* `codecs.surrogateescape_errors` and `PythonSurrogateEscapeEncoding`
* `codecs.surrogatepass_errors` and `PythonSurrogatePassEncoding`

I intend to clean up the duplication by handling all encoding/decoding errors with the `codecs.*_errors` builtins. But before that, support for custom error handlers needs to be implemented.