### PR TITLE
Make isinstance(val, int) return true for long

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -373,6 +373,11 @@ namespace IronPython.Runtime.Operations {
                 return true;
             }
 
+            // https://github.com/IronLanguages/ironpython3/issues/52
+            if (typeinfo == TypeCache.Int32 && o is BigInteger) {
+                return true;
+            }
+
             if (typeinfo.__instancecheck__(o)) {
                 return true;
             }

--- a/Src/StdLib/Lib/fractions.py
+++ b/Src/StdLib/Lib/fractions.py
@@ -367,7 +367,7 @@ class Fraction(numbers.Rational):
 
         """
         def forward(a, b):
-            if isinstance(b, (int, long, Fraction)): # https://github.com/IronLanguages/ironpython3/issues/52
+            if isinstance(b, (int, Fraction)):
                 return monomorphic_operator(a, b)
             elif isinstance(b, float):
                 return fallback_operator(float(a), b)

--- a/Tests/test_isinstance2.py
+++ b/Tests/test_isinstance2.py
@@ -2,6 +2,7 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
+import sys
 import unittest
 
 class IsInstanceTest(unittest.TestCase):
@@ -26,6 +27,14 @@ class IsInstanceTest(unittest.TestCase):
 
         self.assertTrue(isinstance(int, B))
         self.assertTrue(isinstance(B(), B)) # does not call __instancecheck__
+
+    def test_isinstance_bigint(self):
+        # check that isinstance(x, int) returns True on BigInteger values
+        l = sys.maxsize + 1
+        if sys.implementation.name == "ironpython":
+            # https://github.com/IronLanguages/ironpython3/issues/52
+            self.assertNotEqual(type(0), type(l))
+        self.assertTrue(isinstance(l, int))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There are some checks for `isinstance(val, int)` in the stdlib (e.g. `fractions` and `ipaddress`) which end up failing when `val` is a `BigInteger`. This forces `isinstance` to return `true` in that case.

Reverts the workaround in https://github.com/IronLanguages/ironpython3/pull/845
Related to https://github.com/IronLanguages/ironpython3/issues/52