### PR TITLE
Support error handler in constructing bytes from string with encoding

### DIFF
--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -67,8 +67,12 @@ namespace IronPython.Runtime {
             throw PythonOps.TypeError("string argument without an encoding");
         }
 
-        public Bytes(CodeContext context, [NotNull]string unicode, [NotNull]string encoding) {
-            _bytes = StringOps.encode(context, unicode, encoding, "strict").UnsafeByteArray;
+        public Bytes(CodeContext context, [NotNull]string @string, [NotNull]string encoding) {
+            _bytes = StringOps.encode(context, @string, encoding, "strict").UnsafeByteArray;
+        }
+
+        public Bytes(CodeContext context, [NotNull]string @string, [NotNull]string encoding, [NotNull]string errors) {
+            _bytes = StringOps.encode(context, @string, encoding, errors).UnsafeByteArray;
         }
 
         private static readonly IReadOnlyList<Bytes> oneByteBytes = Enumerable.Range(0, 256).Select(i => new Bytes(new byte[] { (byte)i }, false)).ToArray();

--- a/Tests/test_bytes_stdlib.py
+++ b/Tests/test_bytes_stdlib.py
@@ -180,7 +180,7 @@ def load_tests(loader, standard_tests, pattern):
         #suite.addTest(test.test_bytes.BytesTest('test_custom'))
         suite.addTest(test.test_bytes.BytesTest('test_decode'))
         suite.addTest(test.test_bytes.BytesTest('test_empty_sequence'))
-        #suite.addTest(test.test_bytes.BytesTest('test_encoding'))
+        suite.addTest(test.test_bytes.BytesTest('test_encoding'))
         suite.addTest(test.test_bytes.BytesTest('test_endswith'))
         suite.addTest(test.test_bytes.BytesTest('test_extended_getslice'))
         suite.addTest(test.test_bytes.BytesTest('test_find'))


### PR DESCRIPTION
This is not exactly like `bytearray` does it, but follows the agreed convention to provide a separate overload ISO a default value for a parameter, if Python does not define such default.