### PR TITLE
Get test_surrogateescape passing with CPython

### DIFF
--- a/Tests/test_surrogateescape.py
+++ b/Tests/test_surrogateescape.py
@@ -9,7 +9,7 @@
 import unittest
 import codecs
 
-from iptest import run_test
+from iptest import run_test, is_cli
 
 class SurrogateEscapeTest(unittest.TestCase):
     def test_ascii(self):
@@ -44,11 +44,12 @@ class SurrogateEscapeTest(unittest.TestCase):
         encoded = s_dabcd.encode("utf_16_be", errors="surrogateescape")
         self.assertEqual(encoded, b_dabcd)
 
+    @unittest.skipUnless(is_cli, "surrogateescape is not specified for non-ASCII compatible encodings (PEP 383)")
     def test_utf_32(self):
-        b_dabcdef = b'\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf'
-        s_dabcdef = b_dabcdef.decode("utf_32", errors="surrogateescape")
-        encoded = s_dabcdef.encode("utf_32", errors="surrogateescape")
+        b_89dabcdef = b'\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf'
+        s_89dabcdef = b_89dabcdef.decode("utf_32", errors="surrogateescape")
+        encoded = s_89dabcdef.encode("utf_32", errors="surrogateescape")
         # encoded will have BOM added
-        self.assertEqual(encoded, codecs.BOM_UTF32 + b_dabcdef)
+        self.assertEqual(encoded, codecs.BOM_UTF32 + b_89dabcdef)
 
 run_test(__name__)


### PR DESCRIPTION
The behaviour of the `surrogateescape` error handler is only well defined for ASCII-compatible encodings. From [PEP 383](https://www.python.org/dev/peps/pep-0383/#discussion):

> Encodings that are not compatible with ASCII are not supported by this specification

Both UTF-16 and UTF-32 are not ASCII compatible. CPython, however, does not raise `NotImplementedError` with these encodings when `surrogateescape` is used. It will often produce something, and sometimes fail with `UnicodeDecodeError` /`UnicodeEncodeError`. IronPython tries to mimic CPython's behaviour in those cases. The efforts seem to be largely successful for the UTF-16 case, but not so for UTF-32 case, in which case the CPython's behaviour is less consistent. Therefore I have disabled the `surrogateescape` test with UTF-32 when run with CPython.