### PR TITLE
Enable test_imp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,9 @@ jobs:
         name: packages
         path: Package/Release/Packages
     - name: Test (net46)
-      run: ./make.ps1 -frameworks net46 test-all
+      run: |
+        ./make.ps1 -frameworks net46 test-test_imp
+        ./make.ps1 -frameworks net46 test-all
       shell: pwsh
     - name: Test (netcoreapp2.1)
       # TODO: figure out how to test on other OSs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,7 @@ jobs:
         name: packages
         path: Package/Release/Packages
     - name: Test (net46)
-      run: |
-        ./make.ps1 -frameworks net46 test-test_imp
-        ./make.ps1 -frameworks net46 test-all
+      run: ./make.ps1 -frameworks net46 test-all
       shell: pwsh
     - name: Test (netcoreapp2.1)
       # TODO: figure out how to test on other OSs

--- a/Src/IronPython.Modules/zipimport.cs
+++ b/Src/IronPython.Modules/zipimport.cs
@@ -116,12 +116,16 @@ to Zip archives.";
                 path = string.Empty;
                 prefix = string.Empty;
 
-                while (!string.IsNullOrEmpty(buf)) {
-                    if (pal.FileExists(buf)) {
-                        path = buf;
-                        break;
+                try {
+                    while (!string.IsNullOrEmpty(buf)) {
+                        if (pal.FileExists(buf)) {
+                            path = buf;
+                            break;
+                        }
+                        buf = Path.GetDirectoryName(buf);
                     }
-                    buf = Path.GetDirectoryName(buf);
+                } catch {
+                    throw MakeError(context, "not a Zip file");
                 }
 
                 if (!string.IsNullOrEmpty(path)) {

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -802,6 +802,10 @@ namespace IronPython.Compiler {
             var start = GetStart();
 
             int dotCount = 0;
+            while (PeekToken(TokenKind.Constant) && PeekToken().Value == Ellipsis.Value) {
+                dotCount += 3;
+                NextToken();
+            }
             while (MaybeEat(TokenKind.Dot)) {
                 dotCount++;
             }

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -60,7 +60,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
 
             object ret = Importer.ImportModule(context, globals, name, from != null && from.Count > 0, level);
             if (ret == null) {
-                var err = PythonOps.ImportError("No module named {0}", name);
+                var err = PythonOps.ImportError("No module named '{0}'", name);
                 ((PythonExceptions._ImportError)err.GetPythonException()).name = name;
                 return LightExceptions.Throw(err);
             }

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -563,6 +563,7 @@ namespace IronPython.Modules {
             }
 
             private static Stream OpenFile(CodeContext/*!*/ context, PlatformAdaptationLayer pal, string name, FileMode fileMode, FileAccess fileAccess, FileShare fileShare) {
+                if (string.IsNullOrWhiteSpace(name)) throw PythonOps.OSError(2, "No such file or directory", filename: name);
                 try {
                     return pal.OpenInputFileStream(name, fileMode, fileAccess, fileShare);
                 } catch (UnauthorizedAccessException) {

--- a/Src/IronPython/Runtime/Importer.cs
+++ b/Src/IronPython/Runtime/Importer.cs
@@ -341,7 +341,7 @@ namespace IronPython.Runtime {
                 if (lastDot == -1) {
                     // name doesn't include dot, only absolute import possible
                     if (level > 0) {
-                        throw PythonOps.ValueError("Attempted relative import in non-package");
+                        throw PythonOps.SystemError("Parent module '{0}' not loaded, cannot perform relative import", string.Empty);
                     }
 
                     return false;

--- a/Src/IronPython/Runtime/Importer.cs
+++ b/Src/IronPython/Runtime/Importer.cs
@@ -852,11 +852,7 @@ namespace IronPython.Runtime {
 
             foreach (object hook in pathHooks) {
                 try {
-                    object handler = PythonCalls.Call(context, hook, dirname);
-
-                    if (handler != null) {
-                        return handler;
-                    }
+                    return PythonCalls.Call(context, hook, dirname);
                 } catch (ImportException) {
                     // we can't handle the path
                 }

--- a/Src/IronPython/Runtime/Types/Mro.cs
+++ b/Src/IronPython/Runtime/Types/Mro.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Diagnostics;
-using IronPython.Runtime.Operations;
 using System;
+using System.Collections.Generic;
+
+using IronPython.Runtime.Operations;
 
 namespace IronPython.Runtime.Types {
     /// <summary>
@@ -43,15 +43,6 @@ namespace IronPython.Runtime.Types {
     /// </summary>
     internal static class Mro {
         public static List<PythonType> Calculate(PythonType startingType, IList<PythonType> bases) {
-            return Calculate(startingType, new List<PythonType>(bases), false);
-        }
-
-        /// <summary>
-        /// </summary>
-        public static List<PythonType> Calculate(PythonType startingType, IList<PythonType> baseTypes, bool forceNewStyle) {
-            List<PythonType> bases = new List<PythonType>();
-            foreach (PythonType dt in baseTypes) bases.Add(dt);
-
             if (bases.Contains(startingType)) {
                 throw PythonOps.TypeError("a __bases__ item causes an inheritance cycle ({0})", startingType.Name);
             }

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -1220,13 +1220,10 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 
                 // don't look at interfaces - users can inherit from them, but we resolve members
                 // via methods implemented on types and defined by Python.
-                if (dt.IsSystemType && !dt.UnderlyingSystemType.IsInterface) {
-                    return PythonBinder.GetBinder(context).TryResolveSlot(context, dt, this, name, out slot);
-                }
-
-                if (dt.TryLookupSlot(context, name, out slot)) {
+                if (dt.IsSystemType && !dt.UnderlyingSystemType.IsInterface
+                        && PythonBinder.GetBinder(context).TryResolveSlot(context, dt, this, name, out slot)
+                        || dt.TryLookupSlot(context, name, out slot))
                     return true;
-                }
             }
 
             if (UnderlyingSystemType.IsInterface) {

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -1500,6 +1500,13 @@ namespace IronPython.Runtime.Types {
                 Type[] allInterfaces = t.GetInterfaces();
                 List<Type> res = new List<Type>();
                 foreach (Type intf in allInterfaces) {
+#if NET46
+                    // causes failures on Mono: https://github.com/mono/mono/issues/14712
+                    if (intf == typeof(System.Runtime.InteropServices._Type) || intf == typeof(System.Runtime.InteropServices._MethodInfo)) {
+                        continue;
+                    }
+#endif
+
                     try {
                         InterfaceMapping imap = t.GetInterfaceMap(intf);
                         foreach (MethodInfo mi in imap.TargetMethods) {

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -62,6 +62,9 @@ Reason=Takes way too long (ran overnight without completing!)
 [IronPython.test_help]
 IsolationLevel=PROCESS # required for help to use pydoc
 
+[IronPython.test_imp]
+IsolationLevel=PROCESS # expects certain modules not to be loaded
+
 [IronPython.test_importpkg]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -62,9 +62,6 @@ Reason=Takes way too long (ran overnight without completing!)
 [IronPython.test_help]
 IsolationLevel=PROCESS # required for help to use pydoc
 
-[IronPython.test_imp]
-Ignore=true
-
 [IronPython.test_importpkg]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -43,7 +43,6 @@ IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 [IronPython.test_doc]
 RunCondition=NOT $(IS_OSX) # TODO: figure out
 IsolationLevel=PROCESS # required to have quit/exit
-RetryCount=3 # TODO: test_module_doc_cp21360 fails intermittently on CI
 
 [IronPython.test_exec]
 Ignore=true

--- a/Tests/ImpTest/__init__.py
+++ b/Tests/ImpTest/__init__.py
@@ -1,1 +1,0 @@
-my_name = 'imp package test'

--- a/Tests/ImpTest/imptestmod.py
+++ b/Tests/ImpTest/imptestmod.py
@@ -1,1 +1,0 @@
-value = 'imp test module'

--- a/Tests/test_doc.py
+++ b/Tests/test_doc.py
@@ -204,6 +204,7 @@ class DocTest(IronPythonTestCase):
             self.assertTrue(hasattr(e, "__doc__"))
             e.__doc__
 
+    @unittest.skip("intermittent failure during CI") # https://github.com/IronLanguages/ironpython3/issues/887
     def test_module_doc_cp21360(self):
         temp_filename_empty = "cp21360_empty.py"
         temp_filename = "cp21360.py"

--- a/Tests/test_imp.py
+++ b/Tests/test_imp.py
@@ -1232,11 +1232,11 @@ X = 3.14
         with open('test.py', 'w+') as f:
             f.write('x = 42')
 
-        with open('test.py') as inp_file:
-            imp.load_module('my_module_test', inp_file, 'does_not_exist.py', ('', 'U', 1))
-
-        import os
-        os.unlink('test.py')
+        try:
+            with open('test.py') as inp_file:
+                imp.load_module('my_module_test', inp_file, 'does_not_exist.py', ('', 'U', 1))
+        finally:
+            os.unlink('test.py')
 
         self.assertEqual(mod.x, 42)
 

--- a/Tests/test_imp.py
+++ b/Tests/test_imp.py
@@ -1052,7 +1052,6 @@ class Test(object):
         pkg = imp.load_package('some_new_pkg', 'some_path_that_does_not_and_never_will_exist')
         self.assertEqual(sys.modules['some_new_pkg'], pkg)
 
-    @unittest.expectedFailure # TODO
     def test_NullImporter(self):
         self.assertEqual(imp.NullImporter.__module__, 'imp')
 
@@ -1061,7 +1060,8 @@ class Test(object):
             with self.assertRaises(ImportError):
                 import SomeFileThatDoesNotExist
 
-            self.assertTrue(isinstance(sys.path_importer_cache['directory_that_does_not_exist'], imp.NullImporter))
+            # Changed in version 3.3: None is inserted into sys.path_importer_cache instead of an instance of NullImporter.
+            self.assertTrue(sys.path_importer_cache['directory_that_does_not_exist'] is None)
         finally:
             sys.path.remove('directory_that_does_not_exist')
 

--- a/Tests/test_imp.py
+++ b/Tests/test_imp.py
@@ -942,7 +942,6 @@ called = 3.14
             except Exception as e:
                 tb = sys.exc_info()[2].tb_next
                 if is_cli:
-                    self.assertNotEqual(tb.tb_next, None) # check to make sure this hasn't been changed
                     while tb.tb_next is not None: tb = tb.tb_next # importlib has a longer traceback
                 self.assertEqual(tb.tb_lineno, 2)
         finally:

--- a/Tests/test_imp.py
+++ b/Tests/test_imp.py
@@ -315,45 +315,51 @@ else:
         self.assertEqual(imp.is_builtin("builtins"), -1)
 
         imp.init_builtin("sys")
-        imp.init_builtin("__builtin__")
-        imp.init_builtin("exceptions")
+        imp.init_builtin("builtins")
 
     def test_sys_path_none_builtins(self):
         prevPath = sys.path
 
         #import some builtin modules not previously imported
-        sys.path = [None] + prevPath
-        self.assertNotIn('array', sorted(sys.modules.keys()))
-        import array
-        self.assertIn('array', sys.modules)
+        try:
+            sys.path = [None] + prevPath
+            self.assertNotIn('array', sorted(sys.modules.keys()))
+            import array
+            self.assertIn('array', sys.modules)
 
-        sys.path = prevPath + [None]
-        self.assertNotIn('cmath', sys.modules)
-        import array
-        import cmath
-        self.assertIn('array', sys.modules)
-        self.assertIn('cmath', sys.modules)
+            sys.path = prevPath + [None]
+            self.assertNotIn('cmath', sys.modules)
+            import array
+            import cmath
+            self.assertIn('array', sys.modules)
+            self.assertIn('cmath', sys.modules)
 
-        sys.path = [None]
-        self.assertNotIn('_bisect', sys.modules)
-        import array
-        import cmath
-        import _bisect
-        self.assertIn('array', sys.modules)
-        self.assertIn('cmath', sys.modules)
-        self.assertIn('_bisect', sys.modules)
+            sys.path = [None]
+            self.assertNotIn('_bisect', sys.modules)
+            import array
+            import cmath
+            import _bisect
+            self.assertIn('array', sys.modules)
+            self.assertIn('cmath', sys.modules)
+            self.assertIn('_bisect', sys.modules)
+
+        finally:
+            sys.path = prevPath
 
     def test_sys_path_none_userpy(self):
+        prevPath = sys.path
+
         #import a *.py file
         temp_syspath_none = os.path.join(self.test_dir, "temp_syspath_none.py")
         self.write_to_file(temp_syspath_none, "stuff = 3.14")
 
         try:
-            sys.path = [None] + sys.path
+            sys.path = [None] + prevPath
             import temp_syspath_none
             self.assertEqual(temp_syspath_none.stuff, 3.14)
 
         finally:
+            sys.path = prevPath
             self.delete_files(os.path.join(self.test_dir, "temp_syspath_none.py"))
 
     def test_sys_path_none_negative(self):
@@ -569,7 +575,7 @@ called = 3.14
 
     #TODO:@skip("multiple_execute") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=26829
     def test_import_relative_error(self):
-        with self.assertRaises(ValueError if is_cli else SystemError):
+        with self.assertRaises(SystemError):
             exec('from . import *')
 
     @unittest.skip('No access to CPython stdlib')
@@ -788,7 +794,7 @@ called = 3.14
         self.assertRaisesMessage(Exception, 'loader', f)
 
         def f(): import does_not_exist_loader_None
-        self.assertRaisesMessage(ImportError, 'No module named does_not_exist_loader_None' if is_cli else "No module named 'does_not_exist_loader_None'", f)
+        self.assertRaisesMessage(ImportError, "No module named 'does_not_exist_loader_None'", f)
 
         if is_cli:
             from does_not_exist_X import abc

--- a/Tests/test_imp.py
+++ b/Tests/test_imp.py
@@ -21,7 +21,7 @@ class meta_loader(object):
         self.value = value
     def load_module(self, fullname):
         if type(self.value) is Exception: raise self.value
-        
+
         return self.value
 
 class meta_importer(object):
@@ -54,9 +54,20 @@ class ImpTest(IronPythonTestCase):
                     "xxxx"
                     ]
 
+        # backup path values
+        self.__path = sys.path[:]
+        self.__path_hooks = sys.path_hooks[:]
+        self.__meta_path = sys.meta_path[:]
+
     def tearDown(self):
         super(ImpTest, self).tearDown()
         self.clean_directory(self._imptestdir)
+
+        # restore path values
+        sys.path_importer_cache = {}
+        sys.path = self.__path
+        sys.path_hooks = self.__path_hooks
+        sys.meta_path = self.__meta_path
 
     def test_imp_new_module(self):
         x = imp.new_module('abc')
@@ -64,20 +75,20 @@ class ImpTest(IronPythonTestCase):
         x.foo = 'bar'
         import abc
         self.assertEqual(abc.foo, 'bar')
-        
+
         y = imp.new_module('\r\n')
         sys.modules['xyz'] = y
         y.foo = 'foo'
         import xyz
         self.assertEqual(xyz.foo, 'foo')
 
-
+    @unittest.expectedFailure # TODO
     def test_imp_in_exec(self):
         _imfp = 'impmodfrmpkg'
         _f_imfp_init = os.path.join(self.test_dir, _imfp, "__init__.py")
         _f_imfp_mod  = os.path.join(self.test_dir, _imfp, "mod.py")
         _f_imfp_start = os.path.join(self.test_dir, "imfpstart.tpy")
-        
+
         self.write_to_file(_f_imfp_init, "")
         self.write_to_file(_f_imfp_mod, "")
         self.write_to_file(_f_imfp_start, """
@@ -89,33 +100,35 @@ else:
     raise AssertionError("Import of mod from pkg.mod unexpectedly succeeded")
         """)
 
-        # import a package
-        import impmodfrmpkg
-        
-        # create a dictionary like that package
-        glb = {'__name__' : impmodfrmpkg.__name__, '__path__' : impmodfrmpkg.__path__}
-        loc = {}
-        
-        exec('import mod', glb, loc)
-        self.assertTrue('mod' in loc)
-        
-        glb = {'__name__' : impmodfrmpkg.__name__, '__path__' : impmodfrmpkg.__path__}
-        loc = {}
-        exec('from mod import *', glb, loc)
-        #self.assertTrue('value' in loc)         # TODO: Fix me
-        
-        if is_cli:
-            loc = {}
-            exec('from System import *', globals(), loc)
-            
-            self.assertTrue('Int32' in loc)
-            self.assertTrue('Int32' not in globals())
-            
-            exec('from System import *')
-            self.assertTrue('Int32' in dir())
+        try:
+            # import a package
+            import impmodfrmpkg
 
-        self.delete_files(_f_imfp_start)
-        self.clean_directory(os.path.join(self.test_dir, _imfp))
+            # create a dictionary like that package
+            glb = {'__name__' : impmodfrmpkg.__name__, '__path__' : impmodfrmpkg.__path__}
+            loc = {}
+
+            exec('import mod', glb, loc)
+            self.assertTrue('mod' in loc)
+
+            glb = {'__name__' : impmodfrmpkg.__name__, '__path__' : impmodfrmpkg.__path__}
+            loc = {}
+            exec('from mod import *', glb, loc)
+            #self.assertTrue('value' in loc)         # TODO: Fix me
+
+            if is_cli:
+                loc = {}
+                exec('from System import *', globals(), loc)
+
+                self.assertTrue('Int32' in loc)
+                self.assertTrue('Int32' not in globals())
+
+                exec('from System import *')
+                self.assertTrue('Int32' in dir())
+
+        finally:
+            self.delete_files(_f_imfp_start)
+            self.clean_directory(os.path.join(self.test_dir, _imfp))
 
     def test_imp_basic(self):
         magic = imp.get_magic()
@@ -124,8 +137,7 @@ else:
         for suffix in suffixes:
             self.assertTrue(isinstance(suffix, tuple))
             self.assertEqual(len(suffix), 3)
-        self.assertTrue((".py", "U", 1) in suffixes)
-
+        self.assertTrue((".py", "r", 1) in suffixes)
 
     def test_imp_package(self):
         self.write_to_file(self._f_init, "my_name = 'imp package test'")
@@ -153,8 +165,7 @@ else:
         self.write_to_file(self._f_module, "value = 'imp test module'")
         pf, pp, (px, pm, pt) = imp.find_module("imptestmod", [self._imptestdir])
         self.assertEqual(pt, imp.PY_SOURCE)
-        self.assertTrue(pf != None)
-        self.assertTrue(isinstance(pf, file))
+        self.assertTrue(pf is not None)
         module = imp.load_module("imptestmod", pf, pp, (px, pm, pt))
         self.assertEqual(module.value, 'imp test module')
         pf.close()
@@ -165,69 +176,63 @@ else:
         pf, pp, (px, pm, pt) = fm
         self.assertEqual(pt, imp.PY_SOURCE)
         self.assertTrue(pf != None)
-        self.assertTrue(isinstance(pf, file))
         self.assertEqual(px, ".py")
-        self.assertEqual(pm, "U")
+        self.assertEqual(pm, "r")
         module = imp.load_module("imptestmod", pf, pp, (px, pm, pt))
         self.assertEqual(module.value, 'imp test module')
         pf.close()
 
+    @unittest.expectedFailure # TODO
     def test_direct_module_creation(self):
         import math
-        
+
         for baseMod in math, sys:
             module = type(baseMod)
-            
+
             x = module.__new__(module)
-            self.assertEqual(repr(x), "<module '?' (built-in)>")
+            self.assertEqual(repr(x), "<module '?' (built-in)>" if is_cli else "<module '?'>")
             #self.assertEqual(x.__dict__, None)
-            
+
             x.__init__('abc', 'def')
-            self.assertEqual(repr(x), "<module 'abc' (built-in)>")
+            self.assertEqual(repr(x), "<module 'abc' (built-in)>" if is_cli else "<module 'abc'>")
             self.assertEqual(x.__doc__, 'def')
-            
+
             x.__init__('aaa', 'zzz')
-            self.assertEqual(repr(x), "<module 'aaa' (built-in)>")
+            self.assertEqual(repr(x), "<module 'aaa' (built-in)>" if is_cli else "<module 'aaa'>")
             self.assertEqual(x.__doc__, 'zzz')
-                    
+
             # can't assign to module __dict__
-            try:
+            with self.assertRaises(TypeError if is_cli else AttributeError):
                 x.__dict__ = {}
-            except TypeError: pass
-            else: self.assertUnreachable()
-            
+
             # can't delete __dict__
-            try:
+            with self.assertRaises(TypeError if is_cli else AttributeError):
                 del(x.__dict__)
-            except TypeError: pass
-            else: self.assertUnreachable()
-            
+
             # init doesn't clobber dict, it just re-initializes values
-            
+
             x.__dict__['foo'] = 'xyz'
             x.__init__('xyz', 'nnn')
-            
+
             self.assertEqual(x.foo, 'xyz')
-            
+
             # dict is lazily created on set
             x = module.__new__(module)
             x.foo = 23
             self.assertEqual(x.__dict__, {'foo':23})
-            
-            self.assertEqual(repr(x), "<module '?' (built-in)>")
-            
+
+            self.assertEqual(repr(x), "<module '?' (built-in)>" if is_cli else "<module '?'>")
+
             # can't pass wrong sub-type to new
-            try:
+            with self.assertRaises(TypeError):
                 module.__new__(str)
-            except TypeError: pass
-            else: self.assertUnreachable()
-            
+
             # dir on non-initialized module raises TypeError
             x = module.__new__(module)
-            
+
             x.__name__ = 'module_does_not_exist_in_sys_dot_modules'
             self.assertRaises(ImportError, reload, x)
-   
+
     def test_redefine_import(self):
         # redefining global __import__ shouldn't change import semantics
         global __import__
@@ -242,7 +247,7 @@ else:
         called = False
 
         self.assertEqual(called, False)
-   
+
     def test_module_dict(self):
         currentModule = sys.modules[__name__]
         self.assertEqual(isinstance(currentModule.__dict__, collections.Mapping), True)
@@ -259,99 +264,93 @@ else:
             else:
                 imp.release_lock()
 
-
     def test_is_frozen(self):
         for name in self.temp_name:
             f = imp.is_frozen(name)
             self.assertFalse(f)
-            
+
     def test_init_frozen(self):
         for name in self.temp_name:
             f = imp.init_frozen(name)
             self.assertIsNone(f)
-    
+
     def test_is_builtin(self):
-    
+
         self.assertEqual(imp.is_builtin("xxx"),0)
         self.assertEqual(imp.is_builtin("12324"),0)
         self.assertEqual(imp.is_builtin("&*^^"),0)
-        
+
         self.assertEqual(imp.is_builtin("dir"),0)
         self.assertEqual(imp.is_builtin("__doc__"),0)
         self.assertEqual(imp.is_builtin("__name__"),0)
-        
+
         self.assertEqual(imp.is_builtin("_locle"),0)
-        
-        self.assertEqual(imp.is_builtin("cPickle"),1)
+
+        if is_cli:
+            self.assertEqual(imp.is_builtin("_pickle"),0)
+        else:
+            self.assertEqual(imp.is_builtin("_pickle"),1)
         self.assertEqual(imp.is_builtin("_random"),1)
-            
+
         # nt module disabled in Silverlight
         if is_posix:
             self.assertEqual(imp.is_builtin("posix"),1)
         else:
             self.assertEqual(imp.is_builtin("nt"),1)
-            
-        self.assertEqual(imp.is_builtin("thread"),1)
-        
-        
+
+        self.assertEqual(imp.is_builtin("_thread"),1)
+
         # there are a several differences between ironpython and cpython
         if is_cli:
-            self.assertEqual(imp.is_builtin("copy_reg"),1)
+            self.assertEqual(imp.is_builtin("copyreg"),1)
         else:
-            self.assertEqual(imp.is_builtin("copy_reg"),0)
-        
+            self.assertEqual(imp.is_builtin("copyreg"),0)
+
         # supposedly you can't re-init these
         self.assertEqual(imp.is_builtin("sys"), -1)
-        self.assertEqual(imp.is_builtin("__builtin__"), -1)
-        self.assertEqual(imp.is_builtin("exceptions"), -1)
-        
+        self.assertEqual(imp.is_builtin("builtins"), -1)
+
         imp.init_builtin("sys")
         imp.init_builtin("__builtin__")
         imp.init_builtin("exceptions")
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_sys_path_none_builtins(self):
         prevPath = sys.path
 
         #import some builtin modules not previously imported
-        try:
-            sys.path = prevPath + [None]
-            if not imp.is_builtin('copy_reg'):
-                self.assertTrue('copy_reg' not in list(sys.modules.keys()))
-            import datetime
-            import copyreg
-            self.assertTrue('datetime' in list(sys.modules.keys()))
-            self.assertTrue('copy_reg' in list(sys.modules.keys()))
-            
-            sys.path = [None]
-            if not imp.is_builtin('binascii'):
-                self.assertTrue('binascii' not in list(sys.modules.keys()))
-            import datetime
-            import copyreg
-            import binascii
-            self.assertTrue('datetime' in list(sys.modules.keys()))
-            self.assertTrue('copy_reg' in list(sys.modules.keys()))
-            self.assertTrue('binascii' in list(sys.modules.keys()))
-            
-        finally:
-            sys.path = prevPath
+        sys.path = [None] + prevPath
+        self.assertNotIn('array', sorted(sys.modules.keys()))
+        import array
+        self.assertIn('array', sys.modules)
+
+        sys.path = prevPath + [None]
+        self.assertNotIn('cmath', sys.modules)
+        import array
+        import cmath
+        self.assertIn('array', sys.modules)
+        self.assertIn('cmath', sys.modules)
+
+        sys.path = [None]
+        self.assertNotIn('_bisect', sys.modules)
+        import array
+        import cmath
+        import _bisect
+        self.assertIn('array', sys.modules)
+        self.assertIn('cmath', sys.modules)
+        self.assertIn('_bisect', sys.modules)
 
     def test_sys_path_none_userpy(self):
-        prevPath = sys.path
-
         #import a *.py file
         temp_syspath_none = os.path.join(self.test_dir, "temp_syspath_none.py")
         self.write_to_file(temp_syspath_none, "stuff = 3.14")
-        
+
         try:
-            sys.path = [None] + prevPath
+            sys.path = [None] + sys.path
             import temp_syspath_none
             self.assertEqual(temp_syspath_none.stuff, 3.14)
-            
-        finally:
-            sys.path = prevPath
-            self.delete_files(os.path.join(self.test_dir, "temp_syspath_none.py"))
 
+        finally:
+            self.delete_files(os.path.join(self.test_dir, "temp_syspath_none.py"))
 
     def test_sys_path_none_negative(self):
         prevPath = sys.path
@@ -359,34 +358,30 @@ else:
                         prevPath + [None],
                         [None],
                     ]
-                    
+
         try:
             for temp_path in test_paths:
-                
+
                 sys.path = temp_path
-                try:
+                with self.assertRaises(ImportError):
                     import does_not_exist
-                    self.fail('Should not reach this point')
-                except ImportError:
-                    pass
         finally:
             sys.path = prevPath
-
 
     def test_init_builtin(self):
         r  = imp.init_builtin("c_Pickle")
         self.assertEqual(r,None)
-        
+
         r  = imp.init_builtin("2345")
         self.assertEqual(r,None)
         r  = imp.init_builtin("xxxx")
         self.assertEqual(r,None)
         r  = imp.init_builtin("^$%$#@")
         self.assertEqual(r,None)
-        
+
         r  = imp.init_builtin("_locale")
         self.assertTrue(r!=None)
-    
+
     def test_flags(self):
         self.assertEqual(imp.SEARCH_ERROR,0)
         self.assertEqual(imp.PY_SOURCE,1)
@@ -397,8 +392,7 @@ else:
         self.assertEqual(imp.C_BUILTIN,6)
         self.assertEqual(imp.PY_FROZEN,7)
         self.assertEqual(imp.PY_CODERESOURCE,8)
-    
-    
+
     def test_user_defined_modules(self):
         """test the importer using user-defined module types"""
         class MockModule(object):
@@ -407,26 +401,26 @@ else:
 
         TopModule = MockModule("TopModule")
         sys.modules["TopModule"] = TopModule
-        
+
         SubModule = MockModule("SubModule")
         theObj = object()
         SubModule.Object = theObj
         TopModule.SubModule = SubModule
         sys.modules["TopModule.SubModule"] = SubModule
-        
+
         # clear the existing names from our namespace...
         x, y = TopModule, SubModule
         del TopModule, SubModule
-        
+
         # verify we can import TopModule w/ TopModule.SubModule name
         import TopModule.SubModule
         self.assertEqual(TopModule, x)
         self.assertTrue('SubModule' not in dir())
-            
+
         # verify we can import Object from TopModule.SubModule
         from TopModule.SubModule import Object
         self.assertEqual(Object, theObj)
-        
+
         # verify we short-circuit the lookup in TopModule if
         # we have a sys.modules entry...
         SubModule2 = MockModule("SubModule2")
@@ -434,10 +428,10 @@ else:
         sys.modules["TopModule.SubModule"] = SubModule2
         from TopModule.SubModule import Object2
         self.assertEqual(Object2, theObj)
-        
+
         del sys.modules['TopModule']
         del sys.modules['TopModule.SubModule']
-    
+
     def test_constructed_module(self):
         """verify that we don't load arbitrary modules from modules, only truly nested modules"""
         ModuleType = type(sys)
@@ -449,11 +443,8 @@ else:
         SubModule.Object = object()
         TopModule.SubModule = SubModule
 
-        try:
+        with self.assertRaises(ImportError):
             import TopModule.SubModule
-            self.assertUnreachable()
-        except ImportError:
-            pass
 
         del sys.modules['TopModule']
 
@@ -463,41 +454,41 @@ else:
         try:
             class foo(object):
                 b = 'abc'
-            def __import__(name, globals, locals, fromlist):
+            def __import__(name, globals, locals, fromlist, level):
                 global received
                 received = name, fromlist
                 return foo()
-        
+
             saved = builtins.__import__
             builtins.__import__ = __import__
-        
+
             from a import b
             self.assertEqual(received, ('a', ('b', )))
         finally:
             builtins.__import__ = saved
-        
+
     def test_module_name(self):
         import imp
         m = imp.new_module('foo')
-        self.assertEqual(m.__str__(), "<module 'foo' (built-in)>")
+        self.assertEqual(m.__str__(), "<module 'foo' (built-in)>" if is_cli else "<module 'foo'>")
         m.__name__ = 'bar'
-        self.assertEqual(m.__str__(), "<module 'bar' (built-in)>")
+        self.assertEqual(m.__str__(), "<module 'bar' (built-in)>" if is_cli else "<module 'bar'>")
         m.__name__ = None
-        self.assertEqual(m.__str__(), "<module '?' (built-in)>")
+        self.assertEqual(m.__str__(), "<module '?' (built-in)>" if is_cli else "<module None>")
         m.__name__ = []
-        self.assertEqual(m.__str__(), "<module '?' (built-in)>")
+        self.assertEqual(m.__str__(), "<module '?' (built-in)>" if is_cli else "<module []>")
         m.__file__ = None
-        self.assertEqual(m.__str__(), "<module '?' (built-in)>")
+        self.assertEqual(m.__str__(), "<module '?' (built-in)>" if is_cli else "<module [] from None>")
         m.__file__ = []
-        self.assertEqual(m.__str__(), "<module '?' (built-in)>")
+        self.assertEqual(m.__str__(), "<module '?' (built-in)>" if is_cli else "<module [] from []>")
         m.__file__ = 'foo.py'
-        self.assertEqual(m.__str__(), "<module '?' from 'foo.py'>")
+        self.assertEqual(m.__str__(), "<module '?' from 'foo.py'>" if is_cli else "<module [] from 'foo.py'>")
 
     def test_cp7007(self):
         file_contents = '''
 called = 3.14
     '''
-    
+
         strange_module_names = [    "+",
                                     "+a",
                                     "a+",
@@ -508,11 +499,11 @@ called = 3.14
                                     "$",
                                     "^",
                                 ]
-        
+
         strange_file_names = [ os.path.join(self.test_dir, "cp7007", x + ".py") for x in strange_module_names ]
-        
+
         for x in strange_file_names: self.write_to_file(x, file_contents)
-        
+
         try:
             with path_modifier(os.path.join(self.test_dir, 'cp7007')) as p:
                 for x in strange_module_names:
@@ -529,7 +520,7 @@ called = 3.14
             importArgs = list(args)
             importArgs[1] = None    # globals, we don't care about this
             importArgs[2] = None    # locals, we don't care about this either
-            
+
             # we'll pull values out of this class on success, but that's not
             # the important part
             class X:
@@ -540,44 +531,42 @@ called = 3.14
         old_import = get_builtins_dict()['__import__']
         try:
             get_builtins_dict()['__import__'] = myimport
-            
+
             import abc
-            self.assertEqual(importArgs, ['abc', None, None, None])
-            
+            self.assertEqual(importArgs, ['abc', None, None, None, 0])
+
             from . import abc
             self.assertEqual(importArgs, ['', None, None, ('abc',), 1])
-            
+
             from .. import abc
             self.assertEqual(importArgs, ['', None, None, ('abc',), 2])
-            
+
             from ... import abc
             self.assertEqual(importArgs, ['', None, None, ('abc',), 3])
-            
+
             from ...d import abc
             self.assertEqual(importArgs, ['d', None, None, ('abc',), 3])
-            
+
             from ...d import (abc, bar)
             self.assertEqual(importArgs, ['d', None, None, ('abc', 'bar'), 3])
-            
-            from d import (
-                abc,
-                bar)
-            self.assertEqual(importArgs, ['d', None, None, ('abc', 'bar')])
+
+            from d import (abc, bar)
+            self.assertEqual(importArgs, ['d', None, None, ('abc', 'bar'), 0])
 
             code = """from __future__ import absolute_import\nimport abc"""
             exec(code, globals(), locals())
             self.assertEqual(importArgs, ['abc', None, None, None, 0])
-            
+
             def f():exec("from import abc")
             self.assertRaises(SyntaxError, f)
-            
+
         finally:
             get_builtins_dict()['__import__'] = old_import
 
     #TODO:@skip("multiple_execute") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=26829
     def test_import_relative_error(self):
-        def f():  exec('from . import *')
-        self.assertRaises(ValueError, f)
+        with self.assertRaises(ValueError if is_cli else SystemError):
+            exec('from . import *')
 
     @unittest.skip('No access to CPython stdlib')
     def test_import_hooks_import_precence(self):
@@ -599,15 +588,15 @@ called = 3.14
         builtinimp = get_builtins_dict()['__import__']
         try:
             get_builtins_dict()['__import__'] = myimport
-        
+
             import abc
             self.assertEqual(abc, 'myimport')
             self.assertEqual(myimpCalled, None)
-                    
+
             # reload on a built-in hits the loader protocol
             imp.reload(distutils)
             self.assertEqual(myimpCalled, ('distutils', None))
-            
+
             imp.reload(distutils.command)
             self.assertEqual(myimpCalled[0], 'distutils.command')
             self.assertEqual(myimpCalled[1][0][-7:], 'distutils')
@@ -617,12 +606,12 @@ called = 3.14
 
     def test_import_hooks_bad_importer(self):
         class bad_importer(object): pass
-        
+
         mi = bad_importer()
         sys.path.append(mi)
         try:
             def f(): import does_not_exist
-            
+
             self.assertRaises(ImportError, f)
         finally:
             sys.path.remove(mi)
@@ -630,7 +619,7 @@ called = 3.14
         sys.path.append(None)
         try:
             def f(): import does_not_exist
-            
+
             self.assertRaises(ImportError, f)
         finally:
             sys.path.remove(None)
@@ -643,7 +632,7 @@ called = 3.14
         sys.path.append(mi)
         try:
             def f(): import does_not_exist
-            
+
             self.assertRaises(ImportError, f)
         finally:
             sys.path.remove(mi)
@@ -653,36 +642,31 @@ called = 3.14
         errors coming back out correctly"""
         global myimpCalled
         myimpCalled = None
-        
+
         class myimp(object):
             def find_module(self, fullname, path=None):
                 global myimpCalled
                 myimpCalled = fullname, path
                 if fullname == 'does_not_exist_throw':
                     raise Exception('hello')
-        
+
         mi = myimp()
         sys.meta_path.append(mi)
         try:
-            try:
+            with self.assertRaises(ImportError):
                 import does_not_exist
-                self.assertUnreachable()
-            except ImportError: pass
-            
+
             self.assertEqual(myimpCalled, ('does_not_exist', None))
-            
-            try:
+
+            with self.assertRaises(ImportError):
                 from testpkg1 import blah
-                self.assertUnreachable()
-            except ImportError:
-                pass
 
             self.assertEqual(type(myimpCalled[1]), list)
             self.assertEqual(myimpCalled[0], 'testpkg1.blah')
             self.assertEqual(myimpCalled[1][0][-8:], 'testpkg1')
-            
+
             def f(): import does_not_exist_throw
-            
+
             self.assertRaisesMessage(Exception, 'hello', f)
         finally:
             sys.meta_path.remove(mi)
@@ -715,43 +699,44 @@ called = 3.14
                     if fullname[-3:] == 'pkg':
                         # create a package
                         module.__path__ = [fullname]
-                        
+
                     return module
-        
+
         class myimp(object):
             def find_module(self, fullname, path=None):
                 return myloader(fullname, path)
-                
+
         mi = myimp()
         sys.meta_path.append(mi)
         try:
             def f(): import does_not_exist_throw
-            
+
             self.assertRaisesMessage(Exception, 'hello again', f)
-            
-            def f(): import does_not_exist_return_none
-            self.assertRaises(ImportError, f)
-            
+
+            if is_cli:
+                def f(): import does_not_exist_return_none
+                self.assertRaises(ImportError, f)
+
             import does_not_exist_create
             self.assertEqual(does_not_exist_create.__file__, '<myloader file 1>')
             self.assertEqual(does_not_exist_create.fullname, 'does_not_exist_create')
             self.assertEqual(does_not_exist_create.path, None)
-            
+
             imp.reload(does_not_exist_create)
             self.assertEqual(does_not_exist_create.__file__, '<myloader file 2>')
             self.assertEqual(does_not_exist_create.fullname, 'does_not_exist_create')
             self.assertEqual(does_not_exist_create.path, None)
-        
+
             import testpkg1.does_not_exist_create_sub
             self.assertEqual(testpkg1.does_not_exist_create_sub.__file__, '<myloader file 3>')
             self.assertEqual(testpkg1.does_not_exist_create_sub.fullname, 'testpkg1.does_not_exist_create_sub')
             self.assertEqual(testpkg1.does_not_exist_create_sub.path[0][-8:], 'testpkg1')
-            
+
             imp.reload(testpkg1.does_not_exist_create_sub)
             self.assertEqual(testpkg1.does_not_exist_create_sub.__file__, '<myloader file 4>')
             self.assertEqual(testpkg1.does_not_exist_create_sub.fullname, 'testpkg1.does_not_exist_create_sub')
             self.assertEqual(testpkg1.does_not_exist_create_sub.path[0][-8:], 'testpkg1')
-            
+
             import does_not_exist_create_pkg.does_not_exist_create_subpkg
             self.assertEqual(does_not_exist_create_pkg.__file__, '<myloader file 5>')
             self.assertEqual(does_not_exist_create_pkg.fullname, 'does_not_exist_create_pkg')
@@ -762,41 +747,48 @@ called = 3.14
         import toimport
         def prepare(f):
             sys.path_importer_cache = {}
-            sys.path_hooks = [f]
+            sys.path_hooks = [f] + old_path_hooks
             if 'toimport' in sys.modules: del sys.modules['toimport']
-        
-        def hook(*args):  raise Exception('hello')
-        prepare(hook)
-        def f(): import toimport
-        self.assertRaisesMessage(Exception, 'hello', f)
 
-        # ImportError shouldn't propagate out
-        def hook(*args):  raise ImportError('foo')
-        prepare(hook)
-        f()
+        old_path_hooks = sys.path_hooks[:]
+        try:
+            def hook(*args):  raise Exception('hello')
+            prepare(hook)
+            def f(): import toimport
+            self.assertRaisesMessage(Exception, 'hello', f)
 
-        # returning none should be ok
-        def hook(*args): pass
-        prepare(hook)
-        f()
-        
-        sys.path_hooks = []
+            # ImportError shouldn't propagate out
+            def hook(*args):  raise ImportError('foo')
+            prepare(hook)
+            f()
+
+            # returning None
+            def hook(*args): pass
+            prepare(hook)
+            if is_cli:
+                f()
+            else:
+                self.assertRaises(ImportError, f)
+        finally:
+            sys.path_hooks = old_path_hooks
 
     def common_meta_import_tests(self):
         def f(): import does_not_exist_throw
         self.assertRaisesMessage(Exception, 'hello', f)
-        
-        import does_not_exist_abc
-        self.assertEqual(does_not_exist_abc, 'abc')
-        
+
+        if is_cli:
+            import does_not_exist_abc
+            self.assertEqual(does_not_exist_abc, 'abc')
+
         def f(): import does_not_exist_loader_throw
         self.assertRaisesMessage(Exception, 'loader', f)
 
         def f(): import does_not_exist_loader_None
-        self.assertRaisesMessage(ImportError, 'No module named does_not_exist_loader_None', f)
-        
-        from does_not_exist_X import abc
-        self.assertEqual(abc, 3)
+        self.assertRaisesMessage(ImportError, 'No module named does_not_exist_loader_None' if is_cli else "No module named 'does_not_exist_loader_None'", f)
+
+        if is_cli:
+            from does_not_exist_X import abc
+            self.assertEqual(abc, 3)
 
     def test_path_hooks_importer_and_loader(self):
         path = list(sys.path)
@@ -814,18 +806,18 @@ called = 3.14
             sys.path_hooks = hooks
 
     def test_meta_path(self):
-        metapath = list(sys.meta_path)
-        sys.meta_path.append(meta_importer(self))
+        mi = meta_importer(self)
+        sys.meta_path.append(mi)
         try:
             self.common_meta_import_tests()
         finally:
-            sys.meta_path = metapath
+            sys.meta_path.remove(mi)
 
+    @unittest.expectedFailure # TODO
     def test_custom_meta_path(self):
         """most special methods invoked by the runtime from Python only invoke on the type, not the instance.
         the import methods will invoke on instances including using __getattribute__ for resolution or on
         old-style classes.   This test verifies we do a full member lookup to find these methods"""
-        metapath = list(sys.meta_path)
         finder = None
         loader = None
         class K(object):
@@ -839,15 +831,15 @@ called = 3.14
 
         loaderInst = K()
         sys.meta_path.append(loaderInst)
-        
+
         def ok_finder(name, path):
             loaderInst.calls.append( (name, path) )
             return loaderInst
-        
+
         def ok_loader(name):
             loaderInst.calls.append(name)
             return 'abc'
-            
+
         try:
             # dynamically resolve find_module to None
             try:
@@ -855,7 +847,7 @@ called = 3.14
             except TypeError:
                 self.assertEqual(loaderInst.calls[0], 'find_module')
                 loaderInst.calls = []
-            
+
             # dynamically resolve find_module to a function,
             # and load_module to None.
             finder = ok_finder
@@ -865,21 +857,21 @@ called = 3.14
                 self.assertEqual(loaderInst.calls[0], 'find_module')
                 self.assertEqual(loaderInst.calls[1], ('xyz', None))
                 loaderInst.calls = []
-                
-                
+
+
             loader = ok_loader
             import xyz
-            
+
             self.assertEqual(xyz, 'abc')
             self.assertEqual(loaderInst.calls[0], 'find_module')
             self.assertEqual(loaderInst.calls[1], ('xyz', None))
             self.assertEqual(loaderInst.calls[2], 'load_module')
             self.assertEqual(loaderInst.calls[3], 'xyz')
         finally:
-            sys.meta_path = metapath
+            sys.meta_path.remove(loaderInst)
 
     def test_import_kw_args(self):
-        self.assertEqual(__import__(name = 'sys', globals = globals(), locals = locals(), fromlist = [], level = -1), sys)
+        self.assertEqual(__import__(name = 'sys', globals = globals(), locals = locals(), fromlist = [], level = 0), sys)
 
     def test_import_list_empty_string(self):
         """importing w/ an empty string in the from list should be ignored"""
@@ -890,72 +882,65 @@ called = 3.14
         '''
         This test case complements CPython's test_import.py
         '''
-        try:
+        with self.assertRaises(ImportError):
             import Nt
-            self.assertUnreachable("Should not have been able to import 'Nt'")
-        except:
-            pass
 
         self.assertRaises(ImportError, __import__, "Nt")
-        self.assertRaises(ImportError, __import__, "Lib")
+        if is_cli:
+            self.assertRaises(ImportError, __import__, "Lib")
         self.assertRaises(ImportError, __import__, "iptest.Assert_Util")
-            
 
+    @unittest.expectedFailure # TODO
     def test_meta_path_before_builtins(self):
         """the meta path should be consulted before builtins are loaded"""
         class MyException(Exception): pass
-        
+
         class K:
             def find_module(self, name, path):
                 if name == "time": return self
                 return None
             def load_module(self, name):
                 raise MyException
-        
+
         if 'time' in sys.modules:
             del sys.modules["time"]
-        
+
         loader = K()
         sys.meta_path.append(loader)
-        
         try:
-            import time
-            self.assertUnreachable()
-        except MyException:
-            pass    
-        
-        sys.meta_path.remove(loader)
-        
+            with self.assertRaises(MyException):
+                import time
+        finally:
+            sys.meta_path.remove(loader)
+
         import time
 
+    @unittest.expectedFailure # TODO
     def test_file_coding(self):
         try:
             import os
-            f = file('test_coding_mod.py', 'wb+')
-            f.write("# coding: utf-8\nx = '\xe6ble'\n")
-            f.close()
+            with open('test_coding_mod.py', 'wb+') as f:
+                f.write(b"# coding: utf-8\nx = '\xe6ble'\n")
             with path_modifier('.'):
                 import test_coding_mod
                 self.assertEqual(test_coding_mod.x[0], '\xe6')
         finally:
             os.unlink('test_coding_mod.py')
-        
+
         try:
-            f = file('test_coding_2.py', 'wb+')
-            f.write("\xef\xbb\xbf# -*- coding: utf-8 -*-\n")
-            f.write("x = u'ABCDE'\n")
-            f.close()
+            with open('test_coding_2.py', 'wb+') as f:
+                f.write(b"\xef\xbb\xbf# -*- coding: utf-8 -*-\n")
+                f.write(b"x = u'ABCDE'\n")
             with path_modifier('.'):
                 import test_coding_2
                 self.assertEqual(test_coding_2.x, 'ABCDE')
         finally:
             os.unlink('test_coding_2.py')
-            
-            
+
         try:
-            f = file('test_coding_3.py', 'wb+')
-            f.write("# -*- coding: utf-8 -*-\n")
-            f.write("raise Exception()")
+            with open('test_coding_3.py', 'wb+') as f:
+                f.write(b"# -*- coding: utf-8 -*-\n")
+                f.write(b"raise Exception()")
             f.close()
             try:
                 with path_modifier('.'):
@@ -982,7 +967,7 @@ called = 3.14
         self.assertEqual(a.bar, 23)
         self.assertEqual(a.baz, 100)
         self.assertRaises(AttributeError, lambda : a.qux)
-        
+
         #Real *.py file
         import testpkg1.mod1
         class x(type(testpkg1.mod1)):
@@ -1031,27 +1016,26 @@ class Test(object):
         return 34
 """)
 
-        import sys
-        if sys.platform=="win32" and "." not in sys.path:
-            sys.path.append(".")
-        import new
-        import imp
+        try:
+            import sys
+            import imp
 
-        moduleInfo = imp.find_module(shortName)
-        module = imp.load_module(shortName, moduleInfo[0], moduleInfo[1], moduleInfo[2])
-        t = new.classobj('Test1', (getattr(module, 'Test'),), {})
-        i = t()
-        self.assertEqual(i.a(), 34)
+            moduleInfo = imp.find_module(shortName)
+            module = imp.load_module(shortName, moduleInfo[0], moduleInfo[1], moduleInfo[2])
+            t = type('Test1', (getattr(module, 'Test'),), {})
+            i = t()
+            self.assertEqual(i.a(), 34)
 
-        moduleInfo[0].close()
-        self.delete_files(_f_imp_cp13736)
-    
+            moduleInfo[0].close()
+        finally:
+            self.delete_files(_f_imp_cp13736)
+
     def test_import_path_seperator(self):
         """verify using the path seperator in a direct call will result in an ImportError"""
         self.assertRaises(ImportError, __import__, 'iptest\\type_util')
         __import__('iptest.type_util')
-    
-    
+
+    @unittest.expectedFailure # TODO
     def test_load_package(self):
         import testpkg1
         pkg = imp.load_package('libcopy', testpkg1.__path__[0])
@@ -1060,21 +1044,18 @@ class Test(object):
         pkg = imp.load_package('some_new_pkg', 'some_path_that_does_not_and_never_will_exist')
         self.assertEqual(sys.modules['some_new_pkg'], pkg)
 
+    @unittest.expectedFailure # TODO
     def test_NullImporter(self):
-        def f():
-            class x(imp.NullImporter): pass
-            
-        self.assertRaises(TypeError, f)
-        
         self.assertEqual(imp.NullImporter.__module__, 'imp')
-        
+
         sys.path.append('directory_that_does_not_exist')
         try:
-            import SomeFileThatDoesNotExist
-        except ImportError:
-            pass
-            
-        self.assertTrue(isinstance(sys.path_importer_cache['directory_that_does_not_exist'], imp.NullImporter))
+            with self.assertRaises(ImportError):
+                import SomeFileThatDoesNotExist
+
+            self.assertTrue(isinstance(sys.path_importer_cache['directory_that_does_not_exist'], imp.NullImporter))
+        finally:
+            sys.path.remove('directory_that_does_not_exist')
 
     def test_get_frozen_object(self):
         # frozen objects not supported, this always fails
@@ -1093,17 +1074,17 @@ class Test(object):
             self.assertEqual(mymod.__getattribute__(attr), 42)
             self.assertEqual(mymod.__getattribute__(attr), getattr(mymod, attr))
             del d[attr]
-            
+
         for x in dir(type(sys)):
             self.assertEqual(mymod.__getattribute__(x), getattr(mymod, x))
-    
+
     @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_import_lookup_after(self):
         import os
         try:
             _x_mod = os.path.join(self.test_dir, "x.py")
             _y_mod = os.path.join(self.test_dir, "y.py")
-        
+
             self.write_to_file(_x_mod, """
 import sys
 oldmod = sys.modules['y']
@@ -1139,26 +1120,13 @@ X = 3.14
     @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_imp_load_compiled(self):
         #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=17459
-        self.assertEqual(imp.load_compiled("", ""), None)
-        try:
-            _x_mod = os.path.join(self.test_dir, "x.py")
-            self.write_to_file(_x_mod, "")
-            with open(_x_mod, "r") as f:
-                self.assertEqual(imp.load_compiled("", "", f), None)
-        finally:
-            os.unlink(_x_mod)
+        with self.assertRaises(FileNotFoundError):
+            imp.load_compiled("", "")
 
     @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_imp_load_dynamic(self):
         #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=17459
-        self.assertEqual(imp.load_dynamic("", ""), None)
-        try:
-            _x_mod = os.path.join(self.test_dir, "x.py")
-            self.write_to_file(_x_mod, "")
-            with open(_x_mod, "r") as f:
-                self.assertEqual(imp.load_dynamic("", "", f), None)
-        finally:
-            os.unlink(_x_mod)
+        self.assertEqual(imp.load_dynamic, None)
 
     def test_override_dict(self):
         class M(type(sys)):
@@ -1169,36 +1137,36 @@ X = 3.14
             def __dict__(self, value):
                 global setCalled
                 setCalled = True
-        
+
         a = M('foo')
         self.assertEqual(a.__dict__, 'not a dict')
         a.__dict__ = 42
         self.assertEqual(setCalled, True)
-        
+
         class MyDesc(object):
             def __get__(self, instance, context):
                 return 'abc'
-        
+
         class M(type(sys)):
             __dict__ = MyDesc()
-        
+
         a = M('foo')
         self.assertEqual(a.__dict__, 'abc')
-        
+
         # instance members won't be found
         class M(type(sys)): pass
-        
+
         a = M('foo')
         a.__dict__['__dict__'] = 42
-        self.assertEqual(type(a.__dict__), dict)    
-        
+        self.assertEqual(type(a.__dict__), dict)
+
         self.assertEqual(a.__getattribute__('__dict__'), a.__dict__)
-        
+
         class M(type(sys)):
             def baz(self):
                 return 'hello'
             @property
-            def foo(self): 
+            def foo(self):
                 return 'hello'
             @foo.setter
             def foo(self, value):
@@ -1206,17 +1174,17 @@ X = 3.14
             @foo.deleter
             def foo(self):
                 del self.bar
-        
-        a = M('hello')        
+
+        a = M('hello')
         self.assertEqual(a.__getattribute__('baz'), a.baz)
         self.assertEqual(a.baz(), 'hello')
-        
+
         a.__setattr__('foo', 42)
         self.assertEqual(a.__dict__['bar'], 42)
-        
+
         a.__delattr__('foo')
         self.assertTrue('bar' not in a.__dict__)
-        
+
         # mix-in an old-style class
         class old_class:
             def old_method(self):
@@ -1230,13 +1198,13 @@ X = 3.14
             @old_prop.deleter
             def old_prop(self):
                 del self.op
-                
+
         M.__bases__ += (old_class, )
         self.assertEqual(a.old_method(), 42)
-        
+
         a.__setattr__('old_prop', 42)
         self.assertEqual(a.__dict__['op'], 42)
-        
+
         a.__delattr__('old_prop')
         self.assertTrue('op' not in a.__dict__)
 
@@ -1244,37 +1212,35 @@ X = 3.14
         class M2(type(sys)): pass
         a.__setattr__('__class__', M2)
         self.assertEqual(type(a), M2)
-        self.assertRaisesMessage(TypeError, "readonly attribute", a.__setattr__, '__dict__', int)
-        self.assertRaisesMessage(TypeError, "readonly attribute", a.__delattr__, '__dict__')
-        
+        self.assertRaisesMessage(AttributeError, "readonly attribute", a.__setattr__, '__dict__', int)
+        self.assertRaisesMessage(AttributeError, "readonly attribute", a.__delattr__, '__dict__')
+
         # __setattr__/__delattr__ no non-derived type
         m = type(sys)('foo')
         self.assertRaisesMessage(TypeError, "__class__ assignment: only for heap types", m.__setattr__, '__class__', int)
-        self.assertRaisesMessage(TypeError, "readonly attribute", m.__setattr__, '__dict__', int)
+        self.assertRaisesMessage(AttributeError, "readonly attribute", m.__setattr__, '__dict__', int)
         self.assertRaisesMessage(TypeError, "can't delete __class__ attribute", m.__delattr__, '__class__')
-        self.assertRaisesMessage(TypeError, "readonly attribute", m.__delattr__, '__dict__')
-    
+        self.assertRaisesMessage(AttributeError, "readonly attribute", m.__delattr__, '__dict__')
 
     def test_ximp_load_module(self):
         mod = imp.new_module('my_module_test')
         mod.__file__ = 'does_not_exist.py'
         sys.modules['my_module_test'] = mod
-        
-        f = file('test.py', 'w+')
-        f.write('x = 42')
-        f.close()
-        
-        with file('test.py') as inp_file:
+
+        with open('test.py', 'w+') as f:
+            f.write('x = 42')
+
+        with open('test.py') as inp_file:
             imp.load_module('my_module_test', inp_file, 'does_not_exist.py', ('', 'U', 1))
-            
+
         import os
         os.unlink('test.py')
-            
+
         self.assertEqual(mod.x, 42)
-    
+
+    @unittest.expectedFailure # TODO
     def test_import_string_from_list_cp26098(self):
         self.assertEqual(__import__('email.mime.application', globals(), locals(), 'MIMEApplication').__name__, 'email.mime.application')
-
 
     @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_new_builtin_modules(self):
@@ -1282,33 +1248,33 @@ X = 3.14
         clr.AddReference('IronPythonTest')
         import test_new_module
         dir(test_new_module)
-        
+
         # static members should still be accessible
         self.assertEqual(test_new_module.StaticMethod(), 42)
         self.assertEqual(test_new_module.StaticField, 42)
         self.assertEqual(test_new_module.StaticProperty, 42)
-        
+
         # built-in functions shouldn't appear to be bound
         self.assertEqual(test_new_module.test_method.__doc__, 'test_method() -> object%s' % os.linesep)
         self.assertEqual(test_new_module.test_method.__self__, None)
-        
+
         # unassigned attributes should throw as if the callee failed to look them up
         self.assertRaises(NameError, lambda : test_new_module.get_test_attr())
-        
+
         # unassigned builtins should return the built-in as if the caller looked them up
         self.assertEqual(test_new_module.get_min(), min)
-        
+
         # we should be able to assign to values
         test_new_module.test_attr = 42
-        
+
         # and the built-in module should see them
         self.assertEqual(test_new_module.get_test_attr(), 42)
         self.assertEqual(test_new_module.test_attr, 42)
-        
+
         # static members take precedence over things in globals
         self.assertEqual(test_new_module.test_overlap_method(), 42)
         self.assertEqual(type(test_new_module.test_overlap_type), type)
-        
+
         test_new_module.inc_value()
         self.assertEqual(test_new_module.get_value(), 1)
         test_new_module.inc_value()


### PR DESCRIPTION
There are still a tests which are marked as `expectedFailure` which need to be debugged (note that they also fail with CPython).