### PR TITLE
Fix codecs.charmap_encode

### DIFF
--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -85,10 +85,6 @@ Reason=SystemError: The stream does not support seeking
 [AllCPython.test_cgitb]
 Ignore=true
 
-[AllCPython.test_charmapcodec]
-Ignore=true
-Reason=TypeError: charmap must be an int, str, or None
-
 [AllCPython.test_class]
 Ignore=true
 


### PR DESCRIPTION
`codecs.charmap_*` functions are heavily under-tested. Python's StdLib has only one lightweight test (which I enable here) and depends on good coverage through testing of `iso-8859` encodings, which in turn depend on the charmap functionality. In IronPython, however, those encodings are dirrectly pulled from the .NET library, rather than going through charmap. So I have added some extensive tests for `charmap_encode` in its basic form.

`charmap_decode` and `charmap_build` are still to go. 