### PR TITLE
Get rid of force_gc

### DIFF
--- a/Src/IronPython/Lib/iptest/ipunittest.py
+++ b/Src/IronPython/Lib/iptest/ipunittest.py
@@ -146,16 +146,6 @@ class IronPythonTestCase(unittest.TestCase, FileUtil, ProcessUtil):
             else:
                 clr.AddReference(prefix + x)
 
-    def force_gc(self):
-        if is_cpython:
-            import gc
-            gc.collect()
-        else:
-            import System
-            for i in range(100):
-                System.GC.Collect()
-            System.GC.WaitForPendingFinalizers()
-
     # assertion helpers
 
     def assertRaisesMessage(self, expected_exception, expected_message, callable_obj=None, *args, **kwargs):

--- a/Tests/modules/system_related/test_sys_getframe.py
+++ b/Tests/modules/system_related/test_sys_getframe.py
@@ -221,6 +221,7 @@ class SysGetFrameTest(IronPythonTestCase):
 
     def test_cp24242(self):
         # This test requires -X:FullFrames, run it in separate instance of IronPython.
+        import gc
 
         frame = sys._getframe()
         ids = []
@@ -228,7 +229,7 @@ class SysGetFrameTest(IronPythonTestCase):
             ids.append(id(frame))
             frame = frame.f_back
         del frame
-        self.force_gc()
+        gc.collect()
 
         frame = sys._getframe()
         new_ids = []
@@ -236,7 +237,7 @@ class SysGetFrameTest(IronPythonTestCase):
             new_ids.append(id(frame))
             frame = frame.f_back
         del frame
-        self.force_gc()
+        gc.collect()
 
         self.assertEqual(ids, new_ids)
 

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -3619,7 +3619,7 @@ class ClassTest(IronPythonTestCase):
         k = K2()
         k.__class__ = K1
         del k
-        self.force_gc()
+        import gc; gc.collect()
         self.assertEqual(A, 1)
 
 

--- a/Tests/test_weakref.py
+++ b/Tests/test_weakref.py
@@ -18,6 +18,7 @@
 ##      implemented in a thread-safe way.
 ##
 
+import gc
 import weakref
 
 from iptest import IronPythonTestCase, run_test
@@ -58,7 +59,7 @@ class WeakrefTest(IronPythonTestCase):
         # for reasons stated in create_weakrefs(), we cannot test on instance equality
         self.assertTrue(r().value == "a") 
 
-        self.force_gc()
+        gc.collect()
 
         self.assertTrue(r() is None)
 
@@ -70,7 +71,7 @@ class WeakrefTest(IronPythonTestCase):
         r1, r2 = _create_weakrefs(self, C("a"), 2)
         self.assertTrue(hash(r1) == hash("a"))
 
-        self.force_gc()
+        gc.collect()
 
         self.assertTrue(r1() is None)
         self.assertTrue(r2() is None)
@@ -87,7 +88,7 @@ class WeakrefTest(IronPythonTestCase):
         self.assertTrue(r1 == r2)
         self.assertTrue(r1 == r3)
 
-        self.force_gc()
+        gc.collect()
 
         self.assertTrue(r1() is None)
         self.assertTrue(r3() is None)


### PR DESCRIPTION
Caused `IronPython.test_weakref` to be ridiculously slow...