### PR TITLE
Fix sequence assignments using extended slice with big integers

### DIFF
--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1027,19 +1027,17 @@ namespace IronPython.Runtime {
 
                         IList<byte> castedVal = GetBytes(value);
 
-                        int start, stop, step;
-                        slice.indices(_bytes.Count, out start, out stop, out step);
-
-                        int n = (int)((step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
+                        int start, stop, step, count;
+                        slice.GetIndicesAndCount(_bytes.Count, out start, out stop, out step, out count);
 
                         // we don't use slice.Assign* helpers here because bytearray has different assignment semantics.
 
-                        if (list.Count < n) {
-                            throw PythonOps.ValueError("too few items in the enumerator. need {0} have {1}", n, castedVal.Count);
+                        if (list.Count < count) {
+                            throw PythonOps.ValueError("too few items in the enumerator. need {0} have {1}", count, castedVal.Count);
                         }
 
                         for (int i = 0, index = start; i < castedVal.Count; i++, index += step) {
-                            if (i >= n) {
+                            if (i >= count) {
                                 if (index == _bytes.Count) {
                                     _bytes.Add(castedVal[i]);
                                 } else {

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1030,7 +1030,7 @@ namespace IronPython.Runtime {
                         int start, stop, step;
                         slice.indices(_bytes.Count, out start, out stop, out step);
 
-                        int n = (step > 0 ? (stop - start + step - 1) : (stop - start + step + 1)) / step;
+                        int n = (int)((step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
 
                         // we don't use slice.Assign* helpers here because bytearray has different assignment semantics.
 

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -79,9 +79,9 @@ namespace IronPython.Runtime {
 
         private int numberOfElements() {
             if (_end != null) {
-                return GetSliceLength(_start, _end.Value, CoalesceToInt32((long)_step * _itemsize));
+                return PythonOps.GetSliceCount(_start, _end.Value, ((long)_step * _itemsize).ClampToInt32());
             }
-            return GetSliceLength(0, _buffer.ItemCount * (int)_buffer.ItemSize, CoalesceToInt32((long)_step * _itemsize));
+            return PythonOps.GetSliceCount(0, _buffer.ItemCount * (int)_buffer.ItemSize, ((long)_step * _itemsize).ClampToInt32());
         }
 
         public int __len__() {
@@ -491,15 +491,15 @@ namespace IronPython.Runtime {
         public object this[[NotNull]Slice slice] {
             get {
                 CheckBuffer();
-                int start, stop, step;
-                FixSlice(slice, __len__(), out start, out stop, out step);
+                int start, stop, step, count;
+                FixSlice(slice, __len__(), out start, out stop, out step, out count);
 
                 List<int> dimensions = new List<int>();
 
                 // When a multidimensional memoryview is sliced, the slice
                 // applies to only the first dimension. Therefore, other
                 // dimensions are inherited.
-                dimensions.Add(GetSliceLength(start, stop, step));
+                dimensions.Add(count);
 
                 // In a 1-dimensional memoryview, the difference in bytes
                 // between the position of mv[x] and mv[x + 1] is guaranteed
@@ -516,7 +516,7 @@ namespace IronPython.Runtime {
 
                 int newStart = _start + start * firstIndexWidth;
                 int newEnd = _start + stop * firstIndexWidth;
-                int newStep = CoalesceToInt32((long)_step * step);
+                int newStep = ((long)_step * step).ClampToInt32();
 
                 PythonTuple newShape = PythonOps.MakeTupleFromSequence(dimensions);
 
@@ -532,14 +532,13 @@ namespace IronPython.Runtime {
                     throw PythonOps.NotImplementedError("memoryview assignments are restricted to ndim = 1");
                 }
 
-                int start, stop, step;
-                FixSlice(slice, __len__(), out start, out stop, out step);
+                int start, stop, step, sliceCnt;
+                FixSlice(slice, __len__(), out start, out stop, out step, out sliceCnt);
 
                 slice = new Slice(start, stop, step);
 
-                int sliceLen = GetSliceLength(start, stop, step);
                 int newLen = PythonOps.Length(value);
-                if (sliceLen != newLen) {
+                if (sliceCnt != newLen) {
                     throw PythonOps.ValueError("cannot resize memory view");
                 }
 
@@ -555,8 +554,8 @@ namespace IronPython.Runtime {
         /// MemoryView slicing is somewhat different and more restricted than
         /// standard slicing.
         /// </summary>
-        private static void FixSlice(Slice slice, int len, out int start, out int stop, out int step) {
-            slice.indices(len, out start, out stop, out step);
+        private static void FixSlice(Slice slice, int len, out int start, out int stop, out int step, out int count) {
+            slice.GetIndicesAndCount(len, out start, out stop, out step, out count);
 
             if (stop < start && step >= 0) {
                 // wrapped iteration is interpreted as empty slice
@@ -564,15 +563,6 @@ namespace IronPython.Runtime {
             } else if (stop > start && step < 0) {
                 stop = start;
             }
-        }
-
-        private static int GetSliceLength(int start, int stop, int step) {
-            // calculations in int could cause overflow, so using long instead
-            return (int)((step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
-        }
-
-        private static int CoalesceToInt32(long value) {
-            return (int)Math.Max(Math.Min(value, int.MaxValue), int.MinValue);
         }
 
         public object this[[NotNull]PythonTuple index] {

--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -298,7 +298,7 @@ namespace IronPython.Runtime.Operations {
                 return GetSlice(data, start, stop);
             }
 
-            int size = GetSliceSize(start, stop, step);
+            int size = PythonOps.GetSliceCount(start, stop, step);
             if (size <= 0) return ArrayUtils.EmptyObjects;
 
             object[] res = new object[size];
@@ -334,7 +334,7 @@ namespace IronPython.Runtime.Operations {
                 Array.Copy(data, start + data.GetLowerBound(0), ret, 0, n);
                 return ret;
             } else {
-                int n = GetSliceSize(start, stop, step);
+                int n = PythonOps.GetSliceCount(start, stop, step);
                 Array ret = Array.CreateInstance(data.GetType().GetElementType(), n);
                 int ri = 0;
                 for (int i = 0, index = start; i < n; i++, index += step) {
@@ -342,11 +342,6 @@ namespace IronPython.Runtime.Operations {
                 }
                 return ret;
             }
-        }
-
-        private static int GetSliceSize(int start, int stop, int step) {
-            // calculations in int could cause overflow, so using long instead
-            return (int)((step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
         }
 
         internal static object[] CopyArray(object[] data, int newSize) {

--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -345,8 +345,8 @@ namespace IronPython.Runtime.Operations {
         }
 
         private static int GetSliceSize(int start, int stop, int step) {
-            // could cause overflow (?)
-            return step > 0 ? (stop - start + step - 1) / step : (stop - start + step + 1) / step;
+            // calculations in int could cause overflow, so using long instead
+            return (int)((step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
         }
 
         internal static object[] CopyArray(object[] data, int newSize) {

--- a/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
+++ b/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
@@ -913,20 +913,20 @@ namespace IronPython.Runtime.Operations {
                     return null;
                 }
 
-                int icnt = (stop - start + step - 1) / step;
+                int icnt = (int)(((long)stop - start + step - 1) / step);
                 newData = new List<byte>(icnt);
-                for (int i = start; i < stop; i += step) {
-                    newData.Add(bytes[i]);
+                for (long i = start; i < stop; i += step) {
+                    newData.Add(bytes[(int)i]);
                 }
             } else {
                 if (start < stop) {
                     return null;
                 }
 
-                int icnt = (stop - start + step + 1) / step;
+                int icnt = (int)(((long)stop - start + step + 1) / step);
                 newData = new List<byte>(icnt);
-                for (int i = start; i > stop; i += step) {
-                    newData.Add(bytes[i]);
+                for (long i = start; i > stop; i += step) {
+                    newData.Add(bytes[(int)i]);
                 }
             }
 

--- a/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
+++ b/Src/IronPython/Runtime/Operations/IListOfByteOps.cs
@@ -901,8 +901,8 @@ namespace IronPython.Runtime.Operations {
                 throw PythonOps.TypeError("indices must be slices or integers");
             }
 
-            int start, stop, step;
-            slice.indices(bytes.Count, out start, out stop, out step);
+            int start, stop, step, icnt;
+            slice.GetIndicesAndCount(bytes.Count, out start, out stop, out step, out icnt);
             if (step == 1) {
                 return stop > start ? bytes.Substring(start, stop - start) : null;
             }
@@ -913,7 +913,6 @@ namespace IronPython.Runtime.Operations {
                     return null;
                 }
 
-                int icnt = (int)(((long)stop - start + step - 1) / step);
                 newData = new List<byte>(icnt);
                 for (long i = start; i < stop; i += step) {
                     newData.Add(bytes[(int)i]);
@@ -923,7 +922,6 @@ namespace IronPython.Runtime.Operations {
                     return null;
                 }
 
-                int icnt = (int)(((long)stop - start + step + 1) / step);
                 newData = new List<byte>(icnt);
                 for (long i = start; i > stop; i += step) {
                     newData.Add(bytes[(int)i]);

--- a/Src/IronPython/Runtime/Operations/ListOfTOps.cs
+++ b/Src/IronPython/Runtime/Operations/ListOfTOps.cs
@@ -123,8 +123,8 @@ namespace IronPython.Runtime.Operations {
 
         public static List<T> __getitem__(List<T> l, Slice slice) {
             if (slice == null) throw PythonOps.TypeError("List<T> indices must be slices or integers");
-            int start, stop, step;
-            slice.indices(l.Count, out start, out stop, out step);
+            int start, stop, step, icnt;
+            slice.GetIndicesAndCount(l.Count, out start, out stop, out step, out icnt);
             if (step == 1) {
                 return stop > start ? l.Skip(start).Take(stop - start).ToList() : new List<T>();
             } else {
@@ -132,7 +132,6 @@ namespace IronPython.Runtime.Operations {
                 if (step > 0) {
                     if (start >= stop) return new List<T>();
 
-                    int icnt = (int)(((long)stop - start + step - 1) / step);
                     newData = new List<T>(icnt);
                     for (long i = start; i < stop; i += step) {
                         newData.Add(l[(int)i]);
@@ -140,7 +139,6 @@ namespace IronPython.Runtime.Operations {
                 } else {
                     if (start <= stop) return new List<T>();
 
-                    int icnt = (int)(((long)stop - start + step + 1) / step);
                     newData = new List<T>(icnt);
                     for (long i = start; i > stop; i += step) {
                         newData.Add(l[(int)i]);

--- a/Src/IronPython/Runtime/Operations/ListOfTOps.cs
+++ b/Src/IronPython/Runtime/Operations/ListOfTOps.cs
@@ -130,20 +130,20 @@ namespace IronPython.Runtime.Operations {
             } else {
                 List<T> newData;
                 if (step > 0) {
-                    if (start > stop) return new List<T>();
+                    if (start >= stop) return new List<T>();
 
-                    int icnt = (stop - start + step - 1) / step;
+                    int icnt = (int)(((long)stop - start + step - 1) / step);
                     newData = new List<T>(icnt);
-                    for (int i = start; i < stop; i += step) {
-                        newData.Add(l[i]);
+                    for (long i = start; i < stop; i += step) {
+                        newData.Add(l[(int)i]);
                     }
                 } else {
-                    if (start < stop) return new List<T>();
+                    if (start <= stop) return new List<T>();
 
-                    int icnt = (stop - start + step + 1) / step;
+                    int icnt = (int)(((long)stop - start + step + 1) / step);
                     newData = new List<T>(icnt);
-                    for (int i = start; i > stop; i += step) {
-                        newData.Add(l[i]);
+                    for (long i = start; i > stop; i += step) {
+                        newData.Add(l[(int)i]);
                     }
                 }
                 return newData;

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1150,7 +1150,7 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        public static int ClampToInt32(this long value) {
+        internal static int ClampToInt32(this long value) {
             return (int)Math.Max(Math.Min(value, int.MaxValue), int.MinValue);
         }
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1150,6 +1150,10 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
+        public static int ClampToInt32(this long value) {
+            return (int)Math.Max(Math.Min(value, int.MaxValue), int.MinValue);
+        }
+
         public static bool IsMappingType(CodeContext/*!*/ context, object o) {
             if (o is IDictionary || o is PythonDictionary || o is IDictionary<object, object>) {
                 return true;
@@ -1181,7 +1185,19 @@ namespace IronPython.Runtime.Operations {
             return v;
         }
 
-        public static void FixSlice(
+        internal static int GetSliceCount(int start, int stop, int step) {
+            stop = step > 0 ? Math.Max(stop, start) : Math.Min(stop, start);
+            // calculations on int could cause overflow, so using long instead
+            return (int)((step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
+        }
+
+        private static long GetSliceCount(long start, long stop, long step) {
+            // ostep can be close long.MaxValue or long.MinValue so unconditional (ostop - ostart + ostep) could overflow
+            return step > 0 ? (stop <= start ? 0 : step >= (stop - start) ? 1 : checked(stop - start + step - 1) / step)
+                             : (stop >= start ? 0 : step <= (stop - start) ? 1 : checked(stop - start + step + 1) / step);
+        }
+
+        internal static void FixSlice(
             int length, object start, object stop, object step,
             out int ostart, out int ostop, out int ostep
         ) {
@@ -1225,7 +1241,7 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        public static void FixSlice(
+        internal static void FixSlice(
             long length, long? start, long? stop, long? step,
             out long ostart, out long ostop, out long ostep, out long ocount
         ) {
@@ -1267,9 +1283,7 @@ namespace IronPython.Runtime.Operations {
                 }
             }
 
-            // ostep can be close long.MaxValue or long.MinValue so unconditional (ostop - ostart + ostep) could overflow
-            ocount = ostep > 0 ? (ostop <= ostart ? 0 : ostep >= (ostop - ostart) ? 1 : checked(ostop - ostart + ostep - 1) / ostep)
-                               : (ostop >= ostart ? 0 : ostep <= (ostop - ostart) ? 1 : checked(ostop - ostart + ostep + 1) / ostep);
+            ocount = GetSliceCount(ostart, ostop, ostep);
         }
 
         public static int FixIndex(int v, int len) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -333,23 +333,22 @@ namespace IronPython.Runtime.Operations {
             if (step == 1) {
                 return stop > start ? s.Substring(start, stop - start) : String.Empty;
             } else {
-                int index = 0;
                 char[] newData;
                 if (step > 0) {
-                    if (start > stop) return String.Empty;
+                    if (start >= stop) return String.Empty;
 
-                    int icnt = (stop - start + step - 1) / step;
+                    int icnt = (int)(((long)stop - start + step - 1) / step);
                     newData = new char[icnt];
-                    for (int i = start; i < stop; i += step) {
-                        newData[index++] = s[i];
+                    for (int i = 0, index = start; i < icnt; i++, index += step) {
+                        newData[i] = s[index];
                     }
                 } else {
-                    if (start < stop) return String.Empty;
+                    if (start <= stop) return String.Empty;
 
-                    int icnt = (stop - start + step + 1) / step;
+                    int icnt = (int)(((long)stop - start + step + 1) / step);
                     newData = new char[icnt];
-                    for (int i = start; i > stop; i += step) {
-                        newData[index++] = s[i];
+                    for (int i = 0, index = start; i < icnt; i++, index += step) {
+                        newData[i] = s[index];
                     }
                 }
                 return new string(newData);

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -328,8 +328,8 @@ namespace IronPython.Runtime.Operations {
         [SpecialName]
         public static string GetItem(string s, Slice slice) {
             if (slice == null) throw PythonOps.TypeError("string indices must be slices or integers");
-            int start, stop, step;
-            slice.indices(s.Length, out start, out stop, out step);
+            int start, stop, step, icnt;
+            slice.GetIndicesAndCount(s.Length, out start, out stop, out step, out icnt);
             if (step == 1) {
                 return stop > start ? s.Substring(start, stop - start) : String.Empty;
             } else {
@@ -337,7 +337,6 @@ namespace IronPython.Runtime.Operations {
                 if (step > 0) {
                     if (start >= stop) return String.Empty;
 
-                    int icnt = (int)(((long)stop - start + step - 1) / step);
                     newData = new char[icnt];
                     for (int i = 0, index = start; i < icnt; i++, index += step) {
                         newData[i] = s[index];
@@ -345,7 +344,6 @@ namespace IronPython.Runtime.Operations {
                 } else {
                     if (start <= stop) return String.Empty;
 
-                    int icnt = (int)(((long)stop - start + step + 1) / step);
                     newData = new char[icnt];
                     for (int i = 0, index = start; i < icnt; i++, index += step) {
                         newData[i] = s[index];

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -416,8 +416,8 @@ namespace IronPython.Runtime {
         [System.Diagnostics.CodeAnalysis.NotNull]
         public virtual object? this[[NotNull]Slice slice] {
             get {
-                int start, stop, step;
-                slice.indices(_size, out start, out stop, out step);
+                int start, stop, step, count;
+                slice.GetIndicesAndCount(_size, out start, out stop, out step, out count);
 
                 if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) return new PythonList();
 
@@ -426,12 +426,10 @@ namespace IronPython.Runtime {
                     lock (this) ret = ArrayOps.GetSlice(_data, start, stop);
                     return new PythonList(ret);
                 } else {
-                    // start/stop/step could be near Int32.MaxValue, and simply addition could cause overflow
-                    int n = (int)(step > 0 ? (0L + stop - start + step - 1) / step : (0L + stop - start + step + 1) / step);
-                    object?[] ret = new object[n];
+                    object?[] ret = new object[count];
                     lock (this) {
                         int ri = 0;
-                        for (int i = 0, index = start; i < n; i++, index += step) {
+                        for (int i = 0, index = start; i < count; i++, index += step) {
                             ret[ri++] = _data[index];
                         }
                     }

--- a/Src/IronPython/Runtime/PythonRange.cs
+++ b/Src/IronPython/Runtime/PythonRange.cs
@@ -95,7 +95,7 @@ namespace IronPython.Runtime {
             }
         }
 
-        private int Compute(int index) {
+        private long Compute(long index) {
             return index * step + start;
         }
 
@@ -104,7 +104,7 @@ namespace IronPython.Runtime {
             get {
                 int ostart, ostop, ostep;
                 slice.indices(_length, out ostart, out ostop, out ostep);
-                return new PythonRange(Compute(ostart), Compute(ostop), step * ostep);
+                return new PythonRange(Compute(ostart), Compute(ostop), (long)step * ostep);
             }
         }
 

--- a/Src/IronPython/Runtime/Slice.cs
+++ b/Src/IronPython/Runtime/Slice.cs
@@ -100,13 +100,11 @@ namespace IronPython.Runtime {
         }
 
         private static void DoSliceAssign(SliceAssign assign, int start, int stop, int step, object? value) {
-            stop = step > 0 ? Math.Max(stop, start) : Math.Min(stop, start);
-            // start, stop, or step may be near int.MaxValue so perform calculations in long
-            int n = (int)Math.Max(0, (step > 0 ? ((long)stop - start + step - 1) : ((long)stop - start + step + 1)) / step);
             // fast paths, if we know the size then we can
             // do this quickly.
             if (value is IList list) {
-                ListSliceAssign(assign, start, n, step, list);
+                int count = PythonOps.GetSliceCount(start, stop, step);
+                ListSliceAssign(assign, start, count, step, list);
             } else {
                 OtherSliceAssign(assign, start, stop, step, value);
             }
@@ -129,6 +127,11 @@ namespace IronPython.Runtime {
             while (enumerator.MoveNext()) sliceData.AddNoLock(enumerator.Current);
 
             DoSliceAssign(assign, start, stop, step, sliceData);
+        }
+
+        internal void GetIndicesAndCount(int length, out int ostart, out int ostop, out int ostep, out int count) {
+            indices(length, out ostart, out ostop, out ostep);
+            count = PythonOps.GetSliceCount(ostart, ostop, ostep);
         }
 
         private int Compare(Slice obj) {


### PR DESCRIPTION
This is the continuation of #777. Hopefully I have fixed all places. I see a lot of similar, but ultimately tricky calculations being done in different places, so I propose to move `GetSliceLength` and `CoalesceToInt32` from `MemoryView` to `PythonOps` and let the rest of the code to use those functions.