### PR TITLE
Remove automatic conversion from string to ByteArray in Binder

### DIFF
--- a/Src/IronPython/Runtime/Binding/ConversionBinder.cs
+++ b/Src/IronPython/Runtime/Binding/ConversionBinder.cs
@@ -170,20 +170,7 @@ namespace IronPython.Runtime.Binding {
 
                         // Interface conversion helpers...
                         if (genTo == typeof(IList<>)) {
-                            if (self.LimitType == typeof(string)) {
-                                res = new DynamicMetaObject(
-                                    Ast.Call(
-                                        typeof(PythonOps).GetMethod(nameof(PythonOps.MakeByteArray)),
-                                        AstUtils.Convert(self.Expression, typeof(string))
-                                    ),
-                                    BindingRestrictions.GetTypeRestriction(
-                                        self.Expression,
-                                        typeof(string)
-                                    )
-                                );
-                            } else {
-                                res = TryToGenericInterfaceConversion(self, type, typeof(IList<object>), typeof(ListGenericWrapper<>));
-                            }
+                            res = TryToGenericInterfaceConversion(self, type, typeof(IList<object>), typeof(ListGenericWrapper<>));
                         } else if (genTo == typeof(IDictionary<,>)) {
                             res = TryToGenericInterfaceConversion(self, type, typeof(IDictionary<object, object>), typeof(DictionaryGenericWrapper<,>));
                         } else if (genTo == typeof(IEnumerable<>)) {


### PR DESCRIPTION
As discussed in #762, point 6.