### PR TITLE
Resolve various StackOverflowExceptions in tests

### DIFF
--- a/Src/IronPython.Modules/_collections.cs
+++ b/Src/IronPython.Modules/_collections.cs
@@ -1112,7 +1112,6 @@ namespace IronPython.Modules {
                         Debug.Assert(index == infinite.Count - 1);
                         infinite.RemoveAt(index);
                     }
-
                 }
             }
 

--- a/Src/IronPython.Modules/_functools.cs
+++ b/Src/IronPython.Modules/_functools.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using IronPython.Runtime;
 using IronPython.Runtime.Binding;
 using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Actions;
@@ -171,6 +172,15 @@ namespace IronPython.Modules {
                 if (name == "__dict__") Delete__dict__();
 
                 _dict?.Remove(name);
+            }
+
+            public PythonTuple __reduce__() {
+                return PythonTuple.MakeTuple(
+                    DynamicHelpers.GetPythonTypeFromType(typeof(partial)),
+                    PythonTuple.MakeTuple(func),
+                    PythonTuple.MakeTuple(func,  args, keywords),
+                    null // TODO: what should this be?
+                );
             }
 
             #endregion

--- a/Src/IronPython/Runtime/Filter.cs
+++ b/Src/IronPython/Runtime/Filter.cs
@@ -53,5 +53,12 @@ is true. If function is None, return the items that are true.")]
 
         [PythonHidden]
         public void Reset() { throw new System.NotSupportedException(); }
+
+        public PythonTuple __reduce__() {
+            return PythonTuple.MakeTuple(
+                DynamicHelpers.GetPythonTypeFromType(typeof(Filter)),
+                PythonTuple.MakeTuple(_function, _enumerator)
+            );
+        }
     }
 }

--- a/Src/IronPython/Runtime/Map.cs
+++ b/Src/IronPython/Runtime/Map.cs
@@ -58,5 +58,15 @@ each of the iterables.  Stops when the shortest iterable is exhausted.")]
 
         [PythonHidden]
         public void Reset() { throw new NotSupportedException(); }
+
+        public PythonTuple __reduce__() {
+            var args = new object?[_enumerators.Length + 1];
+            args[0] = _func;
+            Array.Copy(_enumerators, 0, args, 1, _enumerators.Length);
+            return PythonTuple.MakeTuple(
+                DynamicHelpers.GetPythonTypeFromType(typeof(Map)),
+                PythonTuple.MakeTuple(args)
+            );
+        }
     }
 }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -154,7 +154,6 @@ namespace IronPython.Runtime.Operations {
         internal static Encoding Latin1Encoding => _latin1 ??= Encoding.GetEncoding(28591, new EncoderExceptionFallback(), new DecoderExceptionFallback()); // ISO-8859-1
         [DisallowNull] private static Encoding? _latin1;
 
-
         internal static object FastNew(CodeContext/*!*/ context, object? x) {
             if (x == null) {
                 return "None";
@@ -1389,8 +1388,8 @@ namespace IronPython.Runtime.Operations {
             return self;
         }
 
-        public static Extensible<string> __str__([NotNull]ExtensibleString self) {
-            return self;
+        public static string __str__([NotNull]ExtensibleString self) {
+            return self.Value;
         }
 
         public static string/*!*/ __repr__([NotNull]string/*!*/ self) {

--- a/Src/IronPython/Runtime/Zip.cs
+++ b/Src/IronPython/Runtime/Zip.cs
@@ -65,5 +65,12 @@ is exhausted and then it raises StopIteration.")]
 
         [PythonHidden]
         public void Reset() { throw new NotSupportedException(); }
+
+        public PythonTuple __reduce__() {
+            return PythonTuple.MakeTuple(
+                DynamicHelpers.GetPythonTypeFromType(typeof(Zip)),
+                PythonTuple.Make(enumerators)
+            );
+        }
     }
 }

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -488,7 +488,6 @@ Ignore=true
 
 [CPython.test_functools]
 Ignore=true
-Reason=StackOverflowException
 
 [CPython.test_future]
 Ignore=true

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -210,7 +210,6 @@ Ignore=true
 
 [CPython.test_builtin]
 Ignore=true
-Reason=StackOverflowException
 
 [CPython.test_bufio]
 RetryCount=2

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -3,7 +3,7 @@ Ignore=false
 Arguments="$(TEST_FILE)"
 WorkingDirectory=$(TEST_FILE_DIR)
 Redirect=false
-Timeout=600000 # 10 minute timeout
+Timeout=60000 # 1 minute timeout
 
 [CPython.ctypes]
 RunCondition=NOT $(IS_OSX) # TODO: debug
@@ -158,7 +158,7 @@ Ignore=true
 
 [CPython.test___all__]
 Ignore=true
-Reason=StackOverflowException
+Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
 
 [CPython.test__locale]
 Ignore=true
@@ -306,6 +306,7 @@ Ignore=true
 
 [CPython.test_compile]
 Ignore=true
+Reason=StackOverflowException
 
 [CPython.test_compileall]
 Ignore=true
@@ -375,6 +376,7 @@ RetryCount=2
 
 [CPython.test_descr]
 Ignore=true
+Reason=Crashes the process
 
 [CPython.test_descrtut]
 Ignore=true
@@ -407,6 +409,7 @@ Ignore=true
 
 [CPython.test_docxmlrpc]
 Ignore=true
+Reason=StackOverflowException
 
 [CPython.test_dynamic]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
@@ -542,6 +545,7 @@ Reason=Blocking
 
 [CPython.test_httpservers]
 Ignore=true
+Reason=Blocking
 
 [CPython.test_idle]
 Ignore=true
@@ -624,7 +628,7 @@ Ignore=true
 
 [CPython.test_logging]
 Ignore=true
-Reason=TypeError: unsupported operand type(s) for //: 'timedelta' and 'timedelta'
+Reason=TypeError: unsupported operand type(s) for //: 'timedelta' and 'timedelta' | StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
 
 [CPython.test_long]
 Ignore=true
@@ -868,10 +872,6 @@ RunCondition=$(IS_POSIX)
 Ignore=true
 Reason=unittest.case.SkipTest: No module named 'resource'
 
-[CPython.test_richcmp]
-Ignore=true
-Reason=AssertionError: TypeError not raised by <lambda$1>
-
 [CPython.test_robotparser]
 Ignore=true
 Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
@@ -924,6 +924,7 @@ Ignore=true
 
 [CPython.test_smtplib]
 RunCondition=NOT $(IS_POSIX) # TODO: debug
+Timeout=600000 # 10 minute timeout
 
 [CPython.test_sndhdr]
 Ignore=true
@@ -948,6 +949,7 @@ Ignore=true
 
 [CPython.test_ssl]
 Ignore=true
+Reason=Blocking
 
 [CPython.test_startfile]
 RunCondition=NOT $(IS_POSIX) # TODO: debug?
@@ -1014,7 +1016,7 @@ Ignore=true
 
 [CPython.test_sys]
 Ignore=true
-Reason=Blocking
+Reason=StackOverflowException
 
 [CPython.test_sys_setprofile]
 Ignore=true
@@ -1131,6 +1133,7 @@ Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/iss
 
 [CPython.test_urllib2_localnet]
 Ignore=true
+Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
 
 [CPython.test_urllib2net]
 Ignore=true
@@ -1171,6 +1174,7 @@ Reason=ImportError: No module named audioop
 
 [CPython.test_weakref]
 Ignore=true
+Reason=NullReferenceException
 
 [CPython.test_weakset]
 Ignore=true
@@ -1196,6 +1200,7 @@ Ignore=true
 
 [CPython.test_xmlrpc]
 Ignore=true
+Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
 
 [CPython.test_zipfile]
 Ignore=true

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -899,7 +899,6 @@ Ignore=true
 
 [CPython.test_set]
 Ignore=true
-Reason=StackOverflowException
 
 [CPython.test_setcomps]
 Ignore=true

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -457,7 +457,6 @@ Ignore=true
 
 [CPython.test_float]
 Ignore=true
-Reason=StackOverflowException
 
 [CPython.test_flufl]
 Ignore=true

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -1109,7 +1109,6 @@ Reason=ImportError: No module named '_tkinter'
 
 [CPython.test_types]
 Ignore=true
-Reason=StackOverflowException
 
 [CPython.test_ucn]
 Ignore=true

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -369,10 +369,6 @@ Reason=ImportError: No module named _dbm
 [CPython.test_decimal]
 Ignore=true
 
-[CPython.test_defaultdict]
-Ignore=true
-Reason=StackOverflowException
-
 [CPython.test_deque]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 RetryCount=2

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -591,7 +591,6 @@ Ignore=true
 
 [CPython.test_itertools]
 Ignore=true
-Reason=StackOverflowException
 
 [CPython.test_json.test_enum]
 Ignore=true

--- a/Src/IronPythonTest/Cases/CaseExecuter.cs
+++ b/Src/IronPythonTest/Cases/CaseExecuter.cs
@@ -19,6 +19,7 @@ using IronPython.Hosting;
 using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
 using IronPythonTest.Util;
+using NUnit.Framework;
 
 namespace IronPythonTest.Cases {
     internal class CaseExecuter {
@@ -119,7 +120,13 @@ namespace IronPythonTest.Cases {
         }
 
         private int RunTestImpl(TestInfo testcase) {
-            switch (testcase.Options.IsolationLevel) {
+            var isolationLevel = testcase.Options.IsolationLevel;
+            // when RUN_IGNORED is set, always isolate ignored tests
+            if (testcase.Options.Ignore) {
+                isolationLevel = TestIsolationLevel.PROCESS;
+            }
+
+            switch (isolationLevel) {
                 case TestIsolationLevel.DEFAULT:
                     return GetScopeTest(testcase);
 

--- a/Src/IronPythonTest/Cases/CaseGenerator.cs
+++ b/Src/IronPythonTest/Cases/CaseGenerator.cs
@@ -63,7 +63,9 @@ namespace IronPythonTest.Cases {
                     .SetName(name)
                     .Returns(0);
 
-                if (testcase.Options.Ignore && string.IsNullOrWhiteSpace(TestContext.Parameters["RUN_IGNORED"])) {
+                var runIgnored = !string.IsNullOrWhiteSpace(TestContext.Parameters["RUN_IGNORED"]);
+
+                if (testcase.Options.Ignore && !runIgnored) {
                     if (!string.IsNullOrWhiteSpace(testcase.Options.Reason)) {
                         result.Ignore($"ignored - {testcase.Options.Reason}");
                     } else {
@@ -71,7 +73,7 @@ namespace IronPythonTest.Cases {
                     }
                 }
 
-                if (!ConditionMatched(testcase.Options.RunCondition) && string.IsNullOrWhiteSpace(TestContext.Parameters["RUN_IGNORED"])) {
+                if (!ConditionMatched(testcase.Options.RunCondition)) {
                     if (!string.IsNullOrWhiteSpace(testcase.Options.Reason)) {
                         result.Ignore($"condition ({testcase.Options.RunCondition}) - {testcase.Options.Reason}");
                     } else {

--- a/Src/IronPythonTest/Cases/IronPythonCases.cs
+++ b/Src/IronPythonTest/Cases/IronPythonCases.cs
@@ -18,17 +18,18 @@ namespace IronPythonTest.Cases {
 
     internal class IronPythonCaseGenerator : CommonCaseGenerator<IronPythonCases> {
         protected override IEnumerable<TestInfo> GetTests() {
-            var root = CaseExecuter.FindRoot();
+            return GetFilenames(new[] {
+                System.Tuple.Create(category, Path.Combine("Tests")),
+                System.Tuple.Create($"{category}.scripts", Path.Combine("Src", "Scripts")),
+            })
+            .OrderBy(testcase => testcase.Name);
 
-            return GetFilenames()
-                .Select(file => new TestInfo(Path.GetFullPath(file), category, "Tests", this.manifest))
-                .OrderBy(testcase => testcase.Name);
-
-            IEnumerable<string> GetFilenames() {
-                foreach (var filename in Directory.EnumerateFiles(Path.Combine(root, "Tests"), "test_*.py", SearchOption.AllDirectories))
-                    yield return filename;
-
-                yield return Path.Combine(root, "Src", "Scripts", "test_cgcheck.py");
+            IEnumerable<TestInfo> GetFilenames(IEnumerable<System.Tuple<string, string>> folders) {
+                foreach (var tuple in folders) {
+                    var fullPath = Path.Combine(CaseExecuter.FindRoot(), tuple.Item2);
+                    foreach (var filename in Directory.EnumerateFiles(fullPath, "test_*.py", SearchOption.AllDirectories))
+                        yield return new TestInfo(Path.GetFullPath(filename), tuple.Item1, tuple.Item2, manifest);
+                }
             }
         }
     }

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -157,6 +157,9 @@ IsolationLevel=PROCESS # for some reason this may fail without the IsolationLeve
 [IronPython.test_strformat]
 IsolationLevel=PROCESS # for some reason this may fail without the IsolationLevel
 
+[IronPython.test_struct_threadsafe]
+Timeout=120000 # 2 minute timeout
+
 [IronPython.test_syntax]
 Ignore=true
 
@@ -228,6 +231,9 @@ RetryCount=2
 
 [IronPython.modules.misc.test_future]
 Ignore=true
+
+[IronPython.modules.misc.test_system_namespaces]
+Timeout=120000 # 2 minute timeout
 
 [IronPython.modules.system_related.test__locale]
 IsolationLevel=PROCESS # changes the locale which can cause other tests to fail

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -242,6 +242,10 @@ Ignore=true
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 FullFrames=true
 
+[IronPython.modules.system_related.test_thread]
+RunCondition=NOT $(IS_POSIX)
+Reason=Blocked by https://github.com/IronLanguages/ironpython3/issues/541
+
 [IronPython.scripts.test_builder]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -3,7 +3,7 @@ Ignore=false
 Arguments="$(TEST_FILE)"
 WorkingDirectory=$(TEST_FILE_DIR)
 Redirect=false
-Timeout=600000 ; 10 minute timeout
+Timeout=60000 # 1 minute timeout
 
 [IronPython.test_buffer]
 Ignore=true
@@ -126,7 +126,7 @@ Ignore=true
 
 [IronPython.test_python25]
 Ignore=true
-Reason=disabled due to https://github.com/IronLanguages/ironpython2/issues/182
+Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
 
 [IronPython.test_regressions]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
@@ -166,7 +166,7 @@ Reason=Unstable
 
 [IronPython.test_tcf]
 Ignore=true
-Reason=disabled due to https://github.com/IronLanguages/ironpython2/issues/182
+Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
 
 [IronPython.test_threadsafety]
 Ignore=true
@@ -177,6 +177,9 @@ IsolationLevel=PROCESS
 [IronPython.test_unicode_stdlib]
 RunCondition=NOT $(IS_MONO) # Mono codepage 852 encoding incorrecly decodes 0xAA to '?' instead of '¬'
 IsolationLevel=PROCESS # reset reporting of warnings
+
+[IronPython.test_weakref]
+Timeout=600000 # 10 minute timeout
 
 [IronPython.hosting.editor_svcs.test_errorlistener]
 Ignore=true
@@ -239,5 +242,14 @@ Ignore=true
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 FullFrames=true
 
-[IronPython.modules.system_related.test_thread]
+[IronPython.scripts.test_builder]
+Ignore=true
+
+[IronPython.scripts.test_cgcheck]
+Timeout=600000 # 10 minute timeout
+
+[IronPython.scripts.test_parrot]
+Ignore=true
+
+[IronPython.scripts.test_pystone]
 Ignore=true

--- a/Tests/test_unicode_stdlib.py
+++ b/Tests/test_unicode_stdlib.py
@@ -16,8 +16,8 @@ import test.test_unicode
 def load_tests(loader, standard_tests, pattern):
     if sys.implementation.name == 'ironpython':
         suite = unittest.TestSuite()
-        #suite.addTest(test.test_unicode.StringModuleTest('test_formatter_field_name_split'))
-        #suite.addTest(test.test_unicode.StringModuleTest('test_formatter_parser'))
+        suite.addTest(test.test_unicode.StringModuleTest('test_formatter_field_name_split'))
+        suite.addTest(test.test_unicode.StringModuleTest('test_formatter_parser'))
         suite.addTest(test.test_unicode.UnicodeTest('test___contains__'))
         suite.addTest(test.test_unicode.UnicodeTest('test_additional_rsplit'))
         suite.addTest(test.test_unicode.UnicodeTest('test_additional_split'))


### PR DESCRIPTION
- Add `__reduce__` methods to `map`, `filter`, `zip`, `_functools.partial`, `itertools.*`
- Fix recursive repr in `SimpleNamespace`, `set`, `defaultdict`
- Fix `__str__` of string subclass
- Testing cleanup