### PR TITLE
Fix array.array construction from memoryview

### DIFF
--- a/Src/IronPython.Modules/array.cs
+++ b/Src/IronPython.Modules/array.cs
@@ -124,7 +124,11 @@ namespace IronPython.Modules {
                 _data = CreateData(_typeCode);
             }
 
-            public array([NotNull]string type, [BytesLike, NotNull]IList<byte> initializer) : this(type) {
+            public array([NotNull]string type, [NotNull]Bytes initializer) : this(type) {
+                frombytes(initializer);
+            }
+
+            public array([NotNull]string type, [NotNull]ByteArray initializer) : this(type) {
                 frombytes(initializer);
             }
 
@@ -325,15 +329,17 @@ namespace IronPython.Modules {
                 if (bytes.Count < bytesNeeded) throw PythonOps.EofError("file not large enough");
             }
 
-            public void frombytes([BytesLike, NotNull]IList<byte> s) {
-                if ((s.Count % itemsize) != 0) throw PythonOps.ValueError("bytes length not a multiple of itemsize");
+            public void frombytes([NotNull]IBufferProtocol buffer) {
+                using IPythonBuffer pb = buffer.GetBuffer();
+                if ((pb.NumBytes() % itemsize) != 0) throw PythonOps.ValueError("bytes length not a multiple of item size");
 
-                if (s is Bytes b) {
+                if (buffer is Bytes b) {
                     FromBytes(b);
                     return;
                 }
 
-                FromStream(new MemoryStream(s.ToArray(), false));
+                // TODO: eliminate data copy
+                FromStream(new MemoryStream(pb.ToArray(), false));
             }
 
             private void FromBytes(Bytes b) {

--- a/Tests/modules/type_related/test_array.py
+++ b/Tests/modules/type_related/test_array.py
@@ -175,6 +175,21 @@ class ArrayTest(unittest.TestCase):
         #--b
         self.assertEqual(array.array('b', b'foo'), array.array('b', [102, 111, 111]))
 
+        #--H
+        self.assertEqual(array.array('H', b'foof'), array.array('H', [28518, 26223]))
+        self.assertEqual(array.array('H', bytearray(b'foof')), array.array('H', [28518, 26223]))
+        self.assertEqual(array.array('H', array.array('b', b'foof')), array.array('H', [102, 111, 111, 102]))
+        self.assertEqual(array.array('H', memoryview(b'foof')), array.array('H', [102, 111, 111, 102]))
+        self.assertEqual(array.array('H', memoryview(b"foof").cast('h')), array.array('H', [28518, 26223]))
+        self.assertEqual(array.array('H', memoryview(b"f.o.")[::2]), array.array('H', [102, 111]))
+        self.assertEqual(array.array('H', memoryview(b"fo\0\0of\0\0").cast('I')), array.array('H', [28518, 26223]))
+
+        self.assertRaisesRegex(ValueError, "^bytes length not a multiple of item size$", array.array, 'H', b'foo')
+        with self.assertRaisesRegex(NotImplementedError, "^multi-dimensional sub-views are not implemented$"):
+            array.array('H', memoryview(bytes(range(16))).cast('H', (4,2)))
+        with self.assertRaisesRegex(TypeError, "^invalid indexing of 0-dim memory$"):
+            array.array('H', memoryview(b"xy").cast('H', ()))
+
     def test_array___iter__(self):
         '''
         TODO
@@ -316,6 +331,19 @@ class ArrayTest(unittest.TestCase):
         TODO
         '''
         pass
+
+    def test_array_frombytes(self):
+        # TODO: add more tests
+        a = array.array('H')
+
+        a.frombytes(b"foof")
+        self.assertEqual(a, array.array('H', [28518, 26223]))
+
+        a.frombytes(memoryview(b"foof"))
+        self.assertEqual(a, array.array('H', [28518, 26223, 28518, 26223]))
+
+        with self.assertRaisesRegex(BufferError, "^memoryview: underlying buffer is not C-contiguous$"):
+            a.frombytes(memoryview(b"f.o.")[::2])
 
     def test_array_fromlist(self):
         '''


### PR DESCRIPTION
Apparently, `memoryview` used to initialize `array.array` is treated as an iterable, not a bytes-like object. This is true also for other objects implementing Python buffer protocol (like Numpy's ND-arrays), exept for `bytes` and `bytearray`.

`array.array.frombytes`, on the other hand, always treats its argument as a bytes-like object.