### PR TITLE
Update memoryview typecodes

### DIFF
--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -78,7 +78,7 @@ namespace IronPython.Runtime {
             // for convenience _shape and _strides are never null, even if _numDims == 0 or _flags indicate no _shape or _strides
             _shape = _buffer.Shape ?? (_numDims > 0 ? new int[] { _buffer.ItemCount } : new int[0]);  // TODO: use a static singleton
 
-            if (shape.Count == 0) {
+            if (_shape.Count == 0) {
                 _strides = _shape; // TODO: use a static singleton
                 _isCContig = true;
             } else if (_buffer.Strides != null) {
@@ -379,13 +379,14 @@ namespace IronPython.Runtime {
 
         public object tolist() {
             CheckBuffer();
+            TypecodeOps.DecomposeTypecode(_format, out char byteorder, out char typecode);
 
             return subdimensionToList(_buffer!.AsReadOnlySpan(), _offset, dim: 0);
 
             object subdimensionToList(ReadOnlySpan<byte> source, int ofs, int dim) {
                 if (dim >= _shape.Count) {
                     // extract individual element (scalar)
-                    return packBytes(_format, source.Slice(ofs));
+                    return packBytes(typecode, source.Slice(ofs));
                 }
 
                 object[] elements = new object[_shape[dim]];
@@ -429,16 +430,23 @@ namespace IronPython.Runtime {
                 }
             }
 
-            int newItemsize;
-            if (!TypecodeOps.TryGetTypecodeWidth(format, out newItemsize)) {
+            if ( format == null
+              || !TypecodeOps.TryDecomposeTypecode(format.AsSpan(), out char byteorder, out char typecode)
+              || !TypecodeOps.IsScalarCode(typecode)
+              || byteorder != '@'
+            ) {
                 throw PythonOps.ValueError(
                     "memoryview: destination format must be a native single character format prefixed with an optional '@'");
             }
 
-            if (!TypecodeOps.IsByteFormat(this._format) && !TypecodeOps.IsByteFormat(format)) {
-                throw PythonOps.TypeError("memoryview: cannot cast between two non-byte formats");
+            if (!TypecodeOps.IsByteCode(typecode)) {
+                TypecodeOps.DecomposeTypecode(_format, out _, out char thisTypecode);
+                if (!TypecodeOps.IsByteCode(thisTypecode)) {
+                    throw PythonOps.TypeError("memoryview: cannot cast between two non-byte formats");
+                }
             }
 
+            int newItemsize = TypecodeOps.GetTypecodeWidth(typecode);
             if ((_numItems * _itemSize) % newItemsize != 0) {
                 throw PythonOps.TypeError("memoryview: length is not a multiple of itemsize");
             }
@@ -463,16 +471,18 @@ namespace IronPython.Runtime {
             return new MemoryView(this, format, newItemsize, newShape);
         }
 
-        private void unpackBytes(string format, object o, Span<byte> dest) {
-            if (TypecodeOps.TryGetBytes(format, o, dest)) {
+        private static void unpackBytes(char typecode, object o, Span<byte> dest) {
+            // TODO: support non-native byteorder
+            if (TypecodeOps.TryGetBytes(typecode, o, dest)) {
                 return;
             } else {
                 throw PythonOps.NotImplementedError("No conversion for type {0} to byte array", PythonOps.GetPythonTypeName(o));
             }
         }
 
-        private static object packBytes(string format, ReadOnlySpan<byte> bytes) {
-            if (TypecodeOps.TryGetFromBytes(format, bytes, out object? result))
+        private static object packBytes(char typecode, ReadOnlySpan<byte> bytes) {
+            // TODO: support non-native byteorder
+            if (TypecodeOps.TryGetFromBytes(typecode, bytes, out object? result))
                 return result;
             else {
                 return Bytes.Make(bytes.ToArray());
@@ -480,57 +490,79 @@ namespace IronPython.Runtime {
         }
 
         private object GetItem(int offset) {
-            object result = packBytes(_format, _buffer!.AsReadOnlySpan().Slice(offset, _itemSize));
+            TypecodeOps.DecomposeTypecode(_format, out char byteorder, out char typecode);
+            object result = packBytes(typecode, _buffer!.AsReadOnlySpan().Slice(offset, _itemSize));
 
             return PythonOps.ConvertToPythonPrimitive(result);
         }
 
         private void SetItem(int offset, object? value) {
             if (value == null) {
-                throw PythonOps.TypeError("memoryview: invalid type for format '{0}'", format);
+                throw PythonOps.TypeError("memoryview: invalid type for format '{0}'", _format);
             }
-            switch (_format) {
-                case "d": // double
-                case "f": // float
+            TypecodeOps.DecomposeTypecode(_format, out char byteorder, out char typecode);
+            switch (typecode) {
+                case 'd': // double
+                case 'f': // float
                     double convertedValueDouble = 0;
                     if (!Converter.TryConvertToDouble(value, out convertedValueDouble)) {
-                        throw PythonOps.TypeError("memoryview: invalid type for format '{0}'", format);
+                        throw PythonOps.TypeError("memoryview: invalid type for format '{0}'", _format);
                     }
                     value = convertedValueDouble;
                     break;
 
-                case "c": // char
-                case "b": // signed byte
-                case "B": // unsigned byte
-                case "u": // unicode char
-                case "h": // signed short
-                case "H": // unsigned short
-                case "i": // signed int
-                case "I": // unsigned int
-                case "l": // signed long
-                case "L": // unsigned long
-                case "q": // signed long long
-                case "P": // pointer
-                case "Q": // unsigned long long
+                case 'c': // char
+                case 'b': // signed byte
+                case 'B': // unsigned byte
+                case 'h': // signed short
+                case 'H': // unsigned short
+                case 'i': // signed int
+                case 'I': // unsigned int
+                case 'l': // signed long
+                case 'L': // unsigned long
+                case 'n': // signed index
+                case 'N': // unsigned index
+                case 'q': // signed long long
+                case 'Q': // unsigned long long
                     if (!PythonOps.IsNumericObject(value)) {
-                        throw PythonOps.TypeError("memoryview: invalid type for format '{0}'", format);
+                        throw PythonOps.TypeError("memoryview: invalid type for format '{0}'", _format);
                     }
 
-                    if (TypecodeOps.CausesOverflow(value, format)) {
-                        throw PythonOps.ValueError("memoryview: invalid value for format '{0}'", format);
+                    if (TypecodeOps.CausesOverflow(value, typecode)) {
+                        throw PythonOps.ValueError("memoryview: invalid value for format '{0}'", _format);
                     }
 
-                    if (format == "Q") {
+                    if (typecode == 'Q') {
                         value = Converter.ConvertToUInt64(value);
                     } else {
                         value = Converter.ConvertToInt64(value);
                     }
                     break;
+
+                case 'P': // void pointer
+                    if (value is UIntPtr) break;
+
+                    if (value is IntPtr iptr) {
+                        value = new UIntPtr(unchecked((UInt64)iptr.ToInt64()));
+                        break;
+                    }
+
+                    if (!PythonOps.IsNumericObject(value)) {
+                        throw PythonOps.TypeError("memoryview: invalid type for format '{0}'", _format);
+                    }
+
+                    var bi = Converter.ConvertToBigInteger(value);
+                    if (TypecodeOps.CausesOverflow(bi, typecode)) {
+                        throw PythonOps.ValueError("memoryview: invalid value for format '{0}'", _format);
+                    }
+                    value = bi;
+                    break;
+
                 default:
                     break; // This could be a variety of types, let the UnpackBytes decide
             }
 
-            unpackBytes(format, value, _buffer!.AsSpan().Slice(offset, _itemSize));
+            unpackBytes(typecode, value, _buffer!.AsSpan().Slice(offset, _itemSize));
         }
 
         // TODO: support indexable, BigInteger etc.
@@ -542,7 +574,7 @@ namespace IronPython.Runtime {
                 }
 
                 index = PythonOps.FixIndex(index, __len__());
-                if (ndim > 1) {
+                if (_numDims > 1) {
                     throw PythonOps.NotImplementedError("multi-dimensional sub-views are not implemented");
                 }
 
@@ -558,7 +590,7 @@ namespace IronPython.Runtime {
                 }
 
                 index = PythonOps.FixIndex(index, __len__());
-                if (ndim > 1) {
+                if (_numDims > 1) {
                     throw PythonOps.NotImplementedError("multi-dimensional sub-views are not implemented");
                 }
 
@@ -602,7 +634,7 @@ namespace IronPython.Runtime {
                 if (_numDims == 0) {
                     throw PythonOps.TypeError("invalid indexing of 0-dim memory");
                 }
-                if (ndim != 1) {
+                if (_numDims != 1) {
                     throw PythonOps.NotImplementedError("memoryview assignments are restricted to ndim = 1");
                 }
 
@@ -658,7 +690,6 @@ namespace IronPython.Runtime {
         private int GetItemOffset(PythonTuple tuple) {
             int flatIndex = _offset;
             int tupleLength = tuple.Count;
-            int ndim = (int)this.ndim;
             int firstOutOfRangeIndex = -1;
 
             bool allInts = true;
@@ -692,7 +723,7 @@ namespace IronPython.Runtime {
                     // about the resulting flat index, but still need
                     // to check the rest of the tuple in case it has a
                     // non-int value
-                    if (i >= ndim || firstOutOfRangeIndex > -1) {
+                    if (i >= _numDims || firstOutOfRangeIndex > -1) {
                         continue;
                     }
 
@@ -722,12 +753,12 @@ namespace IronPython.Runtime {
                 }
             }
 
-            if (tupleLength < ndim) {
+            if (tupleLength < _numDims) {
                 throw PythonOps.NotImplementedError("sub-views are not implemented");
             }
 
-            if (tupleLength > ndim) {
-                throw PythonOps.TypeError("cannot index {0}-dimension view with {1}-element tuple", ndim, tupleLength);
+            if (tupleLength > _numDims) {
+                throw PythonOps.TypeError("cannot index {0}-dimension view with {1}-element tuple", _numDims, tupleLength);
             }
 
             if (firstOutOfRangeIndex != -1) {
@@ -752,7 +783,8 @@ namespace IronPython.Runtime {
                 throw PythonOps.ValueError("cannot hash writable memoryview object");
             }
 
-            if (format != "B" && format != "b" && format != "c") {
+            TypecodeOps.DecomposeTypecode(_format, out _, out char typecode);
+            if (!TypecodeOps.IsByteCode(typecode)) {
                 throw PythonOps.ValueError("memoryview: hashing is restricted to formats 'B', 'b' or 'c'");
             }
 

--- a/Src/IronPython/Runtime/TypecodeOps.cs
+++ b/Src/IronPython/Runtime/TypecodeOps.cs
@@ -9,59 +9,81 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
+using IronPython.Runtime.Operations;
+using Microsoft.Scripting.Utils;
+
 namespace IronPython.Runtime {
     internal static class TypecodeOps {
+        // TODO: integrate with PythonStruct
 
-        public static bool IsByteFormat([NotNullWhen(true)]string? format) {
-            int flen = format?.Length ?? 0;
-            if (flen == 0 || flen > 2) return false;
-            char fchar = format![flen - 1];
-            return fchar == 'B' || fchar == 'b' || fchar == 'c';
-        }
+        public const string ValidByteorder = "@=<>!";
+        public const string ValidScalarCodes = "cbB?hHiIlLqQnNfdP";
+        public const string ValidCodes = ValidScalarCodes + "xsp";
 
-        public static bool TryGetTypecodeWidth([NotNullWhen(true)]string? typecode, out int width) {
-            if (string.IsNullOrEmpty(typecode) || typecode!.Length > 2 || (typecode.Length == 2 && typecode[0] != '@')) {
-                width = 0;
+        public static bool TryDecomposeTypecode(ReadOnlySpan<char> format, out char byteorder, out char code) {
+            if (format.Length == 0 || format.Length > 2) {
+                byteorder = code = default;
                 return false;
             }
-            switch (typecode[typecode.Length - 1]) {
+
+            if (format.Length == 1) {
+                byteorder = '@';
+                code = format[0];
+            } else {
+                byteorder = format[0];
+                code = format[1];
+            }
+            // TODO: add validation of combinations
+            return ValidByteorder.IndexOf(byteorder) >= 0 && ValidCodes.IndexOf(code) >= 0;
+        }
+
+        public static void DecomposeTypecode(string format, out char byteorder, out char code) {
+            if (!TryDecomposeTypecode(format.AsSpan(), out byteorder, out code)) {
+                throw PythonOps.ValueError("invalid typecode");
+            }
+        }
+
+        public static bool IsByteCode(char typecode) {
+            return typecode == 'B' || typecode == 'b' || typecode == 'c';
+        }
+
+        public static bool IsScalarCode(char typecode) {
+            return ValidScalarCodes.IndexOf(typecode) >= 0;
+        }
+
+        public static int GetTypecodeWidth(char typecode) {
+            switch (typecode) {
                 case 'c': // char
                 case 'b': // signed byte
                 case 'B': // unsigned byte
-                    width = 1;
-                    return true;
-                case 'u': // unicode char
+                case '?': // bool
+                    return 1;
                 case 'h': // signed short
                 case 'H': // unsigned short
-                    width = 2;
-                    return true;
+                    return 2;
                 case 'i': // signed int
                 case 'I': // unsigned int
                 case 'l': // signed long
                 case 'L': // unsigned long
                 case 'f': // float
-                    width = 4;
-                    return true;
-                case 'P': // pointer
-                    width = IntPtr.Size;
-                    return true;
+                case 'n': // signed index
+                case 'N': // unsigned index
+                    return 4;
                 case 'q': // signed long long
                 case 'Q': // unsigned long long
                 case 'd': // double
-                    width = 8;
-                    return true;
+                    return 8;
+                case 's': // char pointer
+                case 'p': // char pointer
+                case 'P': // void pointer
+                    return UIntPtr.Size;
                 default:
-                    width = 0;
-                    return false;
+                    return 0;
             }
         }
 
-        public static bool TryGetFromBytes([NotNullWhen(true)]string? typecode, ReadOnlySpan<byte> bytes, [NotNullWhen(true)]out object? result) {
-            if (string.IsNullOrEmpty(typecode) || typecode!.Length > 2 || (typecode.Length == 2 && typecode[0] != '@')) {
-                result = null;
-                return false;
-            }
-            switch (typecode[typecode.Length - 1]) {
+        public static bool TryGetFromBytes(char typecode, ReadOnlySpan<byte> bytes, [NotNullWhen(true)]out object? result) {
+            switch (typecode) {
                 case 'c':
                     result = (char)bytes[0];
                     return true;
@@ -71,8 +93,8 @@ namespace IronPython.Runtime {
                 case 'B':
                     result = bytes[0];
                     return true;
-                case 'u':
-                    result = MemoryMarshal.Read<char>(bytes);
+                case '?':
+                    result = bytes[0] != 0;
                     return true;
                 case 'h':
                     result = MemoryMarshal.Read<short>(bytes);
@@ -82,10 +104,12 @@ namespace IronPython.Runtime {
                     return true;
                 case 'l':
                 case 'i':
+                case 'n':
                     result = MemoryMarshal.Read<int>(bytes);
                     return true;
                 case 'L':
                 case 'I':
+                case 'N':
                     result = MemoryMarshal.Read<uint>(bytes);
                     return true;
                 case 'f':
@@ -100,17 +124,17 @@ namespace IronPython.Runtime {
                 case 'Q':
                     result = MemoryMarshal.Read<ulong>(bytes);
                     return true;
+                case 'P':
+                    result = MemoryMarshal.Read<UIntPtr>(bytes);
+                    return true;
                 default:
                     result = null;
                     return false;
             }
         }
 
-        public static bool TryGetBytes([NotNullWhen(true)]string? typecode, object obj, Span<byte> dest) {
-            if (string.IsNullOrEmpty(typecode) || typecode!.Length > 2 || (typecode.Length == 2 && typecode[0] != '@')) {
-                return false;
-            }
-            switch (typecode[typecode.Length - 1]) {
+        public static bool TryGetBytes(char typecode, object obj, Span<byte> dest) {
+            switch (typecode) {
                 case 'c':
                     var cbyteVal = (byte)Convert.ToChar(obj);
                     return MemoryMarshal.TryWrite(dest, ref cbyteVal);
@@ -120,9 +144,9 @@ namespace IronPython.Runtime {
                 case 'B':
                     var byteVal = Convert.ToByte(obj);
                     return MemoryMarshal.TryWrite(dest, ref byteVal);
-                case 'u':
-                    var charVal = Convert.ToChar(obj);
-                    return MemoryMarshal.TryWrite(dest, ref charVal);
+                case '?':
+                    var boolVal = PythonOps.IsTrue(obj);
+                    return MemoryMarshal.TryWrite(dest, ref boolVal);
                 case 'h':
                     var shortVal = Convert.ToInt16(obj);
                     return MemoryMarshal.TryWrite(dest, ref shortVal);
@@ -131,10 +155,12 @@ namespace IronPython.Runtime {
                     return MemoryMarshal.TryWrite(dest, ref ushortVal);
                 case 'l':
                 case 'i':
+                case 'n':
                     var intVal = Convert.ToInt32(obj);
                     return MemoryMarshal.TryWrite(dest, ref intVal);
                 case 'L':
                 case 'I':
+                case 'N':
                     var uintVal = Convert.ToUInt32(obj);
                     return MemoryMarshal.TryWrite(dest, ref uintVal);
                 case 'f':
@@ -149,6 +175,16 @@ namespace IronPython.Runtime {
                 case 'Q':
                     var ulongVal = Convert.ToUInt64(obj);
                     return MemoryMarshal.TryWrite(dest, ref ulongVal);
+                case 'P':
+                    if (obj is UIntPtr uintptrVal) {
+                        return MemoryMarshal.TryWrite(dest, ref uintptrVal);
+                    }
+                    var bi = Converter.ConvertToBigInteger(obj);
+                    if (bi < 0) {
+                        bi += (UIntPtr.Size == 4 ? new BigInteger(UInt32.MaxValue) : new BigInteger(UInt64.MaxValue)) + 1;
+                    }
+                    uintptrVal = new UIntPtr((ulong)bi);
+                    return MemoryMarshal.TryWrite(dest, ref uintptrVal);
                 default:
                     return false;
             }
@@ -159,13 +195,12 @@ namespace IronPython.Runtime {
         /// width/sign of the field as specified by the given format.
         /// </summary>
         /// <param name="value">The value to be checked.</param>
-        /// <param name="format">Valid struct-style single element format.</param>
-        public static bool CausesOverflow(object value, string format) {
+        /// <param name="typecode">Valid struct-style single element typecode.</param>
+        public static bool CausesOverflow(object value, char typecode) {
             ulong maxValue;
             long minValue;
 
-            int flen = format.Length;
-            switch (flen > 0 && flen <= 2 ? format[flen - 1] : default) {
+            switch (typecode) {
                 case 'c': // char
                     minValue = char.MinValue;
                     maxValue = char.MaxValue;
@@ -178,7 +213,8 @@ namespace IronPython.Runtime {
                     minValue = byte.MinValue;
                     maxValue = byte.MaxValue;
                     break;
-                case 'u': // unicode char
+                case '?': // bool
+                    return false; // bool never causes overflow but is coerced to 0/1
                 case 'h': // signed short
                     minValue = short.MinValue;
                     maxValue = (ulong)short.MaxValue;
@@ -189,11 +225,13 @@ namespace IronPython.Runtime {
                     break;
                 case 'i': // signed int
                 case 'l': // signed long
+                case 'n': // signed index
                     minValue = int.MinValue;
                     maxValue = int.MaxValue;
                     break;
                 case 'I': // unsigned int
                 case 'L': // unsigned long
+                case 'N': // unsigned index
                     minValue = uint.MinValue;
                     maxValue = uint.MaxValue;
                     break;
@@ -201,10 +239,13 @@ namespace IronPython.Runtime {
                     minValue = long.MinValue;
                     maxValue = long.MaxValue;
                     break;
-                case 'P': // pointer
                 case 'Q': // unsigned long long
                     minValue = (long)ulong.MinValue;
                     maxValue = ulong.MaxValue;
+                    break;
+                case 'P': // pointer
+                    minValue = UIntPtr.Size == 4 ? Int32.MinValue : Int64.MinValue;
+                    maxValue = UIntPtr.Size == 4 ? UInt32.MaxValue : UInt64.MaxValue;
                     break;
                 default:
                     return false; // All non-numeric types will not cause overflow.


### PR DESCRIPTION
This PR removes typecode `u` (was for Unicode), and adds `?`, `n`, `N`, and `P`. Also, handling of byteorder codes is corrected and expanded.

For some of these codes, [Python does not prescribe fixed size in bits](https://docs.python.org/3/library/struct.html?highlight=struct#format-characters), so some decisions have to be made.

`P` stands for a void pointer, so it should be 32-bit for 32-bit builds, and 64-bit for 64-bit builds. Python represents it as unsigned integer that corresponds to `void*` in C. In .NET, we have `IntPtr`/`UIntPtr` for the purpose of representing a pointer. I thought it is more in spirit of this typeformat to choose one of them as `P`, although it is debatable, since it introduces incompatibility with CPython. As for the choice between those two types, I used `UIntPtr` because Python uses unsigned values as well. During the assignment, both signed and unsigned values (in range) are accepted (like in CPython), as well as `IntPtr`/`UIntPtr`.

Typecodes `n`/`N` stand for `ssize_t`/`size_t` in C and integers in Python, without a standard size specified. So only native size is available (`@`). This means the size is implementation dependent. In C, `size_t` stands for an integer type capable of holding a size of any object in general, and an array in particular (arrays tend to be the largest structures). Consequently, this type also stands for a type holding a largest possible array index value. In CPython, it is 64-bit for 64-bit builds and 32-bit for 32-bit builds. It is also the size of `sys.maxsize` value. In .NET, even for 64-bit builds, a maximum size of an array is (a bit less than) 2GB, (or 4GB if specifically configured, but even then, the number of elements is limited to be < 2^31). This is reflected by IronPython's `sys.maxsize` being `Int32.MaxValue`. So I believe it is appropriate to set the size of `N` to 32 bits. `n` is simply the signed version of `N` so it follows the suit.

In general, I think it would be good to integrate `TypecodeOps` with code in `PythonStruct`. Python's documentation around `memoryview` often delegates specifics to the documentation on `struct`, and `memoryview` C code utilizes functions from `struct`. So the two should behave the same way. Having the same code doing the same job could also eliminate potentially subtle bugs.

On a last note, `test_memoryview.py` now passes under CPython 3.4.