### PR TITLE
Unsafe encoding

### DIFF
--- a/IronPythonAnalyzer/IronPythonAnalyzer/IronPythonAnalyzerAnalyzer.cs
+++ b/IronPythonAnalyzer/IronPythonAnalyzer/IronPythonAnalyzerAnalyzer.cs
@@ -8,11 +8,9 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace IronPythonAnalyzer
-{
+namespace IronPythonAnalyzer {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class IronPythonAnalyzerAnalyzer : DiagnosticAnalyzer
-    {
+    public class IronPythonAnalyzerAnalyzer : DiagnosticAnalyzer {
         public const string DiagnosticId = "IronPythonAnalyzer";
 
         private static readonly DiagnosticDescriptor Rule1 = new DiagnosticDescriptor("IPY01", title: "Parameter which is marked not nullable does not have the NotNullAttribute", messageFormat: "Parameter '{0}' does not have the NotNullAttribute", category: "Usage", DiagnosticSeverity.Warning, isEnabledByDefault: true, description: "Non-nullable reference type parameters should have the NotNullAttribute.");
@@ -20,41 +18,53 @@ namespace IronPythonAnalyzer
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule1, Rule2); } }
 
-        public override void Initialize(AnalysisContext context)
-        {
+        public override void Initialize(AnalysisContext context) {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Method);
         }
 
-        private static void AnalyzeSymbol(SymbolAnalysisContext context)
-        {
+        private static void AnalyzeSymbol(SymbolAnalysisContext context) {
             var methodSymbol = (IMethodSymbol)context.Symbol;
             if (methodSymbol.DeclaredAccessibility != Accessibility.Public) return;
-            if (!methodSymbol.ContainingType.GetAttributes().Any(x => x.AttributeClass.Name == "PythonTypeAttribute")) return;
-            if (methodSymbol.GetAttributes().Any(x => x.AttributeClass.Name == "PythonHiddenAttribute")) return;
 
-            foreach (IParameterSymbol parameterSymbol in methodSymbol.Parameters)
-            {
-                if (parameterSymbol.Type.IsValueType) continue;
-                if (parameterSymbol.Type.Name == "CodeContext" && parameterSymbol.ContainingAssembly.Name == "IronPython") continue;
-                if (parameterSymbol.NullableAnnotation == NullableAnnotation.NotAnnotated)
-                {
-                    if (!parameterSymbol.GetAttributes().Any(x => x.AttributeClass.Name == "NotNullAttribute" && x.AttributeClass.ContainingAssembly.Name == "Microsoft.Scripting"))
-                    {
-                        var diagnostic = Diagnostic.Create(Rule1, parameterSymbol.Locations[0], parameterSymbol.Name);
-                        context.ReportDiagnostic(diagnostic);
-                    }
-                }
-                else if (parameterSymbol.NullableAnnotation == NullableAnnotation.Annotated)
-                {
-                    if (parameterSymbol.GetAttributes().Any(x => x.AttributeClass.Name == "NotNullAttribute" && x.AttributeClass.ContainingAssembly.Name == "Microsoft.Scripting"))
-                    {
-                        var diagnostic = Diagnostic.Create(Rule2, parameterSymbol.Locations[0], parameterSymbol.Name);
-                        context.ReportDiagnostic(diagnostic);
+            var pythonTypeAttributeSymbol = context.Compilation.GetTypeByMetadataName("IronPython.Runtime.PythonTypeAttribute");
+            var pythonModuleAttributeSymbol = context.Compilation.GetTypeByMetadataName("IronPython.Runtime.PythonModuleAttribute");
+
+#pragma warning disable RS1024 // Compare symbols correctly
+
+            if (methodSymbol.ContainingType.GetAttributes()
+                    .Any(x => x.AttributeClass.Equals(pythonTypeAttributeSymbol)) ||
+                methodSymbol.ContainingAssembly.GetAttributes()
+                    .Where(x => x.AttributeClass.Equals(pythonModuleAttributeSymbol))
+                    .Select(x => (INamedTypeSymbol)x.ConstructorArguments[1].Value)
+                    .Any(x => x.Equals(methodSymbol.ContainingType))) {
+                var pythonHiddenAttributeSymbol = context.Compilation.GetTypeByMetadataName("IronPython.Runtime.PythonHiddenAttribute");
+                if (methodSymbol.GetAttributes().Any(x => x.AttributeClass.Equals(pythonHiddenAttributeSymbol))) return;
+
+                var codeContextSymbol = context.Compilation.GetTypeByMetadataName("IronPython.Runtime.CodeContext");
+                var notNullAttributeSymbol = context.Compilation.GetTypeByMetadataName("Microsoft.Scripting.Runtime.NotNullAttribute");
+                var disallowNullAttributeSymbol = context.Compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.DisallowNullAttribute");
+                foreach (IParameterSymbol parameterSymbol in methodSymbol.Parameters) {
+                    if (parameterSymbol.Type.IsValueType) continue;
+                    if (parameterSymbol.Type.Equals(codeContextSymbol)) continue;
+                    if (parameterSymbol.NullableAnnotation == NullableAnnotation.NotAnnotated) {
+                        if (!parameterSymbol.GetAttributes().Any(x => x.AttributeClass.Equals(notNullAttributeSymbol))) {
+                            var diagnostic = Diagnostic.Create(Rule1, parameterSymbol.Locations[0], parameterSymbol.Name);
+                            context.ReportDiagnostic(diagnostic);
+                        }
+                    } else if (parameterSymbol.NullableAnnotation == NullableAnnotation.Annotated) {
+                        if (parameterSymbol.GetAttributes().Any(x => x.AttributeClass.Equals(notNullAttributeSymbol))
+                            && !parameterSymbol.GetAttributes().Any(x => x.AttributeClass.Equals(disallowNullAttributeSymbol))) {
+                            var diagnostic = Diagnostic.Create(Rule2, parameterSymbol.Locations[0], parameterSymbol.Name);
+                            context.ReportDiagnostic(diagnostic);
+                        }
                     }
                 }
             }
+
+#pragma warning restore RS1024 // Compare symbols correctly
+
         }
     }
 }

--- a/Src/IronPython.Modules/IronPython.Modules.csproj
+++ b/Src/IronPython.Modules/IronPython.Modules.csproj
@@ -33,6 +33,13 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+    <ProjectReference Include="..\..\IronPythonAnalyzer\IronPythonAnalyzer\IronPythonAnalyzer.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -54,8 +54,8 @@ namespace IronPython.Modules {
 
         #region ASCII Encoding
 
-        public static PythonTuple ascii_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null)
-            => DoDecode(context, "ascii", PythonAsciiEncoding.Instance, input, errors, input.Count).ToPythonTuple();
+        public static PythonTuple ascii_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null)
+            => DoDecode(context, "ascii", PythonAsciiEncoding.Instance, input, errors, input.Length).ToPythonTuple();
 
         public static PythonTuple ascii_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "ascii", PythonAsciiEncoding.Instance, input, errors).ToPythonTuple();
@@ -94,14 +94,14 @@ namespace IronPython.Modules {
         /// <summary>
         /// Decodes the input string using the provided string mapping.
         /// </summary>
-        public static PythonTuple charmap_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors, [NotNull]string map) {
+        public static PythonTuple charmap_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors, [NotNull]string map) {
             EncodingMap em = new EncodingMap(map, compileForDecoding: true, compileForEncoding: false);
-            return DoDecode(context, "charmap", new EncodingMapEncoding(em), input, errors, input.Count).ToPythonTuple();
+            return DoDecode(context, "charmap", new EncodingMapEncoding(em), input, errors, input.Length).ToPythonTuple();
         }
 
-        public static PythonTuple charmap_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, IDictionary<object, object>? map = null) {
+        public static PythonTuple charmap_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, IDictionary<object, object>? map = null) {
             if (map != null) {
-                return DoDecode(context, "charmap", new CharmapEncoding(map), input, errors, input.Count).ToPythonTuple();
+                return DoDecode(context, "charmap", new CharmapEncoding(map), input, errors, input.Length).ToPythonTuple();
             } else {
                 return latin_1_decode(context, input, errors);
             }
@@ -114,10 +114,11 @@ namespace IronPython.Modules {
 
         public static object decode(CodeContext/*!*/ context, object? obj, [NotNull, DisallowNull]string? encoding = null, [NotNull]string errors = "strict") {
             if (encoding == null) {
-                if (obj is IList<byte> bytesLikeObj) { // TODO: replace IList with IBufferProtocol
-                    var span = bytesLikeObj.ToArray().AsSpan(); // TODO: use IBufferProtocol.ToSpan
-                    PythonContext lc = context.LanguageContext;
-                    return StringOps.DoDecode(context, span, errors, lc.GetDefaultEncodingName(), lc.DefaultEncoding);
+                PythonContext lc = context.LanguageContext;
+                if (obj is ReadOnlyMemory<byte> bytesLikeObj) {
+                    return StringOps.DoDecode(context, bytesLikeObj, errors, lc.GetDefaultEncodingName(), lc.DefaultEncoding);
+                } else if (obj is IBufferProtocol bp) {
+                    return StringOps.DoDecode(context, bp.ToMemory(), errors, lc.GetDefaultEncodingName(), lc.DefaultEncoding);
                 } else {
                     throw PythonOps.TypeError("expected bytes-like object, got {0}", PythonTypeOps.GetName(obj));
                 }
@@ -152,13 +153,12 @@ namespace IronPython.Modules {
         #region Escape Encoding
 
         public static PythonTuple escape_decode(CodeContext/*!*/ context, [NotNull]string data, string? errors = null)
-            => escape_decode(StringOps.DoEncodeUtf8(context, data), errors);
+            => escape_decode(StringOps.DoEncodeUtf8(context, data).AsMemory(), errors);
 
-        public static PythonTuple escape_decode([BytesLike,NotNull]IList<byte> data, string? errors = null) {
-            var span = data.ToArray().AsSpan(); // TODO: remove when signature changed
-            var res = LiteralParser.ParseBytes(span, isRaw: false, normalizeLineEndings: false, getErrorHandler(errors));
+        public static PythonTuple escape_decode([BytesLike,NotNull]ReadOnlyMemory<byte> data, string? errors = null) {
+            var res = LiteralParser.ParseBytes(data.Span, isRaw: false, normalizeLineEndings: false, getErrorHandler(errors));
 
-            return PythonTuple.MakeTuple(Bytes.Make(res.ToArray()), data.Count);
+            return PythonTuple.MakeTuple(Bytes.Make(res.ToArray()), data.Length);
 
             static LiteralParser.ParseBytesErrorHandler<byte>? getErrorHandler(string? errors) {
                 if (errors == null) return default;
@@ -180,9 +180,11 @@ namespace IronPython.Modules {
         [DisallowNull]
         private static byte[]? _replacementMarker;
 
-        public static PythonTuple/*!*/ escape_encode([BytesLike,NotNull]IList<byte> data, string? errors = null) {
-            List<byte> buf = new List<byte>(data.Count);
-            foreach (byte b in data) {
+        public static PythonTuple/*!*/ escape_encode([BytesLike,NotNull]ReadOnlyMemory<byte> data, string? errors = null) {
+            var buf = new List<byte>(data.Length);
+            var span = data.Span;
+            for (int i = 0; i < span.Length; i++) {
+                byte b = span[i];
                 switch (b) {
                     case (byte)'\n': buf.Add((byte)'\\'); buf.Add((byte)'n'); break;
                     case (byte)'\r': buf.Add((byte)'\\'); buf.Add((byte)'r'); break;
@@ -198,15 +200,15 @@ namespace IronPython.Modules {
                         break;
                 }
             }
-            return PythonTuple.MakeTuple(Bytes.Make(buf.ToArray()), data.Count);
+            return PythonTuple.MakeTuple(Bytes.Make(buf.ToArray()), data.Length);
         }
 
         #endregion
 
         #region Latin-1 Functions
 
-        public static PythonTuple latin_1_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null)
-            => DoDecode(context, "latin-1", Encoding.GetEncoding("iso-8859-1"), input, errors, input.Count).ToPythonTuple();
+        public static PythonTuple latin_1_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null)
+            => DoDecode(context, "latin-1", Encoding.GetEncoding("iso-8859-1"), input, errors, input.Length).ToPythonTuple();
 
         public static PythonTuple latin_1_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "latin-1", Encoding.GetEncoding("iso-8859-1"), input, errors).ToPythonTuple();
@@ -217,8 +219,8 @@ namespace IronPython.Modules {
 #if FEATURE_ENCODING
 
         [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
-        public static PythonTuple mbcs_decode(CodeContext/*!*/ context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false)
-            => DoDecode(context, "mbcs", MbcsEncoding, input, errors, input.Count).ToPythonTuple();
+        public static PythonTuple mbcs_decode(CodeContext/*!*/ context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false)
+            => DoDecode(context, "mbcs", MbcsEncoding, input, errors, input.Length).ToPythonTuple();
 
         [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static PythonTuple mbcs_encode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null)
@@ -231,11 +233,11 @@ namespace IronPython.Modules {
 #if FEATURE_ENCODING
 
         [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
-        public static PythonTuple code_page_decode(CodeContext context, int codepage, [BytesLike, NotNull]IList<byte> input, string? errors = null, bool final = false) {
+        public static PythonTuple code_page_decode(CodeContext context, int codepage, [BytesLike, NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false) {
             // TODO: Use Win32 API MultiByteToWideChar https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
             string encodingName = $"cp{codepage}";
             Encoding encoding = Encoding.GetEncoding(codepage);
-            return DoDecode(context, encodingName, encoding, input, errors, input.Count).ToPythonTuple();
+            return DoDecode(context, encodingName, encoding, input, errors, input.Length).ToPythonTuple();
         }
 
         [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
@@ -255,14 +257,13 @@ namespace IronPython.Modules {
         public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {
             // Encoding with UTF-8 is probably a bug or at least a mistake, as it mutilates non-ASCII characters,
             // but this is what CPython does. Probably encoding with "raw-unicode-escape" would be more reasonable.
-            return raw_unicode_escape_decode(context, StringOps.DoEncodeUtf8(context, input), errors);
+            return raw_unicode_escape_decode(context, StringOps.DoEncodeUtf8(context, input).AsMemory(), errors);
         }
 
-        public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [BytesLike,NotNull]IList<byte> input, string? errors = null) {
-            var span = input.ToArray().AsSpan(); // TODO: remove when signature changed
+        public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null) {
             return PythonTuple.MakeTuple(
-                StringOps.DoDecode(context, span, errors, "raw-unicode-escape", StringOps.CodecsInfo.RawUnicodeEscapeEncoding),
-                input.Count
+                StringOps.DoDecode(context, input, errors, "raw-unicode-escape", StringOps.CodecsInfo.RawUnicodeEscapeEncoding),
+                input.Length
             );
         }
 
@@ -282,14 +283,13 @@ namespace IronPython.Modules {
         public static PythonTuple unicode_escape_decode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {
             // Encoding with UTF-8 is probably a bug or at least a mistake, as it mutilates non-ASCII characters,
             // but this is what CPython does. Probably encoding with "unicode-escape" would be more reasonable.
-            return unicode_escape_decode(context, StringOps.DoEncodeUtf8(context, input), errors);
+            return unicode_escape_decode(context, StringOps.DoEncodeUtf8(context, input).AsMemory(), errors);
         }
 
-        public static PythonTuple unicode_escape_decode(CodeContext/*!*/ context, [BytesLike,NotNull]IList<byte> input, string? errors = null) {
-            var span = input.ToArray().AsSpan(); // TODO: remove when signature changed
+        public static PythonTuple unicode_escape_decode(CodeContext/*!*/ context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null) {
             return PythonTuple.MakeTuple(
-                StringOps.DoDecode(context, span, errors, "unicode-escape", StringOps.CodecsInfo.UnicodeEscapeEncoding),
-                input.Count
+                StringOps.DoDecode(context, input, errors, "unicode-escape", StringOps.CodecsInfo.UnicodeEscapeEncoding),
+                input.Length
             );
         }
 
@@ -306,10 +306,10 @@ namespace IronPython.Modules {
         #region Readbuffer Functions
 
         public static PythonTuple readbuffer_encode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null)
-            => readbuffer_encode(DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").Item1, errors);
+            => DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").ToPythonTuple();
 
-        public static PythonTuple readbuffer_encode([BytesLike,NotNull]IList<byte> input, string? errors = null)
-            => PythonTuple.MakeTuple(new Bytes(input), input.Count);
+        public static PythonTuple readbuffer_encode([BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null)
+            => PythonTuple.MakeTuple(new Bytes(input), input.Length);
 
         #endregion
 
@@ -320,9 +320,9 @@ namespace IronPython.Modules {
             return PythonTuple.MakeTuple(input, input.Length);
         }
 
-        public static PythonTuple unicode_internal_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null) {
+        public static PythonTuple unicode_internal_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null) {
             PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "unicode_internal codec has been deprecated");
-            return DoDecode(context, "unicode-internal", Encoding.Unicode, input, errors, input.Count).ToPythonTuple();
+            return DoDecode(context, "unicode-internal", Encoding.Unicode, input, errors, input.Length).ToPythonTuple();
         }
 
         public static PythonTuple unicode_internal_encode(CodeContext context, [NotNull]string input, string? errors = null) {
@@ -330,16 +330,16 @@ namespace IronPython.Modules {
             return DoEncode(context, "unicode-internal", Encoding.Unicode, input, errors, false).ToPythonTuple();
         }
 
-        public static PythonTuple unicode_internal_encode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null) {
+        public static PythonTuple unicode_internal_encode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null) {
             PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "unicode_internal codec has been deprecated");
-            return PythonTuple.MakeTuple(new Bytes(input), input.Count);
+            return PythonTuple.MakeTuple(new Bytes(input), input.Length);
         }
 
         #endregion
 
         #region Utf-16 Functions
 
-        public static PythonTuple utf_16_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false) {
+        public static PythonTuple utf_16_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false) {
             PythonTuple res = utf_16_ex_decode(context, input, errors, 0, final);
             return PythonTuple.MakeTuple(res[0], res[1]);
         }
@@ -347,35 +347,36 @@ namespace IronPython.Modules {
         public static PythonTuple utf_16_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-16", Utf16LeBomEncoding, input, errors, true).ToPythonTuple();
 
-        public static PythonTuple utf_16_ex_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, int byteorder = 0, bool final = false) {
+        public static PythonTuple utf_16_ex_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, int byteorder = 0, bool final = false) {
 
+            var span = input.Span;
             Tuple<string, int> res;
 
             if (byteorder != 0) {
                 res = (byteorder > 0) ?
-                    DoDecode(context, "utf-16-be", Utf16BeEncoding, input, errors, NumEligibleUtf16Bytes(input, final, false))
+                    DoDecode(context, "utf-16-be", Utf16BeEncoding, input, errors, NumEligibleUtf16Bytes(span, final, false))
                 :
-                    DoDecode(context, "utf-16-le", Utf16LeEncoding, input, errors, NumEligibleUtf16Bytes(input, final, true));
+                    DoDecode(context, "utf-16-le", Utf16LeEncoding, input, errors, NumEligibleUtf16Bytes(span, final, true));
 
             } else {
-                byteorder = Utf16DetectByteorder(input);
+                byteorder = Utf16DetectByteorder(span);
                 res = (byteorder > 0) ?
-                    DoDecode(context, "utf-16-be", Utf16BeBomEncoding, input, errors, NumEligibleUtf16Bytes(input, final, false))
+                    DoDecode(context, "utf-16-be", Utf16BeBomEncoding, input, errors, NumEligibleUtf16Bytes(span, final, false))
                 :
-                    DoDecode(context, "utf-16-le", Utf16LeBomEncoding, input, errors, NumEligibleUtf16Bytes(input, final, true));
+                    DoDecode(context, "utf-16-le", Utf16LeBomEncoding, input, errors, NumEligibleUtf16Bytes(span, final, true));
             }
 
             return PythonTuple.MakeTuple(res.Item1, res.Item2, byteorder);
         }
 
-        private static int Utf16DetectByteorder(IList<byte> input) {
+        private static int Utf16DetectByteorder(ReadOnlySpan<byte> input) {
             if (input.StartsWith(BOM_UTF16_LE)) return -1;
             if (input.StartsWith(BOM_UTF16_BE)) return 1;
             return 0;
         }
 
-        private static int NumEligibleUtf16Bytes(IList<byte> input, bool final, bool isLE) {
-            int numBytes = input.Count;
+        private static int NumEligibleUtf16Bytes(ReadOnlySpan<byte> input, bool final, bool isLE) {
+            int numBytes = input.Length;
             if (!final) {
                 numBytes -= numBytes % 2;
                 if (numBytes >= 2 && (input[numBytes - (isLE ? 1 : 2)] & 0xFC) == 0xD8) { // high surrogate
@@ -397,8 +398,8 @@ namespace IronPython.Modules {
         private static byte[] BOM_UTF16_LE => _bom_utf16_le ??= Utf16LeBomEncoding.GetPreamble();
         [DisallowNull] private static byte[]? _bom_utf16_le;
 
-        public static PythonTuple utf_16_le_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false)
-            => DoDecode(context, "utf-16-le", Utf16LeEncoding, input, errors, NumEligibleUtf16Bytes(input, final, isLE: true)).ToPythonTuple();
+        public static PythonTuple utf_16_le_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false)
+            => DoDecode(context, "utf-16-le", Utf16LeEncoding, input, errors, NumEligibleUtf16Bytes(input.Span, final, isLE: true)).ToPythonTuple();
 
         public static PythonTuple utf_16_le_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-16-le", Utf16LeEncoding, input, errors).ToPythonTuple();
@@ -415,8 +416,8 @@ namespace IronPython.Modules {
         private static byte[] BOM_UTF16_BE => _bom_utf16_be ??= Utf16BeBomEncoding.GetPreamble();
         [DisallowNull] private static byte[]? _bom_utf16_be;
 
-        public static PythonTuple utf_16_be_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false)
-            => DoDecode(context, "utf-16-be", Utf16BeEncoding, input, errors, NumEligibleUtf16Bytes(input, final, isLE: false)).ToPythonTuple();
+        public static PythonTuple utf_16_be_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false)
+            => DoDecode(context, "utf-16-be", Utf16BeEncoding, input, errors, NumEligibleUtf16Bytes(input.Span, final, isLE: false)).ToPythonTuple();
 
         public static PythonTuple utf_16_be_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-16-be", Utf16BeEncoding, input, errors).ToPythonTuple();
@@ -427,14 +428,14 @@ namespace IronPython.Modules {
 
 #if FEATURE_ENCODING
 
-        public static PythonTuple utf_7_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false)
-            => DoDecode(context, "utf-7", Encoding.UTF7, input, errors, NumEligibleUtf7Bytes(input, final)).ToPythonTuple();
+        public static PythonTuple utf_7_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false)
+            => DoDecode(context, "utf-7", Encoding.UTF7, input, errors, NumEligibleUtf7Bytes(input.Span, final)).ToPythonTuple();
 
         public static PythonTuple utf_7_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-7", Encoding.UTF7, input, errors).ToPythonTuple();
 
-        private static int NumEligibleUtf7Bytes(IList<byte> input, bool final) {
-            int numBytes = input.Count;
+        private static int NumEligibleUtf7Bytes(ReadOnlySpan<byte> input, bool final) {
+            int numBytes = input.Length;
             if (!final) {
                 int blockStart = -1;
                 for (int i = 0; i < numBytes; i++) {
@@ -459,14 +460,14 @@ namespace IronPython.Modules {
         private static Encoding Utf8Encoding => _utf8Encoding ??= new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         [DisallowNull] private static Encoding? _utf8Encoding;
 
-        public static PythonTuple utf_8_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false)
-            => DoDecode(context, "utf-8", Utf8Encoding, input, errors, NumEligibleUtf8Bytes(input, final)).ToPythonTuple();
+        public static PythonTuple utf_8_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false)
+            => DoDecode(context, "utf-8", Utf8Encoding, input, errors, NumEligibleUtf8Bytes(input.Span, final)).ToPythonTuple();
 
         public static PythonTuple utf_8_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-8", Encoding.UTF8, input, errors).ToPythonTuple();
 
-        private static int NumEligibleUtf8Bytes(IList<byte> input, bool final) {
-            int numBytes = input.Count;
+        private static int NumEligibleUtf8Bytes(ReadOnlySpan<byte> input, bool final) {
+            int numBytes = input.Length;
             if (!final) {
                 // scan for incomplete but valid sequence at the end
                 for (int i = 1; i < 4; i++) { // 4 is the max length of a valid sequence
@@ -496,7 +497,7 @@ namespace IronPython.Modules {
 
         #region Utf-32 Functions
 
-        public static PythonTuple utf_32_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false) {
+        public static PythonTuple utf_32_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false) {
             PythonTuple res = utf_32_ex_decode(context, input, errors, 0, final);
             return PythonTuple.MakeTuple(res[0], res[1]);
         }
@@ -504,9 +505,9 @@ namespace IronPython.Modules {
         public static PythonTuple utf_32_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-32", Utf32LeBomEncoding, input, errors, includePreamble: true).ToPythonTuple();
 
-        public static PythonTuple utf_32_ex_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, int byteorder = 0, bool final = false) {
+        public static PythonTuple utf_32_ex_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, int byteorder = 0, bool final = false) {
 
-            int numBytes = NumEligibleUtf32Bytes(input, final);
+            int numBytes = NumEligibleUtf32Bytes(input.Span, final);
             Tuple<string, int> res;
 
             if (byteorder != 0) {
@@ -516,7 +517,7 @@ namespace IronPython.Modules {
                     DoDecode(context, "utf-32-le", Utf32LeEncoding, input, errors, numBytes);
 
             } else {
-                byteorder = Utf32DetectByteorder(input);
+                byteorder = Utf32DetectByteorder(input.Span);
                 res = (byteorder > 0) ?
                     DoDecode(context, "utf-32-be", Utf32BeBomEncoding, input, errors, numBytes)
                 :
@@ -526,14 +527,14 @@ namespace IronPython.Modules {
             return PythonTuple.MakeTuple(res.Item1, res.Item2, byteorder);
         }
 
-        private static int Utf32DetectByteorder(IList<byte> input) {
+        private static int Utf32DetectByteorder(ReadOnlySpan<byte> input) {
             if (input.StartsWith(BOM_UTF32_LE)) return -1;
             if (input.StartsWith(BOM_UTF32_BE)) return 1;
             return 0;
         }
 
-        private static int NumEligibleUtf32Bytes(IList<byte> input, bool final) {
-            int numBytes = input.Count;
+        private static int NumEligibleUtf32Bytes(ReadOnlySpan<byte> input, bool final) {
+            int numBytes = input.Length;
             if (!final) numBytes -= numBytes % 4;
             return numBytes;
         }
@@ -550,8 +551,8 @@ namespace IronPython.Modules {
         private static byte[] BOM_UTF32_LE => _bom_utf32_le ??= Utf32LeBomEncoding.GetPreamble();
         [DisallowNull] private static byte[]? _bom_utf32_le;
 
-        public static PythonTuple utf_32_le_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false)
-            => DoDecode(context, "utf-32-le", Utf32LeEncoding, input, errors, NumEligibleUtf32Bytes(input, final)).ToPythonTuple();
+        public static PythonTuple utf_32_le_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false)
+            => DoDecode(context, "utf-32-le", Utf32LeEncoding, input, errors, NumEligibleUtf32Bytes(input.Span, final)).ToPythonTuple();
 
         public static PythonTuple utf_32_le_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-32-le", Utf32LeEncoding, input, errors).ToPythonTuple();
@@ -569,8 +570,8 @@ namespace IronPython.Modules {
         private static byte[] BOM_UTF32_BE => _bom_utf32_be ??= Utf32BeBomEncoding.GetPreamble();
         [DisallowNull] private static byte[]? _bom_utf32_be;
 
-        public static PythonTuple utf_32_be_decode(CodeContext context, [BytesLike,NotNull]IList<byte> input, string? errors = null, bool final = false)
-            => DoDecode(context, "utf-32-be", Utf32BeEncoding, input, errors, NumEligibleUtf32Bytes(input, final)).ToPythonTuple();
+        public static PythonTuple utf_32_be_decode(CodeContext context, [BytesLike,NotNull]ReadOnlyMemory<byte> input, string? errors = null, bool final = false)
+            => DoDecode(context, "utf-32-be", Utf32BeEncoding, input, errors, NumEligibleUtf32Bytes(input.Span, final)).ToPythonTuple();
 
         public static PythonTuple utf_32_be_encode(CodeContext context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "utf-32-be", Utf32BeEncoding, input, errors).ToPythonTuple();
@@ -581,10 +582,12 @@ namespace IronPython.Modules {
 
         #region Private implementation
 
-        private static Tuple<string, int> DoDecode(CodeContext context, string encodingName, Encoding encoding, [BytesLike]IList<byte> input, string? errors, int numBytes) {
-            ReadOnlySpan<byte> data = input.ToArray().AsSpan(0, numBytes); // TODO: remove when signature changed
-            var decoded = StringOps.DoDecode(context, data, errors, encodingName, encoding);
-            return Tuple.Create(decoded, data.Length);
+        private static Tuple<string, int> DoDecode(CodeContext context, string encodingName, Encoding encoding, [BytesLike]ReadOnlyMemory<byte> input, string? errors, int numBytes) {
+            if (numBytes != input.Length) {
+                input = input.Slice(0, numBytes);
+            }
+            var decoded = StringOps.DoDecode(context, input, errors, encodingName, encoding);
+            return Tuple.Create(decoded, input.Length);
         }
 
         private static Tuple<Bytes, int> DoEncode(CodeContext context, string encodingName, Encoding encoding, string input, string? errors, bool includePreamble = false) {

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -250,45 +250,45 @@ namespace IronPython.Modules {
         #endregion
 
         #region Raw Unicode Escape Encoding Functions
+#if FEATURE_ENCODING
 
         public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {
             // Encoding with UTF-8 is probably a bug or at least a mistake, as it mutilates non-ASCII characters,
             // but this is what CPython does. Probably encoding with "raw-unicode-escape" would be more reasonable.
-            return raw_unicode_escape_decode(context, DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").Item1, errors);
+            return raw_unicode_escape_decode(context, StringOps.DoEncodeUtf8(context, input), errors);
         }
 
         public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [BytesConversion,NotNull]IList<byte> input, string? errors = null) {
             var span = input.ToArray().AsSpan(); // TODO: remove when signature changed
-            var encoding = StringOps.CodecsInfo.Codecs["raw_unicode_escape"].Value;
             return PythonTuple.MakeTuple(
-                StringOps.DoDecode(context, span, errors, "raw-unicode-escape", encoding),
+                StringOps.DoDecode(context, span, errors, "raw-unicode-escape", StringOps.CodecsInfo.RawUnicodeEscapeEncoding),
                 input.Count
             );
         }
 
         public static PythonTuple raw_unicode_escape_encode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {
-            var encoding = StringOps.CodecsInfo.Codecs["raw_unicode_escape"].Value;
             return PythonTuple.MakeTuple(
-                StringOps.DoEncode(context, input, errors, "raw-unicode-escape", encoding, includePreamble: false),
+                StringOps.DoEncode(context, input, errors, "raw-unicode-escape", StringOps.CodecsInfo.RawUnicodeEscapeEncoding, includePreamble: false),
                 input.Length
             );
         }
 
+#endif
         #endregion
 
         #region Unicode Escape Encoding Functions
+#if FEATURE_ENCODING
 
         public static PythonTuple unicode_escape_decode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {
             // Encoding with UTF-8 is probably a bug or at least a mistake, as it mutilates non-ASCII characters,
             // but this is what CPython does. Probably encoding with "unicode-escape" would be more reasonable.
-            return unicode_escape_decode(context, DoEncode(context, "utf-8", Encoding.UTF8, input, "strict").Item1, errors);
+            return unicode_escape_decode(context, StringOps.DoEncodeUtf8(context, input), errors);
         }
 
         public static PythonTuple unicode_escape_decode(CodeContext/*!*/ context, [BytesConversion,NotNull]IList<byte> input, string? errors = null) {
             var span = input.ToArray().AsSpan(); // TODO: remove when signature changed
-            var encoding = StringOps.CodecsInfo.Codecs["unicode_escape"].Value;
             return PythonTuple.MakeTuple(
-                StringOps.DoDecode(context, span, errors, "unicode-escape", encoding),
+                StringOps.DoDecode(context, span, errors, "unicode-escape", StringOps.CodecsInfo.UnicodeEscapeEncoding),
                 input.Count
             );
         }
@@ -296,11 +296,12 @@ namespace IronPython.Modules {
         public static PythonTuple unicode_escape_encode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {
             var encoding = StringOps.CodecsInfo.Codecs["unicode_escape"].Value;
             return PythonTuple.MakeTuple(
-                StringOps.DoEncode(context, input, errors, "unicode-escape", encoding, includePreamble: false),
+                StringOps.DoEncode(context, input, errors, "unicode-escape", StringOps.CodecsInfo.UnicodeEscapeEncoding, includePreamble: false),
                 input.Length
             );
         }
 
+#endif
         #endregion
 
         #region Readbuffer Functions

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -294,7 +294,6 @@ namespace IronPython.Modules {
         }
 
         public static PythonTuple unicode_escape_encode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {
-            var encoding = StringOps.CodecsInfo.Codecs["unicode_escape"].Value;
             return PythonTuple.MakeTuple(
                 StringOps.DoEncode(context, input, errors, "unicode-escape", StringOps.CodecsInfo.UnicodeEscapeEncoding, includePreamble: false),
                 input.Length

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -10,13 +10,13 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
-using DisallowNullAttribute = System.Diagnostics.CodeAnalysis.DisallowNullAttribute;
-
 using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
+
+using DisallowNullAttribute = System.Diagnostics.CodeAnalysis.DisallowNullAttribute;
 
 [assembly: PythonModule("_codecs", typeof(IronPython.Modules.PythonCodecs))]
 namespace IronPython.Modules {

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -225,6 +225,28 @@ namespace IronPython.Modules {
 #endif
         #endregion
 
+        #region Code Page Functions
+#if FEATURE_ENCODING
+
+        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        public static PythonTuple code_page_decode(CodeContext context, int codepage, [BytesConversion, NotNull]IList<byte> input, string? errors = null, bool final = false) {
+            // TODO: Use Win32 API MultiByteToWideChar https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
+            string encodingName = $"cp{codepage}";
+            Encoding encoding = Encoding.GetEncoding(codepage);
+            return DoDecode(context, encodingName, encoding, input, errors, input.Count).ToPythonTuple();
+        }
+
+        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        public static PythonTuple code_page_encode(CodeContext context, int codepage, [NotNull]string input, string? errors = null) {
+            // TODO: Use Win32 API WideCharToMultiByte https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
+            string encodingName = $"cp{codepage}";
+            Encoding encoding = Encoding.GetEncoding(codepage);
+            return DoEncode(context, encodingName, encoding, input, errors, includePreamble: true).ToPythonTuple();
+        }
+
+#endif
+        #endregion
+
         #region Raw Unicode Escape Encoding Functions
 
         public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null) {

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -112,7 +112,7 @@ namespace IronPython.Modules {
 
         #region Generic Encoding
 
-        public static object decode(CodeContext/*!*/ context, object obj, [NotNull]string? encoding = null, [NotNull]string errors = "strict") {
+        public static object decode(CodeContext/*!*/ context, object? obj, [NotNull, DisallowNull]string? encoding = null, [NotNull]string errors = "strict") {
             if (encoding == null) {
                 if (obj is IList<byte> bytesLikeObj) {
                     PythonContext lc = context.LanguageContext;
@@ -129,7 +129,7 @@ namespace IronPython.Modules {
             }
         }
 
-        public static object encode(CodeContext/*!*/ context, object obj, [NotNull]string? encoding = null, [NotNull]string errors = "strict") {
+        public static object encode(CodeContext/*!*/ context, object? obj, [NotNull, DisallowNull]string? encoding = null, [NotNull]string errors = "strict") {
             if (encoding == null) {
                 if (obj is string str) {
                     PythonContext lc = context.LanguageContext;

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -154,7 +154,8 @@ namespace IronPython.Modules {
             => escape_decode(StringOps.DoEncodeUtf8(context, data), errors);
 
         public static PythonTuple escape_decode([BytesConversion,NotNull]IList<byte> data, string? errors = null) {
-            var res = LiteralParser.ParseBytes(data, 0, data.Count, isRaw: false, normalizeLineEndings: false, getErrorHandler(errors));
+            var span = data.ToArray().AsSpan(); // TODO: remove when signature changed
+            var res = LiteralParser.ParseBytes(span, isRaw: false, normalizeLineEndings: false, getErrorHandler(errors));
 
             return PythonTuple.MakeTuple(Bytes.Make(res.ToArray()), data.Count);
 
@@ -163,7 +164,7 @@ namespace IronPython.Modules {
 
                 Func<int, IReadOnlyList<byte>>? eh = null;
 
-                return delegate (IList<byte> data, int start, int end) {
+                return delegate (in ReadOnlySpan<byte> data, int start, int end, string message) {
                     eh ??= errors switch
                     {
                         "strict" => idx => throw PythonOps.ValueError(@"invalid \x escape at position {0}", idx),

--- a/Src/IronPython.Modules/_ctypes/CData.cs
+++ b/Src/IronPython.Modules/_ctypes/CData.cs
@@ -130,7 +130,7 @@ namespace IronPython.Modules {
             bool IBufferProtocol.ReadOnly {
                 get { return false; }
             }
-            
+
             [PythonHidden]
             public virtual IList<BigInteger> GetShape(int start, int? end) {
                 return null;
@@ -148,8 +148,8 @@ namespace IronPython.Modules {
                 return Bytes.Make(GetBytes(start, NativeType.Size));
             }
 
-            Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
-                return GetBytes(start, NativeType.Size);
+            ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
+                return GetBytes(0, NativeType.Size);
             }
 
             PythonList IBufferProtocol.ToList(int start, int? end) {

--- a/Src/IronPython.Modules/_ctypes/CData.cs
+++ b/Src/IronPython.Modules/_ctypes/CData.cs
@@ -148,6 +148,10 @@ namespace IronPython.Modules {
                 return Bytes.Make(GetBytes(start, NativeType.Size));
             }
 
+            Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
+                return GetBytes(start, NativeType.Size);
+            }
+
             PythonList IBufferProtocol.ToList(int start, int? end) {
                 return new PythonList(((IBufferProtocol)this).ToBytes(start, end));
             }

--- a/Src/IronPython.Modules/_ctypes/CData.cs
+++ b/Src/IronPython.Modules/_ctypes/CData.cs
@@ -148,12 +148,12 @@ namespace IronPython.Modules {
                 return Bytes.Make(GetBytes(start, NativeType.Size));
             }
 
-            ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
-                return GetBytes(0, NativeType.Size);
-            }
-
             PythonList IBufferProtocol.ToList(int start, int? end) {
                 return new PythonList(((IBufferProtocol)this).ToBytes(start, end));
+            }
+
+            ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
+                return GetBytes(0, NativeType.Size);
             }
 
             #endregion

--- a/Src/IronPython.Modules/winreg.cs
+++ b/Src/IronPython.Modules/winreg.cs
@@ -340,7 +340,7 @@ namespace IronPython.Modules {
                     for (int i = 0; i < length; i++) {
                         tight_fit_data[i] = data[i];
                     }
-                    value = length == 0 ? null : new Bytes(tight_fit_data);
+                    value = length == 0 ? null : Bytes.Make(tight_fit_data);
                     break;
                 case REG_EXPAND_SZ:
                 case REG_SZ:

--- a/Src/IronPython.SQLite/Connection.cs
+++ b/Src/IronPython.SQLite/Connection.cs
@@ -332,7 +332,7 @@ namespace IronPython.SQLite
                             break;
 
                         case Sqlite3.SQLITE_BLOB:
-                            cur_py_value = new Bytes(Sqlite3.sqlite3_value_blob(cur_value)); // TODO: avoid creating a copy
+                            cur_py_value = new Bytes(Sqlite3.sqlite3_value_blob(cur_value).AsSpan()); // TODO: avoid creating a copy
                             break;
 
                         case Sqlite3.SQLITE_NULL:

--- a/Src/IronPython.SQLite/Connection.cs
+++ b/Src/IronPython.SQLite/Connection.cs
@@ -332,7 +332,7 @@ namespace IronPython.SQLite
                             break;
 
                         case Sqlite3.SQLITE_BLOB:
-                            cur_py_value = new Bytes(Sqlite3.sqlite3_value_blob(cur_value).AsSpan()); // TODO: avoid creating a copy
+                            cur_py_value = new Bytes(Sqlite3.sqlite3_value_blob(cur_value)); // TODO: avoid creating a copy
                             break;
 
                         case Sqlite3.SQLITE_NULL:

--- a/Src/IronPython.SQLite/Cursor.cs
+++ b/Src/IronPython.SQLite/Cursor.cs
@@ -5,6 +5,7 @@
 // Copyright (c) Jeff Hardy 2010-2012.
 //
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -352,7 +353,7 @@ namespace IronPython.SQLite
 
                             case Sqlite3.SQLITE_BLOB:
                             default:
-                                converted = new Bytes(Sqlite3.sqlite3_column_blob(this.statement.st, i) ?? new byte[0]); // TODO: avoid creating a copy
+                                converted = new Bytes((Sqlite3.sqlite3_column_blob(this.statement.st, i) ?? new byte[0]).AsSpan()); // TODO: avoid creating a copy
                                 break;
                         }
                     }

--- a/Src/IronPython.SQLite/Cursor.cs
+++ b/Src/IronPython.SQLite/Cursor.cs
@@ -353,7 +353,7 @@ namespace IronPython.SQLite
 
                             case Sqlite3.SQLITE_BLOB:
                             default:
-                                converted = new Bytes((Sqlite3.sqlite3_column_blob(this.statement.st, i) ?? new byte[0]).AsSpan()); // TODO: avoid creating a copy
+                                converted = new Bytes(Sqlite3.sqlite3_column_blob(this.statement.st, i) ?? new byte[0]); // TODO: avoid creating a copy
                                 break;
                         }
                     }

--- a/Src/IronPython/Compiler/Tokenizer.cs
+++ b/Src/IronPython/Compiler/Tokenizer.cs
@@ -682,7 +682,7 @@ namespace IronPython.Compiler {
                     var contents = LiteralParser.ParseString(_buffer, start, length, isRaw, !isRaw, !_disableLineFeedLineSeparator);
                     return new ConstantValueToken(contents);
                 } else {
-                    List<byte> data = LiteralParser.ParseBytes(_buffer, start, length, isRaw, !_disableLineFeedLineSeparator);
+                    List<byte> data = LiteralParser.ParseBytes<char>(_buffer.AsSpan(start, length), isRaw, !_disableLineFeedLineSeparator);
                     if (data.Count == 0) {
                         return new ConstantValueToken(Bytes.Empty);
                     }

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -60,7 +60,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.3" Condition="'$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -5,6 +5,7 @@
     <BaseAddress>879755264</BaseAddress>
     <CodeAnalysisRuleSet>..\..\IronPython.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -59,6 +60,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.3" Condition="'$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">

--- a/Src/IronPython/Modules/_bytesio.cs
+++ b/Src/IronPython/Modules/_bytesio.cs
@@ -95,7 +95,7 @@ namespace IronPython.Modules {
             public MemoryView getbuffer() {
                 _checkClosed();
 
-                return new MemoryView(new Bytes(_data), 0, _length, 1, "B", PythonOps.MakeTuple(_length));
+                return new MemoryView(new Bytes(_data.AsSpan()), 0, _length, 1, "B", PythonOps.MakeTuple(_length));
             }
 
             [Documentation("isatty() -> False\n\n"

--- a/Src/IronPython/Modules/_bytesio.cs
+++ b/Src/IronPython/Modules/_bytesio.cs
@@ -95,7 +95,7 @@ namespace IronPython.Modules {
             public MemoryView getbuffer() {
                 _checkClosed();
 
-                return new MemoryView(new Bytes(_data.AsSpan()), 0, _length, 1, "B", PythonOps.MakeTuple(_length));
+                return new MemoryView(new Bytes(_data), 0, _length, 1, "B", PythonOps.MakeTuple(_length));
             }
 
             [Documentation("isatty() -> False\n\n"

--- a/Src/IronPython/Modules/_bytesio.cs
+++ b/Src/IronPython/Modules/_bytesio.cs
@@ -95,7 +95,7 @@ namespace IronPython.Modules {
             public MemoryView getbuffer() {
                 _checkClosed();
 
-                return new MemoryView(new Bytes(_data), 0, _length, 1, "B", PythonOps.MakeTuple(_length));
+                return new MemoryView(new Bytes(_data), 0, _length, 1, "B", PythonOps.MakeTuple(_length), readonlyView: true);
             }
 
             [Documentation("isatty() -> False\n\n"

--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -2747,7 +2747,7 @@ namespace IronPython.Modules {
                 if (file is Extensible<string>) {
                     fname = ((Extensible<string>)file).Value;
                 } else if (file is Bytes b) {
-                    fname = StringOps.RawDecode(context, b, SysModule.getfilesystemencoding(), "strict");
+                    fname = b.decode(context, SysModule.getfilesystemencoding(), "strict");
                 } else {
                     fd = GetInt(file, 0);
                 }

--- a/Src/IronPython/Modules/array.cs
+++ b/Src/IronPython/Modules/array.cs
@@ -1210,7 +1210,7 @@ namespace IronPython.Modules {
             }
 
             ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
-                return ((IBufferProtocol)tobytes()).ToMemory();
+                return ToByteArray().AsMemory();
             }
 
             #endregion

--- a/Src/IronPython/Modules/array.cs
+++ b/Src/IronPython/Modules/array.cs
@@ -1318,6 +1318,10 @@ namespace IronPython.Modules {
                 return ((array)this[new Slice(start, end)]).tobytes();
             }
 
+            Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
+                return ((IBufferProtocol)this).ToBytes(start, end).UnsafeByteArray.AsSpan();
+            }
+
             PythonList IBufferProtocol.ToList(int start, int? end) {
                 if (start == 0 && end == null) {
                     return tolist();

--- a/Src/IronPython/Modules/array.cs
+++ b/Src/IronPython/Modules/array.cs
@@ -1318,8 +1318,8 @@ namespace IronPython.Modules {
                 return ((array)this[new Slice(start, end)]).tobytes();
             }
 
-            Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
-                return ((IBufferProtocol)this).ToBytes(start, end).UnsafeByteArray.AsSpan();
+            ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
+                return ((IBufferProtocol)tobytes()).ToMemory();
             }
 
             PythonList IBufferProtocol.ToList(int start, int? end) {

--- a/Src/IronPython/Modules/array.cs
+++ b/Src/IronPython/Modules/array.cs
@@ -1193,16 +1193,16 @@ namespace IronPython.Modules {
                 return ((array)this[new Slice(start, end)]).tobytes();
             }
 
-            ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
-                return ((IBufferProtocol)tobytes()).ToMemory();
-            }
-
             PythonList IBufferProtocol.ToList(int start, int? end) {
                 if (start == 0 && end == null) {
                     return tolist();
                 }
 
                 return ((array)this[new Slice(start, end)]).tolist();
+            }
+
+            ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
+                return ((IBufferProtocol)tobytes()).ToMemory();
             }
 
             #endregion

--- a/Src/IronPython/Modules/array.cs
+++ b/Src/IronPython/Modules/array.cs
@@ -136,8 +136,11 @@ namespace IronPython.Modules {
             }
 
             public array([NotNull]string type, object? initializer) : this(type) {
-                if (_typeCode != 'u' && (initializer is string || initializer is Extensible<string>)) {
-                    throw PythonOps.TypeError("cannot use a str to initialize an array with typecode '{0}'", _typeCode);
+                if (_typeCode != 'u') {
+                    if (initializer is string || initializer is Extensible<string>)
+                        throw PythonOps.TypeError("cannot use a str to initialize an array with typecode '{0}'", _typeCode);
+                    if (initializer is array arr && arr._typeCode == 'u')
+                        throw PythonOps.TypeError("cannot use a unicode array to initialize an array with typecode '{0}'", _typeCode);
                 }
 
                 ExtendIter(initializer);

--- a/Src/IronPython/Runtime/ArrayData.cs
+++ b/Src/IronPython/Runtime/ArrayData.cs
@@ -44,6 +44,12 @@ namespace IronPython.Runtime {
             AddRange(collection);
         }
 
+        public ArrayData(ReadOnlyMemory<T> data) {
+            GC.SuppressFinalize(this);
+            _items = data.ToArray();
+            _size = _items.Length;
+        }
+
         ~ArrayData() {
             Debug.Assert(_dataHandle.HasValue);
             _dataHandle?.Free();

--- a/Src/IronPython/Runtime/Binding/ConversionBinder.cs
+++ b/Src/IronPython/Runtime/Binding/ConversionBinder.cs
@@ -170,20 +170,7 @@ namespace IronPython.Runtime.Binding {
 
                         // Interface conversion helpers...
                         if (genTo == typeof(IList<>)) {
-                            if (self.LimitType == typeof(string)) {
-                                res = new DynamicMetaObject(
-                                    Ast.Call(
-                                        typeof(PythonOps).GetMethod(nameof(PythonOps.MakeByteArray)),
-                                        AstUtils.Convert(self.Expression, typeof(string))
-                                    ),
-                                    BindingRestrictions.GetTypeRestriction(
-                                        self.Expression,
-                                        typeof(string)
-                                    )
-                                );
-                            } else {
-                                res = TryToGenericInterfaceConversion(self, type, typeof(IList<object>), typeof(ListGenericWrapper<>));
-                            }
+                            res = TryToGenericInterfaceConversion(self, type, typeof(IList<object>), typeof(ListGenericWrapper<>));
                         } else if (genTo == typeof(IDictionary<,>)) {
                             res = TryToGenericInterfaceConversion(self, type, typeof(IDictionary<object, object>), typeof(DictionaryGenericWrapper<,>));
                         } else if (genTo == typeof(IEnumerable<>)) {

--- a/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
+++ b/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
@@ -112,6 +112,14 @@ namespace IronPython.Runtime.Binding {
                 }
             }
 
+            if (fromType.IsGenericType &&
+                fromType.GetGenericTypeDefinition() == typeof(Memory<>) &&
+                toType.IsGenericType &&
+                toType.GetGenericTypeDefinition() == typeof(ReadOnlyMemory<>) &&
+                fromType.GetGenericArguments()[0] == toType.GetGenericArguments()[0]) {
+                return true;
+            }
+
             return base.CanConvertFrom(fromType, fromArg, toParameter, level);
         }
 

--- a/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
+++ b/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
@@ -103,7 +103,10 @@ namespace IronPython.Runtime.Binding {
                 }
 
                 if (typeof(IBufferProtocol).IsAssignableFrom(fromType)) {
-                    if (toType == typeof(IList<byte>) || toType == typeof(IReadOnlyList<byte>)) {
+                    if (toParameter.Type == typeof(ReadOnlyMemory<byte>)) {
+                        return true;
+                    }
+                    if (toParameter.Type == typeof(IList<byte>) || toParameter.Type == typeof(IReadOnlyList<byte>)) {
                         return true;
                     }
                 }

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -275,7 +275,7 @@ namespace IronPython.Runtime {
 
         public string decode(CodeContext context, [NotNull]Encoding encoding, [NotNull]string errors = "strict") {
             lock (this) {
-                return StringOps.DoDecode(context, ((IBufferProtocol)this).ToSpan(0, null), errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
+                return StringOps.DoDecode(context, ((IBufferProtocol)this).ToMemory().Span, errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
             }
         }
 
@@ -1473,8 +1473,8 @@ namespace IronPython.Runtime {
             return new Bytes((ByteArray)this[new Slice(start, end)]);
         }
 
-        Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
-            return ((IBufferProtocol)this).ToBytes(start, end).UnsafeByteArray.AsSpan();
+        ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
+            return ((IBufferProtocol)new Bytes(this)).ToMemory();
         }
 
         PythonList IBufferProtocol.ToList(int start, int? end) {

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -269,13 +269,13 @@ namespace IronPython.Runtime {
 
         public string decode(CodeContext context, [NotNull]string encoding = "utf-8", [NotNull]string errors = "strict") {
             lock (this) {
-                return StringOps.RawDecode(context, _bytes, encoding, errors);
+                return StringOps.RawDecode(context, this, encoding, errors);
             }
         }
 
         public string decode(CodeContext context, [NotNull]Encoding encoding, [NotNull]string errors = "strict") {
             lock (this) {
-                return StringOps.DoDecode(context, _bytes, errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
+                return StringOps.DoDecode(context, ((IBufferProtocol)this).ToSpan(0, null), errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
             }
         }
 
@@ -1471,6 +1471,10 @@ namespace IronPython.Runtime {
             }
 
             return new Bytes((ByteArray)this[new Slice(start, end)]);
+        }
+
+        Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
+            return ((IBufferProtocol)this).ToBytes(start, end).UnsafeByteArray.AsSpan();
         }
 
         PythonList IBufferProtocol.ToList(int start, int? end) {

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1170,11 +1170,7 @@ namespace IronPython.Runtime {
             return new ByteArray(new List<byte>(_bytes));
         }
 
-        private void SliceNoStep(int start, int stop, IList<byte> value) {
-            // always copy from a List object, even if it's a copy of some user defined enumerator.  This
-            // makes it easy to hold the lock for the duration fo the copy.
-            IList<byte> other = GetBytes(value);
-
+        private void SliceNoStep(int start, int stop, IList<byte> other) {
             lock (this) {
                 if (start > stop) {
                     int newSize = Count + other.Count;

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -275,7 +275,7 @@ namespace IronPython.Runtime {
 
         public string decode(CodeContext context, [NotNull]Encoding encoding, [NotNull]string errors = "strict") {
             lock (this) {
-                return StringOps.DoDecode(context, ((IBufferProtocol)this).ToMemory().Span, errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
+                return StringOps.DoDecode(context, ((IBufferProtocol)this).ToMemory(), errors, StringOps.GetEncodingName(encoding, normalize: false), encoding);
             }
         }
 

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -269,13 +269,7 @@ namespace IronPython.Runtime {
 
         public string decode(CodeContext context, [NotNull]string encoding = "utf-8", [NotNull]string errors = "strict") {
             lock (this) {
-                var mv = new MemoryView(this);
-                // TODO: Move the rest outside lock when wrapping bytearray in memoryview turns byttearray readonly
-                try {
-                    return StringOps.RawDecode(context, mv, encoding, errors);
-                } finally {
-                    mv.release(context);
-                }
+                return StringOps.RawDecode(context, new MemoryView(this, 0, null, 1, "B", PythonTuple.MakeTuple(_bytes.Count), readonlyView: true), encoding, errors);
             }
         }
 

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -110,7 +110,7 @@ namespace IronPython.Runtime {
             => _bytes.CountOf(new[] { @byte.ToByteChecked() }, start ?? 0, end ?? Count);
 
         public string decode(CodeContext context, [NotNull]string encoding = "utf-8", [NotNull]string errors = "strict") {
-            return StringOps.RawDecode(context, this, encoding, errors);
+            return StringOps.RawDecode(context, new MemoryView(this), encoding, errors);
         }
 
         public string decode(CodeContext context, [NotNull]Encoding encoding, [NotNull]string errors = "strict") {
@@ -906,13 +906,13 @@ namespace IronPython.Runtime {
             return this[new Slice(start, end)];
         }
 
-        ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
-            return _bytes.AsMemory();
-        }
-
         PythonList IBufferProtocol.ToList(int start, int? end) {
             var res = _bytes.Slice(new Slice(start, end));
             return res == null ? new PythonList() : new PythonList(res);
+        }
+
+        ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
+            return _bytes.AsMemory();
         }
 
         #endregion

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -40,10 +40,6 @@ namespace IronPython.Runtime {
             _bytes = bytes.ToArray();
         }
 
-        public Bytes(in ReadOnlySpan<byte> bytes) {
-            _bytes = bytes.ToArray();
-        }
-
         public Bytes([NotNull]PythonList bytes) {
             _bytes = ByteOps.GetBytes(bytes).ToArray();
         }
@@ -64,17 +60,7 @@ namespace IronPython.Runtime {
             _bytes = StringOps.encode(context, unicode, encoding, "strict").UnsafeByteArray;
         }
 
-        private static readonly IReadOnlyList<Bytes> oneByteBytes;
-
-        static Bytes() {
-            var barr256 = new Bytes[256];
-            Span<byte> oneByte = stackalloc byte[1];
-            for (int i = 0; i < 256; i++) {
-                oneByte[0] = unchecked((byte)i);
-                barr256[i] = new Bytes(oneByte);
-            }
-            oneByteBytes = barr256;
-        }
+        private static readonly IReadOnlyList<Bytes> oneByteBytes = Enumerable.Range(0, 256).Select(i => new Bytes(new byte[] { (byte)i })).ToArray();
 
         internal static Bytes FromByte(byte b) {
             return oneByteBytes[b];
@@ -914,8 +900,8 @@ namespace IronPython.Runtime {
             return this[new Slice(start, end)];
         }
 
-        Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
-            return _bytes.AsSpan(start, end ?? _bytes.Length);
+        ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
+            return _bytes.AsMemory();
         }
 
         PythonList IBufferProtocol.ToList(int start, int? end) {

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -110,7 +110,7 @@ namespace IronPython.Runtime {
             => _bytes.CountOf(new[] { @byte.ToByteChecked() }, start ?? 0, end ?? Count);
 
         public string decode(CodeContext context, [NotNull]string encoding = "utf-8", [NotNull]string errors = "strict") {
-            return StringOps.RawDecode(context, _bytes, encoding, errors);
+            return StringOps.RawDecode(context, this, encoding, errors);
         }
 
         public string decode(CodeContext context, [NotNull]Encoding encoding, [NotNull]string errors = "strict") {
@@ -898,6 +898,10 @@ namespace IronPython.Runtime {
             }
 
             return this[new Slice(start, end)];
+        }
+
+        Span<byte> IBufferProtocol.ToSpan(int start, int? end) {
+            return _bytes.AsSpan(start, end ?? _bytes.Length);
         }
 
         PythonList IBufferProtocol.ToList(int start, int? end) {

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -40,6 +40,10 @@ namespace IronPython.Runtime {
             _bytes = bytes.ToArray();
         }
 
+        public Bytes(in ReadOnlySpan<byte> bytes) {
+            _bytes = bytes.ToArray();
+        }
+
         public Bytes([NotNull]PythonList bytes) {
             _bytes = ByteOps.GetBytes(bytes).ToArray();
         }
@@ -60,7 +64,17 @@ namespace IronPython.Runtime {
             _bytes = StringOps.encode(context, unicode, encoding, "strict").UnsafeByteArray;
         }
 
-        private static readonly Bytes[] oneByteBytes = Enumerable.Range(0, 256).Select(i => new Bytes(new byte[] { (byte)i })).ToArray();
+        private static readonly IReadOnlyList<Bytes> oneByteBytes;
+
+        static Bytes() {
+            var barr256 = new Bytes[256];
+            Span<byte> oneByte = stackalloc byte[1];
+            for (int i = 0; i < 256; i++) {
+                oneByte[0] = unchecked((byte)i);
+                barr256[i] = new Bytes(oneByte);
+            }
+            oneByteBytes = barr256;
+        }
 
         internal static Bytes FromByte(byte b) {
             return oneByteBytes[b];
@@ -709,7 +723,7 @@ namespace IronPython.Runtime {
                 count += list[i]._bytes.Length;
             }
 
-            return new Bytes(res);
+            return Bytes.Make(res);
         }
 
         #endregion

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -36,7 +36,7 @@ namespace IronPython.Runtime {
             _bytes = source.Select(b => ((int)PythonOps.Index(b)).ToByteChecked()).ToArray();
         }
 
-        public Bytes([NotNull]IList<byte> bytes) {
+        public Bytes([NotNull]IEnumerable<byte> bytes) {
             _bytes = bytes.ToArray();
         }
 
@@ -53,10 +53,6 @@ namespace IronPython.Runtime {
         }
 
         public Bytes([NotNull]byte[] bytes) {
-            _bytes = bytes.ToArray();
-        }
-
-        public Bytes([NotNull]ArraySegment<byte> bytes) {
             _bytes = bytes.ToArray();
         }
 

--- a/Src/IronPython/Runtime/BytesLikeAttribute.cs
+++ b/Src/IronPython/Runtime/BytesLikeAttribute.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace IronPython.Runtime {
     /// <summary>
-    /// For <c>IList〈byte〉</c>, <c>IReadOnlyList〈byte〉</c> parameters:
+    /// For <c>IList〈byte〉</c>, <c>IReadOnlyList〈byte〉</c>, and <c>ReadOnlyMemory〈byte〉</c> parameters:
     /// Marks that the parameter is typed to accept a bytes-like object.
     /// <br/>
     /// If applied on a IList〈byte〉 parameter, this attribute disallows passing

--- a/Src/IronPython/Runtime/BytesLikeAttribute.cs
+++ b/Src/IronPython/Runtime/BytesLikeAttribute.cs
@@ -8,10 +8,18 @@ using System;
 
 namespace IronPython.Runtime {
     /// <summary>
-    /// For IList<byte/> arguments: Marks that the argument is typed to accept a bytes or
-    /// bytearray object.  This attribute disallows passing a Python list object and
-    /// auto-applying our generic conversion.
+    /// For <c>IList〈byte〉</c>, <c>IReadOnlyList〈byte〉</c> parameters:
+    /// Marks that the parameter is typed to accept a bytes-like object.
+    /// <br/>
+    /// If applied on a IList〈byte〉 parameter, this attribute disallows passing
+    /// a Python list object and auto-applying our generic conversion.
+    /// <br/>
+    /// The overload resolver will favor an overload with a BytesLike parameter
+    /// over an otherwise equivalent overload with a different interface parameter.
     /// </summary>
+    /// <remarks>
+    /// A bytes-like object is any object of type implementing IBufferProtocol.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     public sealed class BytesLikeAttribute : Attribute { }
 }

--- a/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
+++ b/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
@@ -949,8 +949,8 @@ for k, v in toError.items():
                     object inputData = ex.BytesUnknown;
                     int startIdx = 0;
                     int endIdx = ex.BytesUnknown?.Length ?? 0;
-                    if (ex.Data.Contains("object") && ex.Data["object"] is IList<byte> s) {
-                        inputData = s;
+                    if (ex.Data.Contains("object") && ex.Data["object"] is Bytes b) {
+                        inputData = b;
                         startIdx = ex.Index;
                         endIdx += startIdx;
                     }

--- a/Src/IronPython/Runtime/IBufferProtocol.cs
+++ b/Src/IronPython/Runtime/IBufferProtocol.cs
@@ -32,8 +32,8 @@ namespace IronPython.Runtime {
 
         Bytes ToBytes(int start, int? end);
 
-        ReadOnlyMemory<byte> ToMemory();
-
         PythonList ToList(int start, int? end);
+
+        ReadOnlyMemory<byte> ToMemory();
     }
 }

--- a/Src/IronPython/Runtime/IBufferProtocol.cs
+++ b/Src/IronPython/Runtime/IBufferProtocol.cs
@@ -32,7 +32,7 @@ namespace IronPython.Runtime {
 
         Bytes ToBytes(int start, int? end);
 
-        Span<byte> ToSpan(int start, int? end);
+        ReadOnlyMemory<byte> ToMemory();
 
         PythonList ToList(int start, int? end);
     }

--- a/Src/IronPython/Runtime/IBufferProtocol.cs
+++ b/Src/IronPython/Runtime/IBufferProtocol.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 
@@ -30,6 +31,8 @@ namespace IronPython.Runtime {
         PythonTuple? SubOffsets { get; }
 
         Bytes ToBytes(int start, int? end);
+
+        Span<byte> ToSpan(int start, int? end);
 
         PythonList ToList(int start, int? end);
     }

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -780,7 +780,7 @@ namespace IronPython.Runtime {
         ReadOnlyMemory<byte> IBufferProtocol.ToMemory() {
             if (_step == 1) {
                 CheckBuffer();
-                return _end.HasValue ? _buffer.ToMemory().Slice(_start, _end.Value) : _buffer.ToMemory().Slice(_start);
+                return _end.HasValue ? _buffer.ToMemory().Slice(_start, _end.Value - _start) : _buffer.ToMemory().Slice(_start);
             } else {
                 return ((IBufferProtocol)tobytes()).ToMemory();
             }

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -151,7 +151,9 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        internal static void RegisterEncodingError(CodeContext/*!*/ context, string name, object handler) {
+#nullable enable
+
+        internal static void RegisterEncodingError(CodeContext/*!*/ context, string name, object? handler) {
             Dictionary<string, object> errorHandlers = context.LanguageContext.ErrorHandlers;
 
             lock (errorHandlers) {
@@ -161,6 +163,8 @@ namespace IronPython.Runtime.Operations {
                 errorHandlers[name] = handler;
             }
         }
+
+#nullable restore
 
         internal static PythonTuple LookupEncoding(CodeContext/*!*/ context, string encoding) {
             if (encoding.IndexOf('\0') != -1) {
@@ -196,7 +200,9 @@ namespace IronPython.Runtime.Operations {
             return tuple;
         }
 
-        internal static void RegisterEncoding(CodeContext/*!*/ context, object search_function) {
+#nullable enable
+
+        internal static void RegisterEncoding(CodeContext/*!*/ context, object? search_function) {
             if (!PythonOps.IsCallable(context, search_function))
                 throw PythonOps.TypeError("search_function must be callable");
 
@@ -206,6 +212,8 @@ namespace IronPython.Runtime.Operations {
                 searchFunctions.Add(search_function);
             }
         }
+
+#nullable restore
 
         internal static string GetPythonTypeName(object obj) {
             return PythonTypeOps.GetName(obj);
@@ -1932,7 +1940,7 @@ namespace IronPython.Runtime.Operations {
             return false;
         }
 
-#nullable disable
+#nullable restore
 
         public static void ForLoopDispose(KeyValuePair<IEnumerator, IDisposable> iteratorInfo) => iteratorInfo.Value?.Dispose();
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3358,8 +3358,9 @@ namespace IronPython.Runtime.Operations {
         }
 
         [Obsolete("Use Bytes(IList<byte>) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static Bytes MakeBytes(byte[] bytes) {
-            return Bytes.Make(bytes.ToArray());
+            return Bytes.Make(bytes);
         }
 
         public static byte[] MakeByteArray(this string s) {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3357,9 +3357,9 @@ namespace IronPython.Runtime.Operations {
             return DoubleOps.Compare(self, other);
         }
 
-        [Obsolete("Use Bytes(IList<byte>) or Bytes(ReadOnlySpan<byte>) instead.")]
+        [Obsolete("Use Bytes(IList<byte>) instead.")]
         public static Bytes MakeBytes(byte[] bytes) {
-            return new Bytes(bytes.AsSpan());
+            return Bytes.Make(bytes.ToArray());
         }
 
         public static byte[] MakeByteArray(this string s) {
@@ -3377,13 +3377,11 @@ namespace IronPython.Runtime.Operations {
         internal static string MakeString(this IList<byte> bytes, int startIdx, int maxBytes) {
             Debug.Assert(startIdx >= 0);
 
-            int bytesToCopy = Math.Min(bytes.Count, maxBytes);
-            StringBuilder b = new StringBuilder(bytesToCopy);
-            int endIdx = startIdx + bytesToCopy;
-            for (int i = startIdx; i < endIdx; i++) {
-                b.Append((char)bytes[i]);
-            }
-            return b.ToString();
+            if (bytes.Count < maxBytes) maxBytes = bytes.Count;
+            if (maxBytes <= 0 || startIdx >= bytes.Count) return string.Empty;
+
+            byte[] byteArr = (bytes is byte[] arr) ? arr : bytes.ToArray();
+            return StringOps.Latin1Encoding.GetString(byteArr, startIdx, maxBytes);
         }
 
         internal static string MakeString(this Span<byte> bytes) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1722,10 +1722,7 @@ namespace IronPython.Runtime.Operations {
 #endif
 
         internal static string DoDecode(CodeContext context, ReadOnlyMemory<byte> data, string errors, string encoding, Encoding e) {
-            int start = GetStartingOffset(e, data.Span);
-            if (start > 0) {
-                data = data.Slice(start);
-            }
+            data = RemovePreamble(data, e);
 
 #if FEATURE_ENCODING
             // CLR's encoder exceptions have a 1-1 mapping w/ Python's encoder exceptions
@@ -1782,9 +1779,9 @@ namespace IronPython.Runtime.Operations {
         /// <summary>
         /// Gets the starting offset checking to see if the incoming bytes already include a preamble.
         /// </summary>
-        private static int GetStartingOffset(Encoding e, in ReadOnlySpan<byte> bytes) {
+        private static ReadOnlyMemory<byte> RemovePreamble(ReadOnlyMemory<byte> bytes, Encoding e) {
             byte[] preamble = e.GetPreamble();
-            return preamble.Length > 0 && bytes.StartsWith(preamble) ? preamble.Length : 0;
+            return preamble.Length > 0 && bytes.Span.StartsWith(preamble) ? bytes.Slice(preamble.Length) : bytes;
         }
 
         internal static Bytes RawEncode(CodeContext/*!*/ context, string s, string encoding, string errors) {

--- a/Tests/interop/net/dynamic/test_dynamic_regressions.py
+++ b/Tests/interop/net/dynamic/test_dynamic_regressions.py
@@ -158,7 +158,7 @@ class DynamicRegressionTest(IronPythonTestCase):
                                                                             os.path.join(sys.exec_prefix, "Microsoft.Scripting.dll"),
                                                                             os.path.join(sys.exec_prefix, "Microsoft.Dynamic.dll"))
         self.assertEqual(self.run_vbc(compile_cmd), 0)
-        for x in ["IronPython.dll", "Microsoft.Scripting.dll", "Microsoft.Dynamic.dll"]:
+        for x in ["IronPython.dll", "Microsoft.Scripting.dll", "Microsoft.Dynamic.dll", "System.Memory.dll"]:
             System.IO.File.Copy(os.path.join(sys.exec_prefix, x), os.path.join(self.temporary_dir, x), True)
 
         self.assertEqual(os.system(cp20519_vb_exename), 0)

--- a/Tests/interop/net/dynamic/test_dynamic_regressions.py
+++ b/Tests/interop/net/dynamic/test_dynamic_regressions.py
@@ -152,15 +152,19 @@ class DynamicRegressionTest(IronPythonTestCase):
         f.close()
 
         cp20519_vb_exename  = os.path.join(self.temporary_dir, "cp20519_vb.exe")
-        compile_cmd = "/target:exe /out:%s %s /reference:%s /reference:%s /reference:%s /reference:%s" % (cp20519_vb_exename,
-                                                                            cp20519_vb_filename,
-                                                                            os.path.join(sys.exec_prefix, "IronPython.dll"),
-                                                                            os.path.join(sys.exec_prefix, "Microsoft.Scripting.dll"),
-                                                                            os.path.join(sys.exec_prefix, "Microsoft.Dynamic.dll"),
-                                                                            os.path.join(sys.exec_prefix, "System.Memory.dll"))
+        dll_list = [
+            "IronPython.dll",
+            "Microsoft.Scripting.dll",
+            "Microsoft.Dynamic.dll",
+            "System.Memory.dll",
+            "System.Runtime.CompilerServices.Unsafe.dll",
+        ]
+        compile_cmd = "/target:exe /out:%s %s /reference:%s" % (cp20519_vb_exename,
+                                                                cp20519_vb_filename,
+                                                                " /reference:".join([os.path.join(sys.exec_prefix, dll) for dll in dll_list]))
         self.assertEqual(self.run_vbc(compile_cmd), 0)
-        for x in ["IronPython.dll", "Microsoft.Scripting.dll", "Microsoft.Dynamic.dll", "System.Memory.dll"]:
-            System.IO.File.Copy(os.path.join(sys.exec_prefix, x), os.path.join(self.temporary_dir, x), True)
+        for dll in dll_list:
+            System.IO.File.Copy(os.path.join(sys.exec_prefix, dll), os.path.join(self.temporary_dir, dll), True)
 
         self.assertEqual(os.system(cp20519_vb_exename), 0)
         os.remove(cp20519_vb_exename)

--- a/Tests/interop/net/dynamic/test_dynamic_regressions.py
+++ b/Tests/interop/net/dynamic/test_dynamic_regressions.py
@@ -152,11 +152,12 @@ class DynamicRegressionTest(IronPythonTestCase):
         f.close()
 
         cp20519_vb_exename  = os.path.join(self.temporary_dir, "cp20519_vb.exe")
-        compile_cmd = "/target:exe /out:%s %s /reference:%s /reference:%s /reference:%s" % (cp20519_vb_exename,
+        compile_cmd = "/target:exe /out:%s %s /reference:%s /reference:%s /reference:%s /reference:%s" % (cp20519_vb_exename,
                                                                             cp20519_vb_filename,
                                                                             os.path.join(sys.exec_prefix, "IronPython.dll"),
                                                                             os.path.join(sys.exec_prefix, "Microsoft.Scripting.dll"),
-                                                                            os.path.join(sys.exec_prefix, "Microsoft.Dynamic.dll"))
+                                                                            os.path.join(sys.exec_prefix, "Microsoft.Dynamic.dll"),
+                                                                            os.path.join(sys.exec_prefix, "System.Memory.dll"))
         self.assertEqual(self.run_vbc(compile_cmd), 0)
         for x in ["IronPython.dll", "Microsoft.Scripting.dll", "Microsoft.Dynamic.dll", "System.Memory.dll"]:
             System.IO.File.Copy(os.path.join(sys.exec_prefix, x), os.path.join(self.temporary_dir, x), True)

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -903,16 +903,25 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(codecs.decode(arr, 'ironpython_test_codecs_test_register'), "***")
         self.assertIs(ironpython_test_codecs_test_register_decode_input, arr)
 
-        # When 'decode' method is used on 'bytes' or 'bytearray', the object is being wrapped in 'memoryview'
+        # When 'decode' method is used on 'bytes' or 'bytearray', the object is being wrapped in a readonly 'memoryview'
         ironpython_test_codecs_test_register_decode_input = None
         self.assertEqual(b.decode('ironpython_test_codecs_test_register'), "***")
         self.assertIs(type(ironpython_test_codecs_test_register_decode_input), memoryview)
+        self.assertTrue(ironpython_test_codecs_test_register_decode_input.readonly)
+        self.assertRaises(TypeError, memoryview.__setitem__, ironpython_test_codecs_test_register_decode_input, 0, 120)
 
         ironpython_test_codecs_test_register_decode_input = None
         self.assertEqual(ba.decode('ironpython_test_codecs_test_register'), "***")
         self.assertIs(type(ironpython_test_codecs_test_register_decode_input), memoryview)
+        self.assertTrue(ironpython_test_codecs_test_register_decode_input.readonly)
+        self.assertRaises(TypeError, memoryview.__setitem__, ironpython_test_codecs_test_register_decode_input, 0, 120)
+        numBytes = len(ba)
+        self.assertEqual(len(ironpython_test_codecs_test_register_decode_input), numBytes)
+        self.assertEqual(ironpython_test_codecs_test_register_decode_input.shape, (numBytes,))
+        ba[1] = ord('x')
+        self.assertEqual(ironpython_test_codecs_test_register_decode_input[1], ord('x'))
 
-        ironpython_test_codecs_test_register_decode_input = None
+        del ironpython_test_codecs_test_register_decode_input
 
     def test_unicode_internal_encode(self):
         # takes one or two parameters, not zero or three

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -1265,7 +1265,7 @@ class CodecTest(IronPythonTestCase):
             self.assertEqual(codecs.utf_8_decode(sample1), (preamble + '12\u20ac\x0a', 6 + bom_len))
             sample1 = sample1[:-1] # 12<euro>
             self.assertEqual(codecs.utf_8_decode(sample1), (preamble + '12\u20ac', 5 + bom_len))
-            sample1 = sample1[:-1] # 12<uncomplete euro>
+            sample1 = sample1[:-1] # 12<incomplete euro>
             self.assertEqual(codecs.utf_8_decode(sample1), (preamble + '12', 2 + bom_len))
 
             sample1 = sample1 + b'x7f' # makes it invalid

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -54,7 +54,7 @@ class BytesTest(IronPythonTestCase):
             self.assertEqual(testType(ars), b"abc")
             if testType != bytearray: # TODO
                 self.assertEqual(testType(rom), b"abc")
-                #self.assertEqual(testType(mem), b"abc") # TODO
+                self.assertEqual(testType(mem), b"abc")
 
     def test_capitalize(self):
         tests = [(b'foo', b'Foo'),

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -2,10 +2,11 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
+import array
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_cpython, is_netcoreapp, run_test, skipUnlessIronPython
 
 if not is_cli:
     long = int
@@ -25,6 +26,35 @@ class Indexable(object):
         return self.value
 
 class BytesTest(IronPythonTestCase):
+
+    def test_init(self):
+        b = bytes(b'abc')
+
+        for testType in types:
+            self.assertEqual(testType(b), b)
+            self.assertEqual(testType(bytearray(b)), b)
+            self.assertEqual(testType(memoryview(b)), b)
+            self.assertEqual(testType(array.array(b)), b)
+
+    @unittest.skipUnless(is_cli, "Interop with CLI")
+    def test_init_interop(self):
+        import System
+        from System import Byte, Array, ArraySegment
+
+        arr = Array[Byte](b"abc")
+        ars = ArraySegment[Byte](arr)
+        if is_netcoreapp:
+            from System import Memory, ReadOnlyMemory
+            mem = Memory[Byte](arr)
+            rom = ReadOnlyMemory[Byte](arr)
+
+        for testType in types:
+            self.assertEqual(testType(arr), b"abc")
+            self.assertEqual(testType(ars), b"abc")
+            if is_netcoreapp:
+                #self.assertEqual(testType(mem), b"abc") # TODO
+                if testType != bytearray: # TODO
+                    self.assertEqual(testType(rom), b"abc")
 
     def test_capitalize(self):
         tests = [(b'foo', b'Foo'),

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -52,9 +52,8 @@ class BytesTest(IronPythonTestCase):
         for testType in types:
             self.assertEqual(testType(arr), b"abc")
             self.assertEqual(testType(ars), b"abc")
-            if testType != bytearray: # TODO
-                self.assertEqual(testType(rom), b"abc")
-                self.assertEqual(testType(mem), b"abc")
+            self.assertEqual(testType(rom), b"abc")
+            self.assertEqual(testType(mem), b"abc")
 
     def test_capitalize(self):
         tests = [(b'foo', b'Foo'),

--- a/Tests/test_codecs_stdlib.py
+++ b/Tests/test_codecs_stdlib.py
@@ -20,31 +20,31 @@ def load_tests(loader, standard_tests, pattern):
         #suite.addTest(test.test_codecs.BasicUnicodeTest('test_bad_decode_args')) # unknown encoding: big5
         #suite.addTest(test.test_codecs.BasicUnicodeTest('test_bad_encode_args')) # unknown encoding: big5
         #suite.addTest(test.test_codecs.BasicUnicodeTest('test_basics')) # unknown encoding: big5
-        suite.addTest(test.test_codecs.BasicUnicodeTest('test_basics_capi')) # skipped
+        suite.addTest(test.test_codecs.BasicUnicodeTest('test_basics_capi'))
         #suite.addTest(test.test_codecs.BasicUnicodeTest('test_decoder_state')) # unknown encoding: big5
         suite.addTest(test.test_codecs.BasicUnicodeTest('test_encoding_map_type_initialized'))
         #suite.addTest(test.test_codecs.BasicUnicodeTest('test_seek')) # unknown encoding: big5
-        #suite.addTest(test.test_codecs.BomTest('test_seek0')) # TypeError: expected str, got bytes
-        #suite.addTest(test.test_codecs.CP65001Test('test_bug1098990_a')) # cp65001 encoding is only available on Windows
-        #suite.addTest(test.test_codecs.CP65001Test('test_bug1098990_b')) # cp65001 encoding is only available on Windows
-        #suite.addTest(test.test_codecs.CP65001Test('test_bug1175396')) # cp65001 encoding is only available on Windows
+        suite.addTest(test.test_codecs.BomTest('test_seek0'))
+        suite.addTest(test.test_codecs.CP65001Test('test_bug1098990_a'))
+        suite.addTest(test.test_codecs.CP65001Test('test_bug1098990_b'))
+        suite.addTest(test.test_codecs.CP65001Test('test_bug1175396'))
         #suite.addTest(test.test_codecs.CP65001Test('test_decode')) # '[��]' != '[���]' (bug in .NET: dotnet/corefx#36163, fixed in .NET Core 3.x)
         suite.addTest(test.test_codecs.CP65001Test('test_encode'))
         suite.addTest(test.test_codecs.CP65001Test('test_lone_surrogates'))
-        #suite.addTest(test.test_codecs.CP65001Test('test_mixed_readline_and_read')) # cp65001 encoding is only available on Windows
-        suite.addTest(test.test_codecs.CP65001Test('test_readline')) # skipped
-        #suite.addTest(test.test_codecs.CP65001Test('test_readlinequeue')) # cp65001 encoding is only available on Windows
-        #suite.addTest(test.test_codecs.CP65001Test('test_surrogatepass_handler')) # unknown error handler name 'surrogatepass'
+        suite.addTest(test.test_codecs.CP65001Test('test_mixed_readline_and_read'))
+        suite.addTest(test.test_codecs.CP65001Test('test_readline'))
+        suite.addTest(test.test_codecs.CP65001Test('test_readlinequeue'))
+        suite.addTest(test.test_codecs.CP65001Test('test_surrogatepass_handler'))
         suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2int_map'))
         suite.addTest(test.test_codecs.CharmapTest('test_decode_with_int2str_map'))
         suite.addTest(test.test_codecs.CharmapTest('test_decode_with_string_map'))
-        #suite.addTest(test.test_codecs.CodePageTest('test_code_page_name')) # 'module' object has no attribute 'code_page_encode'
-        #suite.addTest(test.test_codecs.CodePageTest('test_cp1252')) # 'module' object has no attribute 'code_page_encode'
-        #suite.addTest(test.test_codecs.CodePageTest('test_cp932')) # 'module' object has no attribute 'code_page_encode'
-        #suite.addTest(test.test_codecs.CodePageTest('test_cp_utf7')) # 'module' object has no attribute 'code_page_encode'
-        #suite.addTest(test.test_codecs.CodePageTest('test_incremental')) # 'module' object has no attribute 'code_page_encode'
-        #suite.addTest(test.test_codecs.CodePageTest('test_invalid_code_page')) # 'module' object has no attribute 'code_page_encode'
-        #suite.addTest(test.test_codecs.CodePageTest('test_multibyte_encoding')) # 'module' object has no attribute 'code_page_encode'
+        #suite.addTest(test.test_codecs.CodePageTest('test_code_page_name')) # "CP_UTF8" does not match "'cp65001'""
+        #suite.addTest(test.test_codecs.CodePageTest('test_cp1252')) # b'?' != b'L' for "Ł" with 'replace'
+        #suite.addTest(test.test_codecs.CodePageTest('test_cp932')) # b'[?]' != b'[y]' for "ÿ" with 'replace'
+        #suite.addTest(test.test_codecs.CodePageTest('test_cp_utf7')) # Unable to decode b'[+/]' from "cp65000"
+        #suite.addTest(test.test_codecs.CodePageTest('test_incremental')) # incremental codepage decoding not implemented yet
+        #suite.addTest(test.test_codecs.CodePageTest('test_invalid_code_page')) # SystemError raised iso OSError
+        #suite.addTest(test.test_codecs.CodePageTest('test_multibyte_encoding')) # .NET cp932 does not resynchronize cursor after '\x84' in '\x84\xe9\x80'
         suite.addTest(test.test_codecs.CodecsModuleTest('test_all'))
         suite.addTest(test.test_codecs.CodecsModuleTest('test_decode'))
         suite.addTest(test.test_codecs.CodecsModuleTest('test_encode'))
@@ -93,7 +93,7 @@ def load_tests(loader, standard_tests, pattern):
         #suite.addTest(test.test_codecs.RecodingTest('test_recoding')) # expected IList[Byte], got str
         suite.addTest(test.test_codecs.StreamReaderTest('test_readlines'))
         suite.addTest(test.test_codecs.SurrogateEscapeTest('test_ascii'))
-        #suite.addTest(test.test_codecs.SurrogateEscapeTest('test_charmap')) # 'foobar' != 'foo\udca5bar'
+        #suite.addTest(test.test_codecs.SurrogateEscapeTest('test_charmap')) # .NET iso-8859-3 decodes b'\xa5' to 'uf7f5' rather than undefined
         suite.addTest(test.test_codecs.SurrogateEscapeTest('test_latin1'))
         suite.addTest(test.test_codecs.SurrogateEscapeTest('test_utf8'))
         suite.addTest(test.test_codecs.TransformCodecTest('test_aliases'))
@@ -207,7 +207,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF8SigTest('test_readlinequeue'))
         suite.addTest(test.test_codecs.UTF8SigTest('test_stream_bare'))
         suite.addTest(test.test_codecs.UTF8SigTest('test_stream_bom'))
-        #suite.addTest(test.test_codecs.UTF8SigTest('test_surrogatepass_handler')) # LookupError: unknown error handler name 'surrogatepass'
+        suite.addTest(test.test_codecs.UTF8SigTest('test_surrogatepass_handler'))
         suite.addTest(test.test_codecs.UTF8Test('test_bug1098990_a'))
         suite.addTest(test.test_codecs.UTF8Test('test_bug1098990_b'))
         suite.addTest(test.test_codecs.UTF8Test('test_bug1175396'))
@@ -217,7 +217,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_codecs.UTF8Test('test_partial'))
         suite.addTest(test.test_codecs.UTF8Test('test_readline'))
         suite.addTest(test.test_codecs.UTF8Test('test_readlinequeue'))
-        #suite.addTest(test.test_codecs.UTF8Test('test_surrogatepass_handler')) # LookupError: unknown error handler name 'surrogatepass'
+        suite.addTest(test.test_codecs.UTF8Test('test_surrogatepass_handler'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_decode_errors'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_empty'))
         suite.addTest(test.test_codecs.UnicodeEscapeTest('test_escape_decode'))


### PR DESCRIPTION
This the first step of a feasibility study of using `Span` for bytes-like objects (triggered by #762). I address here my first concern for encodings not having access to the underlying `byte[]` hence needing to copy data to a new array every time on decode.

I did the experiments in net45; I didn't want to get sidetracked by the target upgrade. Once the project target is upgraded to .NET 4.6, we can use/override `Encoding.GetString(bytes*, ...)`, which will eliminate a few copy actions in my feasibility code. Since those changes are straightforward, there is no need to address them in this exercise.

My first concern was the feasibility of `Span` (i.e. byte pointer overloads) for `UnicodeEscapeEncoding`. This encoding depends on `LiteralParser`, which in its turn serves two masters, `UnicodeEscapeEncoding` (which used `Ilist<byte>`) and `Tokenizer` (which used `IList<char>`). In #671 we managed to cover both usecases by a generic method, which was not straightforward to get right so I wasn't sure how it would go here. I am happy to see that it actually went quite fine. Commit e0f7a580f0571ec289bcf5e0c2bdb304c2484f49 shows the result.

It was nice to see that the `IConvertible.ToChar(null)` on `Span<byte>` still works the same as for `IList<byte>`. In fact the whole expression `data[i].ToChar(null)` is somewhat simpler for `Span` than `IList`, probably because `get_Item` call site is simpler. Interesting observation: `get_Item` on `Span` is marginally faster (by one assembly instruction) than on `ReadOnlySpan`. I am guessing that this is because `Span` is being passed by value, while `ReadOnlySpan` by reference. In a loop like this it adds up and probably is more than the extra cost of passing by value. I tried to force the compiler to pass `ReadOnlySpan` by value, by **not** using the `in` parameter modifier, but it had no effect. The generated IL code still had the parameter tagged with `InAttribute`. Maybe because `ReadOnlySpan` as a whole is a `readonly` struct, so compiler "optimization" kicks in. In the end, not a big deal but it is strange to see that the compiler assumes it "knows better" and ignores what the programmer wrote.

In the next commit I go further along the feasibility of spans for decoding functions. Unfortunately, I have encountered some roadblocks there.