### PR TITLE
Comparison cleanup

### DIFF
--- a/Src/IronPython.Modules/_weakref.cs
+++ b/Src/IronPython.Modules/_weakref.cs
@@ -167,22 +167,22 @@ namespace IronPython.Modules {
 
             [return: MaybeNotImplemented]
             public static NotImplementedType operator >(@ref self, object other) {
-                return PythonOps.NotImplemented;
+                return NotImplementedType.Value;
             }
 
             [return: MaybeNotImplemented]
             public static NotImplementedType operator <(@ref self, object other) {
-                return PythonOps.NotImplemented;
+                return NotImplementedType.Value;
             }
 
             [return: MaybeNotImplemented]
             public static NotImplementedType operator <=(@ref self, object other) {
-                return PythonOps.NotImplemented;
+                return NotImplementedType.Value;
             }
 
             [return: MaybeNotImplemented]
             public static NotImplementedType operator >=(@ref self, object other) {
-                return PythonOps.NotImplemented;
+                return NotImplementedType.Value;
             }
 
             #region IStructuralEquatable Members

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1578,7 +1578,7 @@ namespace IronPython.Runtime {
         public bool __eq__(CodeContext context, [NotNull]IBufferProtocol value) => Equals(value.ToBytes(0, null));
 
         [return: MaybeNotImplemented]
-        public object __eq__(CodeContext context, object? value) => NotImplementedType.Value;
+        public NotImplementedType __eq__(CodeContext context, object? value) => NotImplementedType.Value;
 
         public bool __ne__(CodeContext context, [NotNull]ByteArray value) => !__eq__(context, value);
 
@@ -1587,7 +1587,7 @@ namespace IronPython.Runtime {
         public bool __ne__(CodeContext context, [NotNull]IBufferProtocol value) => !__eq__(context, value);
 
         [return: MaybeNotImplemented]
-        public object __ne__(CodeContext context, object? value) => NotImplementedType.Value;
+        public NotImplementedType __ne__(CodeContext context, object? value) => NotImplementedType.Value;
 
         private bool Equals(ByteArray other) {
             if (Count != other.Count) {

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -1016,12 +1016,12 @@ namespace IronPython.Runtime {
         public bool __eq__(CodeContext context, [NotNull]Bytes value) => Equals(value);
 
         [return: MaybeNotImplemented]
-        public object __eq__(CodeContext context, object? value) => NotImplementedType.Value;
+        public NotImplementedType __eq__(CodeContext context, object? value) => NotImplementedType.Value;
 
         public bool __ne__(CodeContext context, [NotNull]Bytes value) => !Equals(value);
 
         [return: MaybeNotImplemented]
-        public object __ne__(CodeContext context, object? value) => NotImplementedType.Value;
+        public NotImplementedType __ne__(CodeContext context, object? value) => NotImplementedType.Value;
 
         [PythonHidden]
         public bool Equals(Bytes? other) => other != null && (ReferenceEquals(this, other) || Enumerable.SequenceEqual(_bytes, other._bytes));

--- a/Src/IronPython/Runtime/FunctionCode.cs
+++ b/Src/IronPython/Runtime/FunctionCode.cs
@@ -650,30 +650,17 @@ namespace IronPython.Runtime {
             return base.GetHashCode();
         }
 
-        // these are present in CPython but always return NotImplemented.
         [return: MaybeNotImplemented]
-        [Python3Warning("code inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator >(FunctionCode self, FunctionCode other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __gt__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("code inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator <(FunctionCode self, FunctionCode other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __lt__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("code inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator >=(FunctionCode self, FunctionCode other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __ge__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("code inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator <=(FunctionCode self, FunctionCode other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __le__(CodeContext context, object other) => NotImplementedType.Value;
 
         /// <summary>
         /// Called the 1st time a function is invoked by our OriginalCallTarget* methods

--- a/Src/IronPython/Runtime/Operations/DecimalOps.cs
+++ b/Src/IronPython/Runtime/Operations/DecimalOps.cs
@@ -9,6 +9,8 @@ using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
+using IronPython.Runtime.Types;
+
 using Microsoft.Scripting.Runtime;
 
 namespace IronPython.Runtime.Operations {
@@ -76,7 +78,7 @@ namespace IronPython.Runtime.Operations {
             if (y is null) {
                 return ScriptingRuntimeHelpers.Int32ToObject(+1);
             }
-            return PythonOps.NotImplemented;
+            return NotImplementedType.Value;
         }
 
         public static int __hash__(decimal x) {

--- a/Src/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/Src/IronPython/Runtime/Operations/ObjectOps.cs
@@ -226,6 +226,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [return: MaybeNotImplemented]
+        public static object __eq__(object self, object value) {
+            if (ReferenceEquals(self, value)) return ScriptingRuntimeHelpers.True;
+            return NotImplementedType.Value;
+        }
+
+        [return: MaybeNotImplemented]
         public static object __ne__(CodeContext context, object self, object other) {
             if (PythonTypeOps.TryInvokeBinaryOperator(context, self, other, "__eq__", out object res)) {
                 if (res is NotImplementedType) {
@@ -235,6 +241,18 @@ namespace IronPython.Runtime.Operations {
             }
             return NotImplementedType.Value;
         }
+
+        [return: MaybeNotImplemented]
+        public static NotImplementedType __gt__(object self, object value) => NotImplementedType.Value;
+
+        [return: MaybeNotImplemented]
+        public static NotImplementedType __lt__(object self, object value) => NotImplementedType.Value;
+
+        [return: MaybeNotImplemented]
+        public static NotImplementedType __ge__(object self, object value) => NotImplementedType.Value;
+
+        [return: MaybeNotImplemented]
+        public static NotImplementedType __le__(object self, object value) => NotImplementedType.Value;
 
         public static string __format__(CodeContext/*!*/ context, object self, [NotNull]string/*!*/ formatSpec) {
             string text = PythonOps.ToString(context, self);

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3019,6 +3019,7 @@ namespace IronPython.Runtime.Operations {
 
         public static Ellipsis Ellipsis => Ellipsis.Value;
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static NotImplementedType NotImplemented => NotImplementedType.Value;
 
         public static void ListAddForComprehension(PythonList l, object? o) {

--- a/Src/IronPython/Runtime/PythonDictionary.cs
+++ b/Src/IronPython/Runtime/PythonDictionary.cs
@@ -463,30 +463,17 @@ namespace IronPython.Runtime {
             );
         }
 
-        // these are present in CPython but always return NotImplemented.
         [return: MaybeNotImplemented]
-        [Python3Warning("dict inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator >(PythonDictionary self, PythonDictionary other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __gt__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("dict inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator <(PythonDictionary self, PythonDictionary other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __lt__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("dict inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator >=(PythonDictionary self, PythonDictionary other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __ge__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("dict inequality comparisons not supported in 3.x")]
-        public static NotImplementedType operator <=(PythonDictionary self, PythonDictionary other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __le__(CodeContext context, object other) => NotImplementedType.Value;
 
         #endregion
 

--- a/Src/IronPython/Runtime/PythonRange.cs
+++ b/Src/IronPython/Runtime/PythonRange.cs
@@ -108,7 +108,7 @@ namespace IronPython.Runtime {
             }
         }
 
-        public bool __eq__(PythonRange other) {
+        public bool __eq__([NotNull]PythonRange other) {
             if (_length != other._length) {
                 return false;
             }
@@ -127,9 +127,13 @@ namespace IronPython.Runtime {
             return step == other.step;
         }
 
-        public bool __ne__(PythonRange other) {
-            return !__eq__(other);
-        }
+        [return: MaybeNotImplemented]
+        public NotImplementedType __eq__(CodeContext context, object other) => NotImplementedType.Value;
+
+        public bool __ne__([NotNull]PythonRange other) => !__eq__(other);
+
+        [return: MaybeNotImplemented]
+        public NotImplementedType __ne__(CodeContext context, object other) => NotImplementedType.Value;
 
         public int __hash__() {
             if (_length == 0) {
@@ -143,21 +147,17 @@ namespace IronPython.Runtime {
             return hash;
         }
 
-        public bool __lt__(PythonRange other) {
-            throw new TypeErrorException("unorderable types: range() < range()");
-        }
+        [return: MaybeNotImplemented]
+        public NotImplementedType __lt__(CodeContext context, object other) => NotImplementedType.Value;
 
-        public bool __le__(PythonRange other) {
-            throw new TypeErrorException("unorderable types: range() <= range()");
-        }
+        [return: MaybeNotImplemented]
+        public NotImplementedType __le__(CodeContext context, object other) => NotImplementedType.Value;
 
-        public bool __gt__(PythonRange other) {
-            throw new TypeErrorException("unorderable types: range() > range()");
-        }
+        [return: MaybeNotImplemented]
+        public NotImplementedType __gt__(CodeContext context, object other) => NotImplementedType.Value;
 
-        public bool __ge__(PythonRange other) {
-            throw new TypeErrorException("unorderable types: range() >= range()");
-        }
+        [return: MaybeNotImplemented]
+        public NotImplementedType __ge__(CodeContext context, object other) => NotImplementedType.Value;
 
         public bool __contains__(CodeContext context, object item) {
             int intItem;

--- a/Src/IronPython/Runtime/Types/BuiltinFunction.cs
+++ b/Src/IronPython/Runtime/Types/BuiltinFunction.cs
@@ -406,7 +406,7 @@ namespace IronPython.Runtime.Types {
             } else if (IsBinaryOperator && args.Length == 2 && IsThrowException(res.Expression)) {
                 // Binary Operators return NotImplemented on failure.
                 res = new DynamicMetaObject(
-                    Ast.Property(null, typeof(PythonOps), "NotImplemented"),
+                    Ast.Property(null, typeof(PythonOps), nameof(PythonOps.NotImplemented)),
                     res.Restrictions
                 );
             } else if (target.Overload != null) {
@@ -592,30 +592,17 @@ namespace IronPython.Runtime.Types {
             return lres > 0 ? 1 : -1;
         }
 
-        // these are present in CPython but always return NotImplemented.
         [return: MaybeNotImplemented]
-        [Python3Warning("builtin_function_or_method order comparisons not supported in 3.x")]
-        public static NotImplementedType operator >(BuiltinFunction self, BuiltinFunction other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __gt__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("builtin_function_or_method order comparisons not supported in 3.x")]
-        public static NotImplementedType operator <(BuiltinFunction self, BuiltinFunction other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __lt__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("builtin_function_or_method order comparisons not supported in 3.x")]
-        public static NotImplementedType operator >=(BuiltinFunction self, BuiltinFunction other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __ge__(CodeContext context, object other) => NotImplementedType.Value;
 
         [return: MaybeNotImplemented]
-        [Python3Warning("builtin_function_or_method order comparisons not supported in 3.x")]
-        public static NotImplementedType operator <=(BuiltinFunction self, BuiltinFunction other) {
-            return PythonOps.NotImplemented;
-        }
+        public NotImplementedType __le__(CodeContext context, object other) => NotImplementedType.Value;
 
         public int __hash__(CodeContext/*!*/ context) {
             return PythonOps.Hash(context, _instance) ^ PythonOps.Hash(context, _data);

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -510,55 +510,6 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             return PythonTypeOps.CallWorker(context, this, kwArgs, args);
         }
 
-        public int __cmp__([NotNull]PythonType other) {
-            if (other != this) {
-                int res = Name.CompareTo(other.Name);
-
-                if (res == 0) {
-                    long thisId = IdDispenser.GetId(this);
-                    long otherId = IdDispenser.GetId(other);
-                    if (thisId > otherId) {
-                        return 1;
-                    } 
-
-                    return -1;
-                }
-
-                return res;
-            }
-            return 0;
-        }
-
-        // Do not override == and != because it causes lots of spurious warnings
-        // TODO Replace those warnings with .ReferenceEquals calls & overload ==/!=
-        public bool __eq__([NotNull]PythonType other) {
-            return __cmp__(other) == 0;
-        }
-
-        public bool __ne__([NotNull]PythonType other) {
-            return this.__cmp__(other) != 0;
-        }
-
-        [Python3Warning("type inequality comparisons not supported in 3.x")]
-        public static bool operator >(PythonType self, PythonType other) {
-            return self.__cmp__(other) > 0;
-        }
-
-        [Python3Warning("type inequality comparisons not supported in 3.x")]
-        public static bool operator <(PythonType self, PythonType other) {
-            return self.__cmp__(other) < 0;
-        }
-
-        [Python3Warning("type inequality comparisons not supported in 3.x")]
-        public static bool operator >=(PythonType self, PythonType other) {
-            return self.__cmp__(other) >= 0;
-        }
-
-        [Python3Warning("type inequality comparisons not supported in 3.x")]
-        public static bool operator <=(PythonType self, PythonType other) {
-            return self.__cmp__(other) <= 0;
-        }
-
         public void __delattr__(CodeContext/*!*/ context, string name) {
             DeleteCustomMember(context, name);
         }


### PR DESCRIPTION
Removes comparisons from `type` and adds rich comparison methods to `object`.