### PR TITLE
Fix codecs.charmap in optimized form

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -58,20 +58,17 @@ namespace IronPython.Modules {
         #endregion
 
         #region Charmap Encoding
+#if FEATURE_ENCODING
 
         /// <summary>
         /// Creates an optimized encoding mapping that can be consumed by an optimized version of charmap_encode.
         /// </summary>
-        public static EncodingMap charmap_build(string decoding_table) {
-            if (decoding_table.Length != 256) {
-                throw PythonOps.TypeError("charmap_build expected 256 character string");
+        public static EncodingMap charmap_build([NotNull]string decoding_table) {
+            if (decoding_table.Length == 0) {
+                throw PythonOps.TypeError("charmap_build expected non-empty string");
             }
 
-            EncodingMap map = new EncodingMap();
-            for (int i = 0; i < decoding_table.Length; i++) {
-                map.Mapping[(int)decoding_table[i]] = (char)i;
-            }
-            return map;
+            return new EncodingMap(decoding_table, compile: true);
         }
 
         /// <summary>
@@ -107,10 +104,7 @@ namespace IronPython.Modules {
         /// Decodes the input string using the provided string mapping.
         /// </summary>
         public static PythonTuple charmap_decode(CodeContext context, [BytesConversion]IList<byte> input, string errors, [NotNull]string map) {
-            EncodingMap m = new EncodingMap();
-            for (int i = 0; i < map.Length; i++) {
-                m.Mapping[i] = map[i];
-            }
+            EncodingMap m = new EncodingMap(map, compile: false);
             return CharmapDecodeWorker(context, input, errors, new EncodingMapEncoding(m, errors));
         }
 
@@ -136,6 +130,7 @@ namespace IronPython.Modules {
             return PythonTuple.MakeTuple(res, input.Count);
         }
 
+#endif
         #endregion
 
         #region Generic Encoding
@@ -576,15 +571,50 @@ namespace IronPython.Modules {
         #endregion
     }
 
+#if FEATURE_ENCODING    // Encoding
+
     /// <summary>
-    /// Optimized encoding mapping that can be consumed by charmap_encode.
+    /// Optimized encoding mapping that can be consumed by charmap_encode/EncodingMapEncoding.
     /// </summary>
     [PythonHidden]
     public class EncodingMap {
-        internal Dictionary<int, char> Mapping = new Dictionary<int, char>();
-    }
+        private string _dmap;
+        private Dictionary<char, byte> _emap;
 
-#if FEATURE_ENCODING    // Encoding
+        public EncodingMap([NotNull]string stringMap, bool compile) {
+            _dmap = stringMap;
+            if (compile) CompileEncodingMap();
+        }
+
+        private void CompileEncodingMap() {
+            if (_emap == null) {
+                _emap = new Dictionary<char, byte>(Math.Min(_dmap.Length, 256));
+                for (int i = 0; i < _dmap.Length && i < 256; i++) {
+                    _emap[_dmap[i]] = unchecked((byte)i);
+                }
+            }
+        }
+
+        public bool TryGetCharValue(byte b, out char val) {
+            if (b < _dmap.Length) {
+                val = _dmap[b];
+                return true;
+            } else {
+                val = '\0';
+                return false;
+            }
+        }
+
+        public bool TryGetByteValue(char c, out byte val) {
+            CompileEncodingMap();
+            if (_emap != null) {
+                return _emap.TryGetValue(c, out val);
+            } else {
+                val = 0;
+                return false;
+            }
+        }
+    }
 
     internal class EncodingMapEncoding : Encoding {
         private readonly EncodingMap _map;
@@ -595,90 +625,77 @@ namespace IronPython.Modules {
             _errors = errors;
         }
 
-        public override int GetByteCount(char[] chars, int index, int count) {
-            int byteCount = 0;
-            int charEnd = index + count;
-            while (index < charEnd) {
-                char c = chars[index];
-
-                if (!_map.Mapping.TryGetValue(c, out _)) {
-                    EncoderFallbackBuffer efb = EncoderFallback.CreateFallbackBuffer();
-                    if (efb.Fallback(c, index)) {
-                        byteCount += efb.Remaining;
-                    }
-                } else {
-                    byteCount++;
-                }
-                index++;
-            }
-            return byteCount;
-        }
+        public override int GetByteCount(char[] chars, int index, int count)
+            => GetBytes(chars, index, count, null, 0);
 
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {
             int charEnd = charIndex + charCount;
-            int outputBytes = 0;
+            int byteStart = byteIndex;
+            EncoderFallbackBuffer efb = null;
+
             while (charIndex < charEnd) {
                 char c = chars[charIndex];
-                char val;
-
-                if (!_map.Mapping.TryGetValue((int)c, out val)) {
-                    EncoderFallbackBuffer efb = EncoderFallback.CreateFallbackBuffer();
-                    if (efb.Fallback(c, charIndex)) {
-                        while (efb.Remaining != 0) {
-                            bytes[byteIndex++] = (byte)_map.Mapping[(int)efb.GetNextChar()];
-                            outputBytes++;
+                if (!_map.TryGetByteValue(c, out byte val)) {
+                    efb ??= EncoderFallback.CreateFallbackBuffer();
+                    try {
+                        if (efb.Fallback(c, charIndex)) {
+                            while (efb.Remaining != 0) {
+                                _map.TryGetByteValue(efb.GetNextChar(), out val);
+                                if (bytes != null) {
+                                    bytes[byteIndex] = val;
+                                }
+                                byteIndex++;
+                            }
                         }
+                    } catch (EncoderFallbackException) {
+                        throw PythonOps.UnicodeEncodeError("charmap", new string(chars), charIndex, charIndex + 1, "character maps to <undefined>");
                     }
                 } else {
-                    bytes[byteIndex++] = (byte)val;
-                    outputBytes++;
+                    if (bytes != null) {
+                        bytes[byteIndex] = val;
+                    }
+                    byteIndex++;
                 }
                 charIndex++;
             }
-            return outputBytes;
+            return byteIndex - byteStart;
         }
 
-        public override int GetCharCount(byte[] bytes, int index, int count) {
-            int byteEnd = index + count;
-            int outputChars = 0;
-            while (index < byteEnd) {
-                byte b = bytes[index];
-
-                if (!_map.Mapping.TryGetValue(b, out _)) {
-                    DecoderFallbackBuffer dfb = DecoderFallback.CreateFallbackBuffer();
-                    if (dfb.Fallback(new[] { b }, 0)) {
-                        outputChars += dfb.Remaining;
-                    }
-                } else {
-                    outputChars++;
-                }
-                index++;
-            }
-            return outputChars;
-        }
+        public override int GetCharCount(byte[] bytes, int index, int count)
+            => GetChars(bytes, index, count, null, 0);
 
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) {
             int byteEnd = byteIndex + byteCount;
-            int outputChars = 0;
+            int charStart = charIndex;
+            DecoderFallbackBuffer dfb = null;
+
             while (byteIndex < byteEnd) {
                 byte b = bytes[byteIndex];
-                char val;
-
-                if (!_map.Mapping.TryGetValue(b, out val)) {
-                    DecoderFallbackBuffer dfb = DecoderFallback.CreateFallbackBuffer();
-                    if (dfb.Fallback(new[] { b }, 0)) {
-                        while (dfb.Remaining != 0) {
-                            chars[charIndex++] = (char)((int)_map.Mapping[(int)dfb.GetNextChar()]);
-                            outputChars++;
+                if (!_map.TryGetCharValue(b, out char val)) {
+                    dfb ??= DecoderFallback.CreateFallbackBuffer();
+                    byte[] bytesUnknown = new[] { b };
+                    try {
+                        if (dfb.Fallback(bytesUnknown, byteIndex)) {
+                            while (dfb.Remaining != 0) {
+                                val = dfb.GetNextChar();
+                                if (chars != null) {
+                                    chars[charIndex] = val;
+                                }
+                                charIndex++;
+                            }
                         }
+                    } catch (DecoderFallbackException) {
+                        throw PythonOps.UnicodeDecodeError("character maps to <undefined>", bytesUnknown, byteIndex);
                     }
                 } else {
-                    chars[charIndex++] = val;
-                    outputChars++;
+                    if (chars != null) {
+                        chars[charIndex] = val;
+                    }
+                    charIndex++;
                 }
                 byteIndex++;
             }
-            return outputChars;
+            return charIndex - charStart;
         }
 
         public override int GetMaxByteCount(int charCount) {
@@ -703,7 +720,8 @@ namespace IronPython.Modules {
             _errors = errors;
         }
 
-        public override int GetByteCount(char[] chars, int index, int count) => GetBytes(chars, index, count, null, 0);
+        public override int GetByteCount(char[] chars, int index, int count)
+            => GetBytes(chars, index, count, null, 0);
 
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {
             int charEnd = charIndex + charCount;

--- a/Src/Scripts/generate.py
+++ b/Src/Scripts/generate.py
@@ -254,7 +254,7 @@ class BlockReplacer:
         return res
 
 def save_file(name, text):
-    f = open(name, 'w')
+    f = open(name, 'w', encoding='latin-1')
     f.write(text)
     f.close()
 
@@ -278,7 +278,7 @@ class FileGenerator:
         self.generator = generator
         self.replacer = replacer
 
-        with open(filename) as thefile:
+        with open(filename, encoding='latin-1') as thefile:
             self.text = thefile.read()
         self.indent = self.replacer.match(self.text)
         self.has_match = self.indent is not None

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -133,6 +133,7 @@ class CodecTest(IronPythonTestCase):
     def test_charmap_decode(self):
         self.assertEqual(codecs.charmap_decode(b""), ("", 0))
         self.assertEqual(codecs.charmap_decode(b"", 'strict', {}), ("", 0))
+        self.assertEqual(codecs.charmap_decode(b"", 'strict', ""), ("", 0))
 
         # Default map is Latin-1
         self.assertEqual(codecs.charmap_decode(b"abc\xff"), ("abcÿ", 4))
@@ -165,6 +166,14 @@ class CodecTest(IronPythonTestCase):
         # using a string mapping
         self.assertEqual(codecs.charmap_decode(b'\x02\x01\x00', 'strict', "abc"), ('cba', 3))
 
+        # Full-size string mapping
+        charmap = "".join(chr(c) for c in range(255, -1, -1))
+        self.assertEqual(codecs.charmap_decode(b"ABC", 'strict', charmap), ('¾½¼', 3))
+
+        # Oversize string mapping
+        charmap = "".join(chr(c) for c in range(255, -1, -1)) + "abc"
+        self.assertEqual(codecs.charmap_decode(b"ABC", 'strict', charmap), ('¾½¼', 3))
+
         # Missing key
         self.assertRaisesRegex(UnicodeDecodeError, "^'charmap' codec can't decode byte 0x61 in position 0: character maps to <undefined>",
             codecs.charmap_decode, b"abc", 'strict', {})
@@ -193,11 +202,17 @@ class CodecTest(IronPythonTestCase):
         self.assertRaisesRegex(TypeError, r"character mapping must be in range\(0x.*\)",
             codecs.charmap_decode, b"abc", 'strict', {ord(c): ord(c) + 0x110000 for c in "abcdefgh"})
 
-        #Negative
-        self.assertRaises(UnicodeDecodeError, codecs.charmap_decode, b"a", "strict", {})
-        self.assertRaises(UnicodeDecodeError, codecs.charmap_decode, b"a", "strict", {'a': None})
+        # Wrong number type format
+        self.assertRaisesRegex(TypeError, "^character mapping must return integer, None or str",
+            codecs.charmap_decode, b"a", "strict", {ord('a'): 2.0})
 
-        self.assertRaises(TypeError, codecs.charmap_decode, b"a", "strict", {ord('a'): 2.0})
+        # Too short charmap
+        self.assertRaisesRegex(UnicodeDecodeError, "^'charmap' codec can't decode byte 0x01 in position 0: character maps to <undefined>",
+            codecs.charmap_decode, b"\x01", 'strict', "x")
+
+        # Empty charmap
+        self.assertRaisesRegex(UnicodeDecodeError, "^'charmap' codec can't decode byte 0x00 in position 0: character maps to <undefined>",
+            codecs.charmap_decode, b"\0", 'strict', "")
 
     def test_decode(self):
         #sanity
@@ -1192,6 +1207,44 @@ class CodecTest(IronPythonTestCase):
         # Values outside of bytes range
         self.assertRaisesRegex(TypeError, r"^character mapping must be in range\(256\)",
             codecs.charmap_encode, "abc", 'strict', {ord(c): ord(c) + 0x100 for c in "abcdefgh"})
+
+        # Invalid charmap_build calls
+        self.assertRaises(TypeError, codecs.charmap_build)
+        self.assertRaises(TypeError, codecs.charmap_build, None)
+        self.assertRaises(TypeError, codecs.charmap_build, 1)
+        self.assertRaises(TypeError, codecs.charmap_build, "")
+        self.assertRaises(TypeError, codecs.charmap_build, "", "")
+
+        # Using EncodingMap
+        charmap = "".join(chr(c) for c in range(255, -1, -1))
+        em = codecs.charmap_build(charmap)
+        self.assertEqual(codecs.charmap_encode("ABC", 'strict', em), (b"\xbe\xbd\xbc", 3))
+        charmap = "\0" + "".join(chr(c) for c in range(254, 0, -1)) + "\xff"
+        em = codecs.charmap_build(charmap)
+        self.assertEqual(codecs.charmap_encode("ABC", 'strict', em), (b"\xbe\xbd\xbc", 3))
+        self.assertEqual(str(type(em)), "<class 'EncodingMap'>")
+
+        # EncodingMap and error handlers
+        charmap = "".join(chr(c).lower() for c in range(0x60)) # short map, no capital letters
+        em = codecs.charmap_build(charmap)
+        self.assertEqual(codecs.charmap_encode("abcABC", 'ignore', em), (b"ABC", 6))
+
+        charmap = "".join(chr(c).lower() for c in range(0x60)) # short map, no capital letters
+        em = codecs.charmap_build(charmap)
+        self.assertEqual(codecs.charmap_encode("abcABC", 'replace', em), (b"ABC???", 6))
+        charmap = charmap.replace('?', '`').replace('!', '?')
+        em = codecs.charmap_build(charmap)
+        self.assertEqual(codecs.charmap_encode("abcABC", 'replace', em), (b"ABC!!!", 6))
+
+        charmap = "".join(chr(c).lower() for c in range(0x60)) # short map, no capital letters
+        charmap = charmap.replace('\\', '`').replace('/', '\\')
+        em = codecs.charmap_build(charmap)
+        self.assertEqual(codecs.charmap_encode("abcABC", 'backslashreplace', em), (b"ABC/X41/X42/X43", 6))
+
+        charmap = "".join(chr(c).lower() for c in range(0x60)) # short map, no capital letters
+        charmap = charmap.replace('#', '`').replace('=', '#')
+        em = codecs.charmap_build(charmap)
+        self.assertEqual(codecs.charmap_encode("abcABC", 'xmlcharrefreplace', em), (b"ABC&=65;&=66;&=67;", 6))
 
     @unittest.skipIf(is_posix, 'only UTF8 on posix - mbcs_decode/encode only exist on windows versions of python')
     def test_mbcs_decode(self):

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -35,9 +35,9 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.CP65001Test('test_readline')) # skipped
         #suite.addTest(test.test_codecs.CP65001Test('test_readlinequeue')) # cp65001 encoding is only available on Windows
         #suite.addTest(test.test_codecs.CP65001Test('test_surrogatepass_handler')) # unknown error handler name 'surrogatepass'
-        suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2int_map')) # ('\uffffbc', 3) != ('\udbff\udfffbc', 3)
-        #suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2str_map')) # ('AaBbCc', 6) != ('AaBbCc', 3)
-        #suite.addTest(test.test_codecs.CharmapTest('test_decode_with_string_map')) # ('\udbff\udfffb', 3) != ('\udbff\udfffbc', 3)
+        suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2int_map'))
+        suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2str_map'))
+        suite.addTest(test.test_codecs.CharmapTest('test_decode_with_string_map'))
         #suite.addTest(test.test_codecs.CodePageTest('test_code_page_name')) # 'module' object has no attribute 'code_page_encode'
         #suite.addTest(test.test_codecs.CodePageTest('test_cp1252')) # 'module' object has no attribute 'code_page_encode'
         #suite.addTest(test.test_codecs.CodePageTest('test_cp932')) # 'module' object has no attribute 'code_page_encode'

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -35,7 +35,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.CP65001Test('test_readline')) # skipped
         #suite.addTest(test.test_codecs.CP65001Test('test_readlinequeue')) # cp65001 encoding is only available on Windows
         #suite.addTest(test.test_codecs.CP65001Test('test_surrogatepass_handler')) # unknown error handler name 'surrogatepass'
-        #suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2int_map')) # ('\uffffbc', 3) != ('\udbff\udfffbc', 3)
+        suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2int_map')) # ('\uffffbc', 3) != ('\udbff\udfffbc', 3)
         #suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2str_map')) # ('AaBbCc', 6) != ('AaBbCc', 3)
         #suite.addTest(test.test_codecs.CharmapTest('test_decode_with_string_map')) # ('\udbff\udfffb', 3) != ('\udbff\udfffbc', 3)
         #suite.addTest(test.test_codecs.CodePageTest('test_code_page_name')) # 'module' object has no attribute 'code_page_encode'


### PR DESCRIPTION
`codecs.charmap_encode`/`decode` use a different encoding class (`EncodingMapEncoding`) when given a map in optimized form than when given a regular dictionary (`CharmapEncoding`). I have considered merging those classes, but ultimately decided to keep them separate. There are some similarities, but shared code is not that big.

Curiosity: CPython's `charmap_build` produces a regular Python dict (hence unoptimized) unless byte 0 maps to character NUL. IronPython will always produce an optimized map (`<class 'EncodingMap'>`).