### PR TITLE
Implement conversion from IBufferProtocol to IList<byte> in Binder

### DIFF
--- a/Src/IronPython/Runtime/Binding/ConversionBinder.cs
+++ b/Src/IronPython/Runtime/Binding/ConversionBinder.cs
@@ -181,6 +181,8 @@ namespace IronPython.Runtime.Binding {
                                         typeof(string)
                                     )
                                 );
+                            } else if (type.GenericTypeArguments[0] == typeof(byte) && self.Value is IBufferProtocol) {
+                                res = ConvertFromBufferProtocolToByteList(self.Restrict(self.GetLimitType()));
                             } else {
                                 res = TryToGenericInterfaceConversion(self, type, typeof(IList<object>), typeof(ListGenericWrapper<>));
                             }
@@ -720,6 +722,21 @@ namespace IronPython.Runtime.Binding {
                         AstUtils.Constant("Can't convert a Reference<> instance to a bool")
                     ),
                     ReturnType
+                ),
+                self.Restrictions
+            );
+        }
+
+        private DynamicMetaObject ConvertFromBufferProtocolToByteList(DynamicMetaObject self) {
+            return new DynamicMetaObject(
+                AstUtils.Convert(
+                    Ast.Call(
+                        AstUtils.Convert(self.Expression, typeof(IBufferProtocol)),
+                        typeof(IBufferProtocol).GetMethod(nameof(IBufferProtocol.ToBytes)),
+                        AstUtils.Constant(0, typeof(int)),
+                        AstUtils.Constant(null, typeof(Nullable<int>))
+                    ),
+                    typeof(IList<byte>)
                 ),
                 self.Restrictions
             );

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -87,10 +87,10 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_escape_encode'))
         suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_raw_decode'))
         suite.addTest(test.test_codecs.RawUnicodeEscapeTest('test_raw_encode'))
-        #suite.addTest(test.test_codecs.ReadBufferTest('test_array')) # TypeError: Specified cast is not valid
+        suite.addTest(test.test_codecs.ReadBufferTest('test_array'))
         suite.addTest(test.test_codecs.ReadBufferTest('test_bad_args'))
         suite.addTest(test.test_codecs.ReadBufferTest('test_empty'))
-        #suite.addTest(test.test_codecs.RecodingTest('test_recoding')) # expected IList[Byte], got str
+        suite.addTest(test.test_codecs.RecodingTest('test_recoding'))
         suite.addTest(test.test_codecs.StreamReaderTest('test_readlines'))
         suite.addTest(test.test_codecs.SurrogateEscapeTest('test_ascii'))
         #suite.addTest(test.test_codecs.SurrogateEscapeTest('test_charmap')) # .NET iso-8859-3 decodes b'\xa5' to 'uf7f5' rather than undefined


### PR DESCRIPTION
This PR originated from a failing `codecs` test. It turns out that all codec functions accept a 'b' type `array` just as well as `Bytes`. At first I thought of adding another overload accepting `IBufferProtocol` objects, but it turns out that `[BytestConversion]IList<byte>` will catch `array` as well. However, it does not go through `IBufferProtocol`, instead what is happening is that the binder sees that `array` implements `IList<object>` and wraps it in `ListGenericWrapper<byte>`, hoping for the best. 

But it does not work. `ListGenericWrapper<byte>`, on access or on copy (which is triggered by `ToArray()` in the first line of `StringOps.DoDecode`) accesses each element as object and unboxes to `byte`. But the `array`, even for type 'B', when accessed thought `IList<object>`, boxes its elements to `int` for some reason. Even if I changed that and made `array` box a `byte`, this still would not be good enough: the conversion will fail for other array types, like `sbyte` or `float`, and in CPython all objects work as long as they support the buffer protocol:

```python
>>> codecs.latin_1_decode(array.array('f', [12345.67]))
('®æ@F', 4)
```

So it is clear that wrapping in `ListGenericWrapper<byte>` is not a way to do it. In the end I went aheand modyfing the Binder logic to do the conversion on the fly in the expression tree. This seems to do the right thing, does it?

Questions/issues:

 1. Is `BytesConversionAttribute` really needed? I do not see it being checked/used anywhere by the Binder.

 2. Wouldn't it be better to wrap `IBufferProtocol` objects on binding and serialize to a memory stream only on access? This would delay the serialization to when the object is actually accessed, rather than having it done already in the binding expression tree.

 3. Use a dedicated attribute to enable this functionality, e.g. `BufferProtocolAttribute`? In this way, `BytesConversion` will be used only for `Bytes` and `ByteArray`, and `MemoryView`. On the other hand, I haven't found a case when `BytesConversion` would apply but `BufferProtocol` conversion not. In all cases I tried, where IronPython uses `BytesConversion` on parameters, CPython does accept an arbitrary `array` as well:

```python
 >>> b"spam".startswith(array.array('b', [ord('s'), ord('p')]))
True
```

 4. Is the binding constraint right? It is supposed to constraint the binging to the argument that match the type exactly (I assume that `LimitType` means specialized type for generics). Ideally, the constraint would be more relaxed, matching any type that implements interface `IBufferProtocol` but I coudn't figure out how to define such constraint. Maybe constraining on the exact type match is more efficient in the average case.
 
 5. Even with this change, things are not quite right. CPython will accept `memoryview` in all those instances, but IronPython not. Shouldn't `MemoryView` implement `IBufferProtocol`? (Or at least `IList<byte>`).

 6.  A side issue but caught my eye: `ConversionBinder.cs`, line 173, "blindly" converts a string to `Bytes`. This is error prone (only Latin 1 characters succeed) and it seems to me it is not a way to do it in Python 3, where all `str` to `bytes` conversions are explicit. See NewTypeMaker.cs, line 413: "`[BytesConversionAttribute]` to make enable automatic cast between .net IList<byte> and string." Really?