### PR TITLE
Fix failing tests on .NET Core 3.1 on macOS

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -5,6 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <MainBuildPrefix Condition=" '$(MainBuildPrefix)' == '' "></MainBuildPrefix>
     <Mono Condition="'$(OS)' != 'Windows_NT'">true</Mono>
+    <MacOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">true</MacOS>
 
     <RootDir>$(MSBuildThisFileDirectory)</RootDir>
     <Solution>$(RootDir)IronPython.sln</Solution>

--- a/Build.proj
+++ b/Build.proj
@@ -5,7 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <MainBuildPrefix Condition=" '$(MainBuildPrefix)' == '' "></MainBuildPrefix>
     <Mono Condition="'$(OS)' != 'Windows_NT'">true</Mono>
-    <MacOS Condition="'$(OS)' == 'Unix' AND Exists('/Applications') AND Exists('/Library') AND Exists('/System') AND Exists('/Volumes')">true</MacOS>
 
     <RootDir>$(MSBuildThisFileDirectory)</RootDir>
     <Solution>$(RootDir)IronPython.sln</Solution>

--- a/Src/IronPythonConsole/IronPythonConsole.csproj
+++ b/Src/IronPythonConsole/IronPythonConsole.csproj
@@ -9,7 +9,6 @@
     <CodeAnalysisRuleSet>..\..\IronPython.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <MacOS Condition="'$(OS)' == 'Unix' AND Exists('/Applications') AND Exists('/Library') AND Exists('/System') AND Exists('/Volumes')">true</MacOS>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +18,7 @@
     </ProjectReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR ('$(TargetFramework)' == 'netcoreapp3.1' AND '$(MacOS)' != '') ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR ('$(TargetFramework)' == 'netcoreapp3.1' AND $([MSBuild]::IsOSPlatform('OSX'))) ">
     <Content Include="ipy.bat" Condition=" '$(OS)' == 'Windows_NT' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -28,7 +27,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR ('$(TargetFramework)' == 'netcoreapp3.1' AND '$(MacOS)' != '') ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR ('$(TargetFramework)' == 'netcoreapp3.1' AND $([MSBuild]::IsOSPlatform('OSX'))) ">
     <StageItem Include="ipy.bat" Condition=" '$(OS)' == 'Windows_NT' "/>
     <StageItem Include="ipy.sh" Condition=" '$(OS)' == 'Unix' "/>
   </ItemGroup>

--- a/Src/IronPythonConsole/IronPythonConsole.csproj
+++ b/Src/IronPythonConsole/IronPythonConsole.csproj
@@ -9,6 +9,7 @@
     <CodeAnalysisRuleSet>..\..\IronPython.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <MacOS Condition="'$(OS)' == 'Unix' AND Exists('/Applications') AND Exists('/Library') AND Exists('/System') AND Exists('/Volumes')">true</MacOS>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,18 +19,18 @@
     </ProjectReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <Content Include="ipy.bat">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR ('$(TargetFramework)' == 'netcoreapp3.1' AND '$(MacOS)' != '') ">
+    <Content Include="ipy.bat" Condition=" '$(OS)' == 'Windows_NT' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="ipy.sh">
+    <Content Include="ipy.sh" Condition=" '$(OS)' == 'Unix' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <StageItem Include="ipy.bat" />
-    <StageItem Include="ipy.sh" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR ('$(TargetFramework)' == 'netcoreapp3.1' AND '$(MacOS)' != '') ">
+    <StageItem Include="ipy.bat" Condition=" '$(OS)' == 'Windows_NT' "/>
+    <StageItem Include="ipy.sh" Condition=" '$(OS)' == 'Unix' "/>
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">


### PR DESCRIPTION
Unfortunately, .NET Core 3.1 on macOS does not produce a standalone executable, so the shell script is still needed.