### PR TITLE
key and reverse arguments are keyword only, for builtin.sorted() and list.sort()

### DIFF
--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -255,14 +255,14 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         public static PythonList dir(CodeContext/*!*/ context) {
             PythonList res = new PythonList(context.Dict.Keys);
 
-            res.sort(context);
+            res.Sort(context);
             return res;
         }
 
         public static PythonList dir(CodeContext/*!*/ context, object? o) {
             IList<object?> ret = PythonOps.GetAttrNames(context, o);
             PythonList lret = new PythonList(ret);
-            lret.sort(context);
+            lret.Sort(context);
             return lret;
         }
 
@@ -551,7 +551,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
                 }
 
                 PythonList names = type.GetMemberNames(context);
-                names.sort(context);
+                names.Sort(context);
 
                 foreach (string? name in names) {
                     if (name == "__class__") continue;
@@ -1374,16 +1374,15 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         public static PythonType slice => DynamicHelpers.GetPythonTypeFromType(typeof(Slice));
 
         public static PythonList sorted(CodeContext/*!*/ context,
-            object? iterable = null,
-            object? key = null,
-            bool reverse = false) {
+            object? iterable,
+            [ParamDictionary, NotNull]IDictionary<string, object> kwArgs) {
 
             IEnumerator iter = PythonOps.GetEnumerator(iterable);
             PythonList l = new PythonList(10);
             while (iter.MoveNext()) {
                 l.AddNoLock(iter.Current);
             }
-            l.sort(context, key, reverse);
+            l.sort(context, kwArgs);
             return l;
         }
 

--- a/Src/IronPython/Runtime/ClrModule.cs
+++ b/Src/IronPython/Runtime/ClrModule.cs
@@ -815,7 +815,7 @@ import Namespace.")]
         public static PythonList Dir(object o) {
             IList<object> ret = PythonOps.GetAttrNames(DefaultContext.Default, o);
             PythonList lret = new PythonList(ret);
-            lret.sort(DefaultContext.Default);
+            lret.Sort(DefaultContext.Default);
             return lret;
         }
 
@@ -825,7 +825,7 @@ import Namespace.")]
         public static PythonList DirClr(object o) {
             IList<object> ret = PythonOps.GetAttrNames(DefaultContext.DefaultCLS, o);
             PythonList lret = new PythonList(ret);
-            lret.sort(DefaultContext.DefaultCLS);
+            lret.Sort(DefaultContext.DefaultCLS);
             return lret;
         }
 

--- a/Src/IronPython/Runtime/DictionaryOps.cs
+++ b/Src/IronPython/Runtime/DictionaryOps.cs
@@ -218,8 +218,8 @@ namespace IronPython.Runtime {
         internal static int CompareToWorker(CodeContext/*!*/ context, IDictionary<object, object> left, PythonList ritems) {
             PythonList litems = ToList(left);
 
-            litems.sort(context);
-            ritems.sort(context);
+            litems.Sort(context);
+            ritems.Sort(context);
 
             return litems.CompareToWorker(ritems);
         }

--- a/Src/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/Src/IronPython/Runtime/Operations/InstanceOps.cs
@@ -232,7 +232,7 @@ namespace IronPython.Runtime.Operations {
 
             res.extend(DynamicHelpers.GetPythonTypeFromType(t).GetMemberNames(context));
 
-            res.sort(context);
+            res.Sort(context);
             return res;
         }
 

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -858,6 +858,31 @@ namespace IronPython.Runtime {
         }
 
         public void sort(CodeContext/*!*/ context,
+            [ParamDictionary, NotNull]IDictionary<string, object> kwArgs) {
+
+            object? key = null;
+            bool reverse = false;
+
+            foreach (var arg in kwArgs) {
+                switch (arg.Key) {
+                    case "key":
+                        key = arg.Value;
+                        break;
+                    case "reverse":
+                        if (!PythonOps.CheckingConvertToBool(arg.Value) && !PythonOps.CheckingConvertToInt(arg.Value)) {
+                            throw PythonOps.TypeErrorForTypeMismatch("integer", arg.Value);
+                        }
+                        reverse = Convert.ToBoolean(arg.Value);
+                        break;
+                    default:
+                        throw PythonOps.TypeError("'{0} is an invalid keyword argument for sort()", arg.Key);
+                }
+            }
+            Sort(context, key, reverse);
+        }
+
+        [PythonHidden]
+        public void Sort(CodeContext/*!*/ context,
                          object? key = null,
                          bool reverse = false) {
             // the empty list is already sorted

--- a/Src/IronPython/Runtime/SimpleNamespace.cs
+++ b/Src/IronPython/Runtime/SimpleNamespace.cs
@@ -49,7 +49,7 @@ namespace IronPython.Runtime {
             int index = infinite.Count;
             infinite.Add(this);
             try {
-                var attrs = Modules.Builtin.sorted(context, __dict__).Select(key => $"{PythonOps.ToString(context, key)}={PythonOps.Repr(context, __dict__[key])}");
+                var attrs = Modules.Builtin.sorted(context, __dict__, new Dictionary<string, object>()).Select(key => $"{PythonOps.ToString(context, key)}={PythonOps.Repr(context, __dict__[key])}");
                 return $"namespace({string.Join(", ", attrs)})";
             } finally {
                 System.Diagnostics.Debug.Assert(index == infinite.Count - 1);

--- a/WhatsNewInPython30.md
+++ b/WhatsNewInPython30.md
@@ -12,7 +12,7 @@ Views And Iterators Instead Of Lists
 Ordering Comparisons
 ==============
 - [ ] The ordering comparison operators (`<`, `<=`, `>=`, `>`) raise a `TypeError` exception when the operands don't have a meaningful natural ordering. Thus, expressions like `1 < ''`, `0 > None` or `len <= len` are no longer valid, and e.g. `None < None` raises `TypeError` instead of returning `False`. A corollary is that sorting a heterogeneous list no longer makes sense - all the elements must be comparable to each other. Note that this does not apply to the `==` and `!=` operators: objects of different incomparable types always compare unequal to each other.
-- [ ] `builtin.sorted()` and `list.sort()` no longer accept the `cmp` argument providing a comparison function. Use the `key` argument instead. N.B. the `key` and `reverse` arguments are now "keyword-only"
+- [x] `builtin.sorted()` and `list.sort()` no longer accept the `cmp` argument providing a comparison function. Use the `key` argument instead. N.B. the `key` and `reverse` arguments are now "keyword-only"
 - [ ] The `cmp()` function should be treated as gone, and the `__cmp__()` special method is no longer supported. Use `__lt__()` for sorting, `__eq__()` with `__hash__()`, and other rich comparisons as needed. (If you really need the `cmp()` functionality, you could use the expression `(a > b) - (a < b)` as the equivalent for` cmp(a, b)`.)
 
 Integers


### PR DESCRIPTION
Rename original `list.sort()` to `list.Sort()` so that it could still be called from c#

Listed in #33 