### PR TITLE
Make IronPython.test_datetime passing on Feb 29

### DIFF
--- a/Tests/test_datetime.py
+++ b/Tests/test_datetime.py
@@ -110,7 +110,7 @@ class TestDatetime(unittest.TestCase):
         self.assertRaises(OverflowError, datetime.time().replace, microsecond=long(1000000000000))
         self.assertRaises(TypeError, datetime.time().replace, microsecond=1000.1)
 
-    def test_time_replace(self):
+    def test_date_replace(self):
         # cp35075
         d = datetime.date.today().replace(year=long(2000))
         self.assertEqual(d.year, 2000)

--- a/Tests/test_datetime.py
+++ b/Tests/test_datetime.py
@@ -112,8 +112,8 @@ class TestDatetime(unittest.TestCase):
 
     def test_time_replace(self):
         # cp35075
-        d = datetime.date.today().replace(year=long(1000))
-        self.assertEqual(d.year, 1000)
+        d = datetime.date.today().replace(year=long(2000))
+        self.assertEqual(d.year, 2000)
         self.assertRaises(ValueError, datetime.date.today().replace, year=long(10000000))
         self.assertRaises(OverflowError, datetime.date.today().replace, year=long(1000000000000))
         self.assertRaises(TypeError, datetime.date.today().replace, year=1000.1)


### PR DESCRIPTION
By no means comprehensive update to `test_datetime`. Simply to get the test passing on 2020-02-29.