### PR TITLE
Accept int parameter(s) in System.Array constructor

### DIFF
--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -36,6 +36,20 @@ namespace IronPython.Runtime.Operations {
         }
 
         [StaticExtensionMethod]
+        public static object __new__(CodeContext context, PythonType pythonType, int length) {
+            Type type = pythonType.UnderlyingSystemType.GetElementType();
+
+            return Array.CreateInstance(type, length);
+        }
+
+        [StaticExtensionMethod]
+        public static object __new__(CodeContext context, PythonType pythonType, params int[] lengths) {
+            Type type = pythonType.UnderlyingSystemType.GetElementType();
+
+            return Array.CreateInstance(type, lengths);
+        }
+
+        [StaticExtensionMethod]
         public static object __new__(CodeContext context, PythonType pythonType, ICollection items) {
             Type type = pythonType.UnderlyingSystemType.GetElementType();
 
@@ -173,7 +187,7 @@ namespace IronPython.Runtime.Operations {
             Type elm = a.GetType().GetElementType();
 
             index.DoSliceAssign(
-                delegate(int idx, object val) {
+                delegate (int idx, object val) {
                     a.SetValue(Converter.Convert(val, elm), idx + a.GetLowerBound(0));
                 },
                 a.Length,
@@ -333,7 +347,7 @@ namespace IronPython.Runtime.Operations {
         private static int GetSliceSize(int start, int stop, int step) {
             // could cause overflow (?)
             return step > 0 ? (stop - start + step - 1) / step : (stop - start + step + 1) / step;
-        }        
+        }
 
         internal static object[] CopyArray(object[] data, int newSize) {
             if (newSize == 0) return ArrayUtils.EmptyObjects;

--- a/Tests/test_array.py
+++ b/Tests/test_array.py
@@ -112,6 +112,22 @@ class ArrayTest(IronPythonTestCase):
             self.assertEqual([i for i in x], [2, 1])
 
     @unittest.skipUnless(is_cli, 'IronPython specific test')
+    def test_constructor(self):
+        array1 = System.Array[int](10)
+        array2 = System.Array.CreateInstance(System.Int32, 10)
+        self.assertEquals(len(array1), len(array2))
+        for i in range(len(array1)):
+            self.assertEquals(array1[i], 0)
+            self.assertEquals(array1[i], array2[i])
+
+        # 2-dimensional
+        array3 = System.Array[System.Byte](3, 4)
+        self.assertEquals(array3.Rank, 2)
+        for x in range(array3.GetLength(0)):
+            for y in range(array3.GetLength(1)):
+                self.assertEquals(array3[x, y], 0)
+
+    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_nonzero_lowerbound(self):
         a = System.Array.CreateInstance(int, (5,), (5,))
         for i in range(5): a[i] = i


### PR DESCRIPTION
Fixes:
```
>>> System.Array[System.Byte](1000)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: expected object with __len__ function, got int
```