### PR TITLE
Fix split/rsplit

### DIFF
--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -637,18 +637,10 @@ namespace IronPython.Runtime {
             }
         }
 
-        public PythonList rsplit() {
+        public PythonList rsplit([BytesLike]IList<byte>? sep = null, int maxsplit = -1) {
             lock (this) {
-                return _bytes.SplitInternal(null, -1, x => new ByteArray(x));
+                return _bytes.RightSplit(sep, maxsplit, x => new ByteArray(new List<byte>(x)));
             }
-        }
-
-        public PythonList rsplit([BytesLike]IList<byte>? sep) {
-            return rsplit(sep, -1);
-        }
-
-        public PythonList rsplit([BytesLike]IList<byte>? sep, int maxsplit) {
-            return _bytes.RightSplit(sep, maxsplit, x => new ByteArray(new List<byte>(x)));
         }
 
         public ByteArray rstrip() {
@@ -666,17 +658,7 @@ namespace IronPython.Runtime {
             }
         }
 
-        public PythonList split() {
-            lock (this) {
-                return _bytes.SplitInternal(null, -1, x => new ByteArray(x));
-            }
-        }
-
-        public PythonList split([BytesLike]IList<byte>? sep) {
-            return split(sep, -1);
-        }
-
-        public PythonList split([BytesLike]IList<byte>? sep, int maxsplit) {
+        public PythonList split([BytesLike]IList<byte>? sep = null, int maxsplit = -1) {
             lock (this) {
                 return _bytes.Split(sep, maxsplit, x => new ByteArray(x));
             }

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -416,15 +416,7 @@ namespace IronPython.Runtime {
             return new PythonTuple(obj);
         }
 
-        public PythonList rsplit() {
-            return _bytes.SplitInternal(null, -1, x => new Bytes(x));
-        }
-
-        public PythonList rsplit([BytesLike]IList<byte>? sep) {
-            return rsplit(sep, -1);
-        }
-
-        public PythonList rsplit([BytesLike]IList<byte>? sep, int maxsplit) {
+        public PythonList rsplit([BytesLike]IList<byte>? sep = null, int maxsplit = -1) {
             return _bytes.RightSplit(sep, maxsplit, x => new Bytes(new List<byte>(x)));
         }
 
@@ -439,15 +431,7 @@ namespace IronPython.Runtime {
             return res == null ? this : new Bytes(res);
         }
 
-        public PythonList split() {
-            return _bytes.SplitInternal(null, -1, x => new Bytes(x));
-        }
-
-        public PythonList split([BytesLike]IList<byte>? sep) {
-            return split(sep, -1);
-        }
-
-        public PythonList split([BytesLike]IList<byte>? sep, int maxsplit) {
+        public PythonList split([BytesLike]IList<byte>? sep = null, int maxsplit = -1) {
             return _bytes.Split(sep, maxsplit, x => new Bytes(x));
         }
 

--- a/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
+++ b/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
@@ -286,35 +286,28 @@ namespace IronPython.Runtime.Operations {
             return -1;
         }
 
-        internal static List<byte>[] Split(this IList<byte> str, IList<byte>? separators, int maxComponents, StringSplitOptions options) {
+        internal static List<byte>[] Split(this IList<byte> str, IList<byte>? separator, int maxComponents, StringSplitOptions options) {
             bool keep_empty = (options & StringSplitOptions.RemoveEmptyEntries) != StringSplitOptions.RemoveEmptyEntries;
 
-            if (separators == null) {
+            if (separator == null) {
                 Debug.Assert(!keep_empty);
                 return SplitOnWhiteSpace(str, maxComponents);
             }
 
-            List<List<byte>> result = new List<List<byte>>(maxComponents == Int32.MaxValue ? 1 : maxComponents + 1);
+            List<List<byte>> result = new List<List<byte>>(maxComponents + 1);
 
             int i = 0;
             int next;
-            while (maxComponents > 1 && i < str.Count && (next = IndexOfAny(str, separators, i)) != -1) {
+            while (maxComponents > 1 && i < str.Count && (next = str.IndexOf(separator, i)) != -1) {
                 if (next > i || keep_empty) {
                     result.Add(Substring(str, i, next - i));
                     maxComponents--;
                 }
 
-                i = next + separators.Count;
+                i = next + separator.Count;
             }
 
             if (i < str.Count || keep_empty) {
-                /*while (i < str.Count) {
-                    if (!separators.Contains(str[i])) {
-                        break;
-                    }
-
-                    i++;
-                }*/
                 result.Add(Substring(str, i));
             }
 
@@ -322,7 +315,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static List<byte>[] SplitOnWhiteSpace(this IList<byte> str, int maxComponents) {
-            var result = new List<List<byte>>(maxComponents == Int32.MaxValue ? 1 : maxComponents + 1);
+            var result = new List<List<byte>>(maxComponents + 1);
 
             int i = 0;
             int next;
@@ -450,6 +443,10 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static PythonList RightSplit(this IList<byte> bytes, IList<byte>? sep, int maxsplit, Func<IList<byte>, IList<byte>> ctor) {
+            if (sep == null && maxsplit < 0) {
+                // in this case RightSplit becomes equivalent of Split
+                return SplitInternal(bytes, null, -1, ctor);
+            }
             //  rsplit works like split but needs to split from the right;
             //  reverse the original string (and the sep), split, reverse 
             //  the split list and finally reverse each element of the list
@@ -811,8 +808,6 @@ namespace IronPython.Runtime.Operations {
 
             if (sep.Count == 0) {
                 throw PythonOps.ValueError("empty separator");
-            } else if (sep.Count == 1) {
-                return SplitInternal(bytes, new byte[] { sep[0] }, maxsplit, ctor);
             } else {
                 return SplitInternal(bytes, sep, maxsplit, ctor);
             }
@@ -830,7 +825,7 @@ namespace IronPython.Runtime.Operations {
             //  If the optional second argument sep is absent or None, the words are separated 
             //  by arbitrary strings of whitespace characters (space, tab, newline, return, formfeed);
 
-            List<byte>[] r = bytes.Split(separator, (maxsplit < 0) ? Int32.MaxValue : maxsplit + 1, GetStringSplitOptions(separator));
+            List<byte>[] r = bytes.Split(separator, (maxsplit < 0 || maxsplit > bytes.Count) ? bytes.Count + 1 : maxsplit + 1, GetStringSplitOptions(separator));
 
             PythonList ret = PythonOps.MakeEmptyList(r.Length);
             foreach (List<byte> s in r) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -971,16 +971,11 @@ namespace IronPython.Runtime.Operations {
             return new PythonTuple(obj);
         }
 
-        //  when no maxsplit arg is given then just use split
-        public static PythonList rsplit(this string self) {
-            return SplitInternal(self, (char[])null, -1);
-        }
-
-        public static PythonList rsplit(this string self, string sep) {
-            return rsplit(self, sep, -1);
-        }
-
-        public static PythonList rsplit(this string self, string sep, int maxsplit) {
+        public static PythonList rsplit(this string self, string sep = null, int maxsplit = -1) {
+            if (sep == null && maxsplit < 0) {
+                // in this case rsplit becomes equivalent of split
+                return SplitInternal(self, (char[])null, -1);
+            }
             //  rsplit works like split but needs to split from the right;
             //  reverse the original string (and the sep), split, reverse 
             //  the split list and finally reverse each element of the list
@@ -1009,15 +1004,7 @@ namespace IronPython.Runtime.Operations {
             return self.TrimEnd(chars.ToCharArray());
         }
 
-        public static PythonList split(this string self) {
-            return SplitInternal(self, (char[])null, -1);
-        }
-
-        public static PythonList split(this string self, string sep) {
-            return split(self, sep, -1);
-        }
-
-        public static PythonList split(this string self, string sep, int maxsplit) {
+        public static PythonList split(this string self, string sep = null, int maxsplit = -1) {
             if (sep == null) {
                 if (maxsplit == 0) {
                     // Corner case for CPython compatibility


### PR DESCRIPTION
Several related bugs in `split`/`rsplit` fixed, mostly for `bytes`/`bytearray`.

Assorted examples:

Was:
```
>>> import sys
>>> b'<tag></></tag>'.split(b'</>')
[b'', b'g', b'', b'tag', b'']
>>> b'A,B,C,D'.split(b',', sys.maxsize-100)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
MemoryError: Array dimensions exceeded supported range.
>>> b'A B C'.split(maxsplit=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: split() got an unexpected keyword argument 'maxsplit'
```
Now:
```
>>> import sys
>>> b'<tag></></tag>'.split(b'</>')
[b'<tag>', b'</tag>']
>>> b'A,B,C,D'.split(b',', sys.maxsize-100)
[b'A', b'B', b'C', b'D']
>>> b'A B C'.split(maxsplit=1)
[b'A', b'B C']
```