### PR TITLE
Report SyntaxError for non-ASCII characters in bytes literals

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -154,7 +154,7 @@ namespace IronPython.Modules {
             => escape_decode(StringOps.DoEncodeUtf8(context, data), errors);
 
         public static PythonTuple escape_decode([BytesLike,NotNull]IList<byte> data, string? errors = null) {
-            var res = LiteralParser.ParseBytes(data, 0, data.Count, isRaw: false, normalizeLineEndings: false, getErrorHandler(errors));
+            var res = LiteralParser.ParseBytes(data, 0, data.Count, isRaw: false, isAscii: false, normalizeLineEndings: false, getErrorHandler(errors));
 
             return PythonTuple.MakeTuple(Bytes.Make(res.ToArray()), data.Count);
 

--- a/Src/IronPython/Compiler/Tokenizer.cs
+++ b/Src/IronPython/Compiler/Tokenizer.cs
@@ -682,7 +682,7 @@ namespace IronPython.Compiler {
                     var contents = LiteralParser.ParseString(_buffer, start, length, isRaw, !isRaw, !_disableLineFeedLineSeparator);
                     return new ConstantValueToken(contents);
                 } else {
-                    List<byte> data = LiteralParser.ParseBytes(_buffer, start, length, isRaw, !_disableLineFeedLineSeparator);
+                    List<byte> data = LiteralParser.ParseBytes(_buffer, start, length, isRaw, isAscii: true, !_disableLineFeedLineSeparator);
                     if (data.Count == 0) {
                         return new ConstantValueToken(Bytes.Empty);
                     }
@@ -696,6 +696,10 @@ namespace IronPython.Compiler {
             } catch (ValueErrorException ex) {
                 var msg = $"(value error) {ex.Message}";
                 ReportSyntaxError(BufferTokenSpan, msg, ErrorCodes.NoCaret);
+                return new ErrorToken(msg);
+            } catch (SyntaxErrorException ex) {
+                var msg = ex.Message;
+                ReportSyntaxError(BufferTokenSpan, msg, ErrorCodes.SyntaxError);
                 return new ErrorToken(msg);
             }
         }

--- a/Src/IronPython/Runtime/LiteralParser.cs
+++ b/Src/IronPython/Runtime/LiteralParser.cs
@@ -226,7 +226,7 @@ namespace IronPython.Runtime {
 
         internal delegate IReadOnlyList<byte> ParseBytesErrorHandler<T>(IList<T> data, int start, int end);
 
-        internal static List<byte> ParseBytes<T>(IList<T> data, int start, int length, bool isRaw, bool normalizeLineEndings, ParseBytesErrorHandler<T> errorHandler = default) where T : IConvertible {
+        internal static List<byte> ParseBytes<T>(IList<T> data, int start, int length, bool isRaw, bool isAscii, bool normalizeLineEndings, ParseBytesErrorHandler<T> errorHandler = default) where T : IConvertible {
             Debug.Assert(data != null);
             Debug.Assert(start + length <= data.Count);
 
@@ -298,6 +298,9 @@ namespace IronPython.Runtime {
                             buf.Add((byte)val);
                             continue;
                         default:
+                            if (isAscii && ch >= 0x80) {
+                                throw PythonOps.SyntaxError("bytes can only contain ASCII literal characters.");
+                            }
                             buf.Add((byte)'\\');
                             buf.Add((byte)ch);
                             continue;
@@ -308,10 +311,12 @@ namespace IronPython.Runtime {
                         i++;
                     }
                     buf.Add((byte)'\n');
+                } else if (isAscii && ch >= 0x80) {
+                    throw PythonOps.SyntaxError("bytes can only contain ASCII literal characters.");
                 } else {
                     buf.Add((byte)ch);
                 }
-            }            
+            }
 
             return buf;
         }

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -64,6 +64,10 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(codecs.escape_decode(b"ab\\\rc"), (b"ab\\\rc", 5))
         self.assertEqual(codecs.escape_decode(b"ab\\\r\\\nc"), (b"ab\\\rc", 7))
 
+        self.assertEqual(codecs.escape_decode("ÿ".encode('latin-1')), (b'\xff', 1))
+        self.assertEqual(codecs.escape_decode("\\ÿ".encode('latin-1')), (b'\\\xff', 2))
+        self.assertEqual(codecs.escape_decode("\\\\ÿ".encode('latin-1')), (b'\\\xff', 3))
+
     def test_escape_decode_errors(self):
         self.assertEqual(codecs.escape_decode("abc", None), (b"abc", 3))
 

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -1426,4 +1426,11 @@ class BytesTest(IronPythonTestCase):
     def test_add(self):
         self.assertEqual(bytearray(b"abc") + memoryview(b"def"), b"abcdef")
 
+    def test_literals(self):
+        s = "'ÿ'"
+        for prefix in ["b", "rb"]:
+            self.assertRaises(SyntaxError, eval, prefix + s)
+            self.assertRaises(SyntaxError, eval, prefix + "\\" + s)
+            self.assertRaises(SyntaxError, eval, prefix + "\\\\" + s)
+
 run_test(__name__)


### PR DESCRIPTION
Was:
```
>>> print(b"ÿ")
b'\xff'
```
Now:
```
>>> print(b"ÿ")
  File "<stdin>", line 1
    print(b"ÿ")
          ^
SyntaxError: bytes can only contain ASCII literal characters.
```