### PR TITLE
Fix list assignment using extended slice with big integers

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1185,6 +1185,8 @@ namespace IronPython.Runtime.Operations {
             int length, object start, object stop, object step,
             out int ostart, out int ostop, out int ostep
         ) {
+            Debug.Assert(length >= 0);
+
             if (step == null) {
                 ostep = 1;
             } else {
@@ -1201,7 +1203,7 @@ namespace IronPython.Runtime.Operations {
                 if (ostart < 0) {
                     ostart += length;
                     if (ostart < 0) {
-                        ostart = ostep > 0 ? Math.Min(length, 0) : Math.Min(length - 1, -1);
+                        ostart = ostep > 0 ? 0 : -1;
                     }
                 } else if (ostart >= length) {
                     ostart = ostep > 0 ? length : length - 1;
@@ -1215,7 +1217,7 @@ namespace IronPython.Runtime.Operations {
                 if (ostop < 0) {
                     ostop += length;
                     if (ostop < 0) {
-                        ostop = ostep > 0 ? Math.Min(length, 0) : Math.Min(length - 1, -1);
+                        ostop = ostep > 0 ? 0 : -1;
                     }
                 } else if (ostop >= length) {
                     ostop = ostep > 0 ? length : length - 1;
@@ -1227,6 +1229,8 @@ namespace IronPython.Runtime.Operations {
             long length, long? start, long? stop, long? step,
             out long ostart, out long ostop, out long ostep, out long ocount
         ) {
+            Debug.Assert(length >= 0);
+
             if (step == null) {
                 ostep = 1;
             } else if (step == 0) {
@@ -1242,7 +1246,7 @@ namespace IronPython.Runtime.Operations {
                 if (ostart < 0) {
                     ostart += length;
                     if (ostart < 0) {
-                        ostart = ostep > 0 ? Math.Min(length, 0) : Math.Min(length - 1, -1);
+                        ostart = ostep > 0 ? 0 : -1;
                     }
                 } else if (ostart >= length) {
                     ostart = ostep > 0 ? length : length - 1;
@@ -1256,15 +1260,16 @@ namespace IronPython.Runtime.Operations {
                 if (ostop < 0) {
                     ostop += length;
                     if (ostop < 0) {
-                        ostop = ostep > 0 ? Math.Min(length, 0) : Math.Min(length - 1, -1);
+                        ostop = ostep > 0 ? 0 : -1;
                     }
                 } else if (ostop >= length) {
                     ostop = ostep > 0 ? length : length - 1;
                 }
             }
 
-            ocount = Math.Max(0, ostep > 0 ? (ostop - ostart + ostep - 1) / ostep
-                                           : (ostop - ostart + ostep + 1) / ostep);
+            // ostep can be close long.MaxValue or long.MinValue so unconditional (ostop - ostart + ostep) could overflow
+            ocount = ostep > 0 ? (ostop <= ostart ? 0 : ostep >= (ostop - ostart) ? 1 : checked(ostop - ostart + ostep - 1) / ostep)
+                               : (ostop >= ostart ? 0 : ostep <= (ostop - ostart) ? 1 : checked(ostop - ostart + ostep + 1) / ostep);
         }
 
         public static int FixIndex(int v, int len) {

--- a/Src/IronPython/Runtime/Slice.cs
+++ b/Src/IronPython/Runtime/Slice.cs
@@ -101,7 +101,8 @@ namespace IronPython.Runtime {
 
         private static void DoSliceAssign(SliceAssign assign, int start, int stop, int step, object? value) {
             stop = step > 0 ? Math.Max(stop, start) : Math.Min(stop, start);
-            int n = Math.Max(0, (step > 0 ? (stop - start + step - 1) : (stop - start + step + 1)) / step);
+            // start, stop, or step may be near int.MaxValue so perform calculations in long
+            int n = (int)Math.Max(0, (step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
             // fast paths, if we know the size then we can
             // do this quickly.
             if (value is IList list) {


### PR DESCRIPTION
Was:
```
>>> plist = [1, 2]
>>> plist[0:None:2<<222] = [0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: too many items in the enumerator need 0 have 1
>>> plist[0:None:2<<222] = [111, 222]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: too many items in the enumerator need 0 have 2
```
Now:
```
>>> plist = [1, 2]
>>> plist[0:None:2<<222] = [0]
>>> plist
[0, 2]
>>> plist[0:None:2<<222] = [111, 222]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: too many items in the enumerator need 1 have 2
```
Which is the same as CPython, except that the message for `ValueError` reads `attempt to assign sequence of size 2 to extended slice of size 1`. Do we care about the error message?

The patched code seems quite old. The same bug exists in IronPython 2.

Similar issues are with assigning slices of `bytesarray` and `memoryview`, but I am reluctant of submitting any updates of code in that area until the status of #765 is resolved, to avoid merge conflicts.