### PR TITLE
Support bytes/bytearray initialization through __index__

### DIFF
--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -62,10 +62,6 @@ namespace IronPython.Runtime {
             }
         }
 
-        public void __init__(BigInteger source) {
-            __init__((int)source);
-        }
-
         public void __init__([NotNull]IEnumerable<byte> source) {
             _bytes = new ArrayData<byte>(source);
         }
@@ -75,10 +71,14 @@ namespace IronPython.Runtime {
         }
 
         public void __init__(CodeContext context, object? source) {
-            _bytes = new ArrayData<byte>();
-            IEnumerator ie = PythonOps.GetEnumerator(context, source);
-            while (ie.MoveNext()) {
-                Add(GetByte(ie.Current));
+            if (Converter.TryConvertToIndex(source, throwOverflowError: true, out int size)) {
+                __init__(size);
+            } else {
+                _bytes = new ArrayData<byte>();
+                IEnumerator ie = PythonOps.GetEnumerator(context, source);
+                while (ie.MoveNext()) {
+                    Add(GetByte(ie.Current));
+                }
             }
         }
 

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -30,7 +30,14 @@ namespace IronPython.Runtime {
             _bytes = new byte[0];
         }
 
-        public Bytes(object? source) : this(ByteArray.GetBytes(source, useHint: true)) { }
+        public Bytes(object? source) {
+            if (Converter.TryConvertToIndex(source, throwOverflowError: true, out int size)) {
+                if (size < 0) throw PythonOps.ValueError("negative count");
+                _bytes = new byte[size];
+            } else {
+                _bytes = ByteArray.GetBytes(source, useHint: true).ToArray(); 
+            }
+        }
 
         public Bytes([NotNull]IEnumerable<object?> source) {
             _bytes = source.Select(b => ((int)PythonOps.Index(b)).ToByteChecked()).ToArray();
@@ -52,8 +59,6 @@ namespace IronPython.Runtime {
             if (size < 0) throw PythonOps.ValueError("negative count");
             _bytes = new byte[size];
         }
-
-        public Bytes(BigInteger size) : this((int)size) { }
 
         public Bytes([NotNull]byte[] bytes) {
             _bytes = bytes.ToArray();

--- a/Src/IronPython/Runtime/PythonBytesIterator.cs
+++ b/Src/IronPython/Runtime/PythonBytesIterator.cs
@@ -29,7 +29,7 @@ namespace IronPython.Runtime {
 
         public PythonTuple __reduce__(CodeContext context) {
             // Using BuiltinModuleInstance rather than GetBuiltinsDict() or TryLookupBuiltin() matches CPython 3.8.2 behaviour
-            // Older versions of CPython may have a different hehaviour
+            // Older versions of CPython may have a different behaviour
             object? iter = PythonOps.GetBoundAttr(context, context.LanguageContext.BuiltinModuleInstance, nameof(Builtin.iter));
 
             if (_index < _bytes.Count) {

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -47,8 +47,14 @@ class BytesTest(IronPythonTestCase):
             self.assertEqual(testType(5), b'\x00\x00\x00\x00\x00')
             self.assertRaises(ValueError, testType, [256])
             self.assertRaises(ValueError, testType, [257])
+            self.assertRaises(ValueError, testType, -1)
 
             self.assertEqual(list(testType(list(range(256)))), list(range(256)))
+
+            self.assertEqual(testType(IndexableOC(10)), b"\0" * 10)
+            self.assertRaisesRegex(TypeError, "'IndexableOC' object", testType, IndexableOC(IndexableOC(10)))
+            self.assertRaises(OverflowError, testType, 2<<222)
+            self.assertRaises(OverflowError, testType, IndexableOC(2<<222))
 
         def f():
             yield 42


### PR DESCRIPTION
Adds ability to initialize `bytes`/`bytearray` with objects implementing `__index__`.

This solution may still change once `long`/'int` unification is done.