### PR TITLE
Prefer BigInteger to UInt64 conversion over to Int32/UInt32

### DIFF
--- a/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
+++ b/Src/IronPython/Runtime/Binding/PythonOverloadResolver.cs
@@ -71,6 +71,26 @@ namespace IronPython.Runtime.Binding {
                 return basePreferred;
             }
 
+            if (Converter.IsNumeric(arg.LimitType)) {
+                if (Converter.IsFloatingPoint(arg.LimitType)) {
+                    if (Converter.IsFloatingPoint(candidateOne.Type)) {
+                        if (!Converter.IsFloatingPoint(candidateTwo.Type)) {
+                            return Candidate.One;
+                        }
+                    } else if (Converter.IsFloatingPoint(candidateTwo.Type)) {
+                        return Candidate.Two;
+                    }
+                } else { // arg is integer
+                    if (Converter.IsInteger(candidateOne.Type)) {
+                        if (!Converter.IsInteger(candidateTwo.Type)) {
+                            return Candidate.One;
+                        }
+                    } else if (Converter.IsInteger(candidateTwo.Type)) {
+                        return Candidate.Two;
+                    }
+                }
+            }
+
             bool isBytesLikeOne = IsBytesLikeParameter(candidateOne);
             bool isBytesLikeTwo = IsBytesLikeParameter(candidateTwo);
 

--- a/Src/IronPython/Runtime/Converter.cs
+++ b/Src/IronPython/Runtime/Converter.cs
@@ -429,6 +429,7 @@ namespace IronPython.Runtime {
         private static readonly Type DoubleType = typeof(System.Double);
         private static readonly Type DecimalType = typeof(System.Decimal);
         private static readonly Type Int64Type = typeof(System.Int64);
+        private static readonly Type UInt64Type = typeof(System.UInt64);
         private static readonly Type CharType = typeof(System.Char);
         private static readonly Type SingleType = typeof(System.Single);
         private static readonly Type BooleanType = typeof(System.Boolean);
@@ -824,13 +825,14 @@ namespace IronPython.Runtime {
                 } else if (genTo == NullableOfTType) {
                     if (fromType == typeof(DynamicNull) || CanConvertFrom(fromType, toType.GetGenericArguments()[0], allowNarrowing)) {
                         return true;
-                    }                
+                    }
                 } else if (genTo == IDictOfTType) {
                     return IDictionaryOfObjectType.IsAssignableFrom(fromType);
                 }
             }
 
             if (fromType == BigIntegerType && toType == Int64Type) return true;
+            if (fromType == BigIntegerType && toType == UInt64Type) return true;
             if (toType.IsEnum && fromType == Enum.GetUnderlyingType(toType)) return true;
 
             return false;

--- a/Src/IronPython/Runtime/Converter.cs
+++ b/Src/IronPython/Runtime/Converter.cs
@@ -908,6 +908,23 @@ namespace IronPython.Runtime {
             }
         }
 
+        internal static bool IsFloatingPoint(Type t) {
+            switch (t.GetTypeCode()) {
+                case TypeCode.Double:
+                case TypeCode.Single:
+                case TypeCode.Decimal:
+                    return true;
+                case TypeCode.Object:
+                    return t == ComplexType;
+                default:
+                    return false;
+            }
+        }
+
+        internal static bool IsInteger(Type t) {
+            return IsNumeric(t) && !IsFloatingPoint(t);
+        }
+
         private static bool IsPythonType(Type t) {
             return t.FullName.StartsWith("IronPython."); //!!! this and the check below are hacks
         }

--- a/Src/IronPython/Runtime/Converter.cs
+++ b/Src/IronPython/Runtime/Converter.cs
@@ -561,7 +561,6 @@ namespace IronPython.Runtime {
 
             if (fromType == typeof(BigInteger)) {
                 if (toType == typeof(double)) return true;
-                if (toType == typeof(float)) return true;
                 if (toType == typeof(Complex)) return true;
                 return false;
             }
@@ -770,8 +769,9 @@ namespace IronPython.Runtime {
                 }
             }
 
-            if (toType == DoubleType && fromType == DecimalType) return true;
-            if (toType == SingleType && fromType == DecimalType) return true;
+            if (toType == DoubleType || toType == SingleType) {
+                if (IsNumeric(fromType) && fromType != ComplexType) return true;
+            }
 
             if (toType.IsArray) {
                 return typeof(PythonTuple).IsAssignableFrom(fromType);

--- a/Tests/test_memoryview.py
+++ b/Tests/test_memoryview.py
@@ -480,10 +480,9 @@ class CastTests(unittest.TestCase):
         mv = memoryview(ba)
         mvr = mv.cast('R')
 
-        # https://github.com/IronLanguages/ironpython3/issues/868
-        #mvr[0] = System.UIntPtr(0xFFFFFFFFFFFFFFFF)
-        #self.assertIsInstance(mvr[1], System.UIntPtr)
-        #self.assertEqual(mvr[0].ToUInt64(), 0xFFFFFFFFFFFFFFFF)
+        mvr[0] = System.UIntPtr(0xFFFFFFFFFFFFFFFF)
+        self.assertIsInstance(mvr[1], System.UIntPtr)
+        self.assertEqual(mvr[0].ToUInt64(), 0xFFFFFFFFFFFFFFFF)
         mvr[1] = System.IntPtr(-1)
         self.assertIsInstance(mvr[1], System.UIntPtr)
         self.assertEqual(mvr[1].ToUInt64(), 0xFFFFFFFFFFFFFFFF)
@@ -492,10 +491,9 @@ class CastTests(unittest.TestCase):
             mvr[0] = 0
 
         mvr = mv.cast('r')
-        # https://github.com/IronLanguages/ironpython3/issues/868
-        #mvr[0] = System.UIntPtr(0xFFFFFFFFFFFFFFFF)
-        #self.assertIsInstance(mvr[1], System.IntPtr)
-        #self.assertEqual(mvr[0].ToInt64(), -1)
+        mvr[0] = System.UIntPtr(0xFFFFFFFFFFFFFFFF)
+        self.assertIsInstance(mvr[1], System.IntPtr)
+        self.assertEqual(mvr[0].ToInt64(), -1)
         mvr[1] = System.IntPtr(-1)
         self.assertIsInstance(mvr[1], System.IntPtr)
         self.assertEqual(mvr[1].ToInt64(), -1)

--- a/Tests/test_methodbinder2.py
+++ b/Tests/test_methodbinder2.py
@@ -65,7 +65,6 @@ if is_cli:
     arrayByte = array_byte((10, 20))
     arrayObj = array_object(['str', 10])
 
-
 @skipUnlessIronPython()
 class MethodBinder2Test(IronPythonTestCase):
     def setUp(self):
@@ -192,8 +191,6 @@ class MethodBinder2Test(IronPythonTestCase):
         target.M140(PT_C3_int(), PT_C3_int())
         self.assertEqual(Flag.Value, 140); Flag.Value = 99
 
-
-
 ######### generated python code below #########
 
     def test_arg_ClrReference(self):
@@ -318,7 +315,6 @@ class MethodBinder2Test(IronPythonTestCase):
     def test_arg_String(self):
         from IronPythonTest.BinderTest import COverloads_String
         target = COverloads_String()
-        from IronPythonTest.BinderTest import COverloads_String
         for (arg, mapping, funcTypeError, funcOverflowError) in [
             (         'a', _merge(_first('M100 M101 '), _second('M102 ')), '', '', ),
             (       'abc', _merge(_first('M100 M101 '), _second('M102 ')), '', '', ),
@@ -335,7 +331,7 @@ class MethodBinder2Test(IronPythonTestCase):
             (        E1.A, _first('M100 '), 'M101 ', '', ),
             (        E2.A, _first('M101 '), 'M100 ', '', ),
             (           1, _second('M100 M101 '), '', '', ),
-            (     UInt163, _second('M101 '), 'M100 ', '', ),
+            (     UInt163, _second('M100 M101 '), '', '', ),
             ]:
             self._try_arg(target, arg, mapping, funcTypeError, funcOverflowError)
 
@@ -383,45 +379,6 @@ class MethodBinder2Test(IronPythonTestCase):
             ]:
             self._try_arg(target, arg, mapping, funcTypeError, funcOverflowError)
 
-    #------------------------------------------------------------------------------
-    #--Boolean
-    def test_arg_boolean_overload(self):
-        '''
-        TODO:
-        In addition to test_arg_boolean_overload, we need to split up test_arg_Boolean
-        into two more functions as well - test_arg_boolean_overload_typeerror and
-        test_arg_boolean_overload_overflowerror.  This should be done for all of these
-        types of tests to make them more readable and maintainable.
-        '''
-        from IronPythonTest.BinderTest import COverloads_Boolean, Flag
-        o = COverloads_Boolean()
-        
-        param_method_map = {
-            None : [        o.M100, o.M101, o.M102, o.M103, o.M104, o.M105, o.M106, 
-                            o.M107, o.M108, o.M109, o.M110, o.M111],
-            True : [        o.M100, o.M101, o.M102, o.M103, o.M104, o.M105, o.M106, o.M107, o.M108, o.M109, o.M110, o.M111, o.M112],
-            False : [       o.M100, o.M101, o.M102, o.M103, o.M104, o.M105, o.M106, o.M107, o.M108, o.M109, o.M110, o.M111, o.M112],
-            100 : [         o.M100],
-            myint(100): [   o.M100],
-            -100 : [        o.M100],
-            UInt32Max: [    o.M100, o.M106],
-            long(200) : [   o.M100, o.M106, o.M109],
-            long(-200) : [  o.M100, o.M106, o.M109],
-            Byte10 : [      o.M100],
-            SBytem10 : [    o.M100],
-            Int1610 : [     o.M100],
-            Int16m20 : [    o.M100],
-            12.34 : [       o.M100, o.M101, o.M102, o.M103, o.M104, o.M105, o.M106, o.M107, o.M108, o.M109, o.M110],
-            
-        }
-        
-        for param in param_method_map.keys():
-            for meth in param_method_map[param]:
-                expected_flag = int(meth.__name__[1:])
-                meth(param)
-                self.assertEqual(expected_flag, Flag.Value)
-        
-
     def test_arg_Boolean(self):
         from IronPythonTest.BinderTest import COverloads_Boolean
         target = COverloads_Boolean()
@@ -429,17 +386,17 @@ class MethodBinder2Test(IronPythonTestCase):
             (        None, _merge(_first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 '), _second('M112 ')), '', '', ),
             (        True, _merge(_first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), _second('')), '', '', ),
             (       False, _merge(_first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), _second('')), '', '', ),
-            (         100, _merge(_first('M100 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
+            (         100, _merge(_first('M100 '), _second('M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 ')), '', '', ),
             (  myint(100), _merge(_first('M100 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
-            (        -100, _merge(_first('M100 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
-            (   UInt32Max, _merge(_first('M100 M106 '), _second('M105 M107 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M104 ', '', ),
-            (   long(200), _merge(_first('M100 M106 M109 '), _second('M108 M112 M110 M111 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
-            (  long(-200), _merge(_first('M100 M106 M109 '), _second('M108 M112 M110 M111 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
-            (      Byte10, _merge(_first('M100 '), _second('M101 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 ')), 'M102 ', '', ),
-            (    SBytem10, _merge(_first('M100 '), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), 'M101 M103 M105 M107 ', '', ),
-            (     Int1610, _merge(_first('M100 '), _second('M104 M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M105 M107 ', '', ),
-            (    Int16m20, _merge(_first('M100 '), _second('M104 M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M105 M107 ', '', ),
-            (       12.34, _merge(_first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 '), _second('M111 M112 ')), '', '', ),
+            (        -100, _merge(_first('M100 '), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), '', 'M101 M103 M105 M107 ', ),
+            (   UInt32Max, _merge(_first('M100 '), _second('M105 M107 M108 M109 M110 M111 M112 ')), '', 'M101 M102 M103 M104 M106 ', ),
+            (   long(200), _merge(_first('M100 M109 '), _second('M101 M103 M104 M105 M106 M107 M108 M112 M110 M111 ')), '', 'M102 ', ),
+            (  long(-200), _merge(_first('M100 M109 '), _second('M104 M106 M108 M112 M110 M111 ')), '', 'M101 M102 M103 M105 M107 ', ),
+            (      Byte10, _merge(_first('M100 '), _second('M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 ')), '', '', ),
+            (    SBytem10, _merge(_first('M100 '), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), '', 'M101 M103 M105 M107 ', ),
+            (     Int1610, _merge(_first('M100 '), _second('M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 ')), '', '', ),
+            (    Int16m20, _merge(_first('M100 '), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), '', 'M101 M103 M105 M107 ', ),
+            (       12.34, _merge(_first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 '), _second('M110 M111 M112 ')), '', '', ),
             ]:
             self._try_arg(target, arg, mapping, funcTypeError, funcOverflowError)
 
@@ -451,17 +408,17 @@ class MethodBinder2Test(IronPythonTestCase):
             (        None, _merge(_first(''), _second('M100 M112 ')), 'M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 ', '', ),
             (        True, _merge(_first('M101 M102 M103 M104 M105 M107 '), _second('M100 M106 M108 M109 M110 M112 M111 ')), '', '', ),
             (        False, _merge(_first('M101 M102 M103 M104 M105 M107 '), _second('M100 M106 M108 M109 M110 M112 M111 ')), '', '', ),
-            (         100, _merge(_first('M101 M102 M103 M104 M105 M107 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
+            (         100, _merge(_first('M100 M101 M102 M103 M104 M105 M107 '), _second('M106 M108 M109 M110 M111 M112 ')), '', '', ),
             (  myint(100), _merge(_first('M101 M102 M103 M104 M105 M107 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
-            (        -100, _merge(_first(''), _second('M106 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M102 M103 M104 M105 M107 ', ),
-            (   UInt32Max, _merge(_first(''), _second('M105 M107 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M102 M103 M104 M106 ', ),
-            (   long(200), _merge(_first('M101 M102 M103 M104 M105 M106 M107 M109 '), _second('M108 M112 M110 M111 ')), 'M100 ', '', ),
-            (  long(-200), _merge(_first(''), _second('M108 M112 M110 M111 ')), 'M100 ', 'M101 M102 M103 M104 M105 M106 M107 M109 ', ),
+            (        -100, _merge(_first(''), _second('M106 M108 M109 M110 M111 M112 ')), '', 'M100 M101 M102 M103 M104 M105 M107 ', ),
+            (   UInt32Max, _merge(_first(''), _second('M105 M107 M108 M109 M110 M111 M112 ')), '', 'M100 M101 M102 M103 M104 M106 ', ),
+            (   long(200), _merge(_first('M100 M101 M102 M103 M104 M105 M106 M109 '), _second('M107 M108 M110 M111 M112 ')), '', '', ),
+            (  long(-200), _merge(_first(''), _second('M108 M112 M110 M111 ')), '', 'M100 M101 M102 M103 M104 M105 M106 M107 M109 ', ),
             (      Byte10, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
-            (    SBytem10, _merge(_first(''), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M103 M105 M107 ', ),
-            (     Int1610, _merge(_first('M101 M102 M103 M105 M107 '), _second('M104 M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
-            (    Int16m20, _merge(_first(''), _second('M104 M106 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M102 M103 M105 M107 ', ),
-            (       12.34, _merge(_first('M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 '), _second('M100 M111 M112 ')), '', '', ),
+            (    SBytem10, _merge(_first(''), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), '', 'M100 M101 M103 M105 M107 ', ),
+            (     Int1610, _merge(_first('M100 M101 M102 M103 M105 M107 '), _second('M104 M106 M108 M109 M110 M111 M112 ')), '', '', ),
+            (    Int16m20, _merge(_first(''), _second('M104 M106 M108 M109 M110 M111 M112 ')), '', 'M100 M101 M102 M103 M105 M107 ', ),
+            (       12.34, _merge(_first('M101 M102 M103 M104 M105 M106 M107 M108 '), _second('M100 M109 M110 M111 M112 ')), '', '', ),
             ]:
             self._try_arg(target, arg, mapping, funcTypeError, funcOverflowError)
 
@@ -472,17 +429,17 @@ class MethodBinder2Test(IronPythonTestCase):
             (        None, _merge(_first(''), _second('M100 M112 ')), 'M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 ', '', ),
             (        True, _merge(_first('M101 '), _second('M100 M102 M103 M104 M105 M107 M106 M108 M109 M110 M112 M111 ')), '', '', ),
             (       False, _merge(_first('M101 '), _second('M100 M102 M103 M104 M105 M107 M106 M108 M109 M110 M112 M111 ')), '', '', ),
-            (         100, _merge(_first('M101 '), _second('M102 M103 M104 M105 M107 M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
+            (         100, _merge(_first('M100 M101 '), _second('M102 M103 M104 M105 M107 M106 M108 M109 M110 M111 M112 ')), '', '', ),
             (  myint(100), _merge(_first('M101 '), _second('M102 M103 M104 M105 M107 M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
-            (        -100, _merge(_first('M101 '), _second('M103 M106 M108 M109 M110 M111 M112 ')), 'M100 ', 'M102 M104 M105 M107 ', ),
-            (   UInt32Max, _merge(_first(''), _second('M105 M107 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M102 M103 M104 M106 ', ),
-            (   long(200), _merge(_first('M101 M106 M109 '), _second('M102 M104 M105 M107 M108 M110 M111 M112 ')), 'M100 ', 'M103 ', ),
-            (  long(-200), _merge(_first('M101 M106 M109 '), _second('M108 M110 M111 M112 ')), 'M100 ', 'M102 M103 M104 M105 M107 ', ),
+            (        -100, _merge(_first('M100 M101 '), _second('M103 M106 M108 M109 M110 M111 M112 ')), '', 'M102 M104 M105 M107 ', ),
+            (   UInt32Max, _merge(_first(''), _second('M105 M107 M108 M109 M110 M111 M112 ')), '', 'M100 M101 M102 M103 M104 M106 ', ),
+            (   long(200), _merge(_first('M100 M101 M106 M109 '), _second('M102 M104 M105 M107 M108 M110 M111 M112 ')), '', 'M103 ', ),
+            (  long(-200), _merge(_first('M100 M101 M106 M109 '), _second('M108 M110 M111 M112 ')), '', 'M102 M103 M104 M105 M107 ', ),
             (      Byte10, _merge(_first('M100 M101 M103 M106 M108 M109 M110 M111 M112'), _second('M102 M104 M105 M107 ')), '', '', ),
             (    SBytem10, _merge(_first('M100 M101 M102 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), _second('M103 ')), '', '', ),
             (     Int1610, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
             (    Int16m20, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
-            (       12.34, _merge(_first('M101 M106 M108 M109 M110 '), _second('M100 M111 M112 M102 M103 M104 M105 M107 ')), '', '', ),
+            (       12.34, _merge(_first('M101 M106 M108 '), _second('M100 M111 M109 M110 M112 M102 M103 M104 M105 M107 ')), '', '', ),
             ]:
             self._try_arg(target, arg, mapping, funcTypeError, funcOverflowError)
 
@@ -496,9 +453,9 @@ class MethodBinder2Test(IronPythonTestCase):
             (         100, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
             (  myint(100), _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
             (        -100, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
-            (   UInt32Max, _merge(_first(''), _second('M100 M106 M107 M108 M109 M110 M111 M112 ')), '', 'M101 M102 M103 M104 M105 ', ),
-            (   long(200), _merge(_first('M101 M109 '), _second('M100 M102 M104 M105 M106 M107 M108 M110 M111 M112 ')), '', 'M103 ', ),
-            (  long(-200), _merge(_first('M101 M109 '), _second('M100 M105 M108 M110 M111 M112 ')), '', 'M102 M103 M104 M106 M107 ', ),
+            (   UInt32Max, _merge(_first(''), _second('M106 M107 M108 M109 M110 M111 M112 ')), '', 'M100 M101 M102 M103 M104 M105 ', ),
+            (   long(200), _merge(_first('M100 M101 M109 '), _second('M102 M104 M105 M106 M107 M108 M110 M111 M112 ')), '', 'M103 ', ),
+            (  long(-200), _merge(_first('M100 M101 M109 '), _second('M105 M108 M110 M111 M112 ')), '', 'M102 M103 M104 M106 M107 ', ),
             (      Byte10, _merge(_first('M100 M101 M103 M108 M109 M110 M111 M112'), _second('M102 M104 M105 M106 M107 ')), '', '', ),
             (    SBytem10, _merge(_first('M100 M101 M102 M104 M106 M107 M108 M109 M110 M111 M112 '), _second('M103 M105 ')), '', '', ),
             (     Int1610, _merge(_first('M100 M101 M102 M103 M104 M106 M107 M108 M109 M110 M111 M112 '), _second('M105 ')), '', '', ),
@@ -518,8 +475,8 @@ class MethodBinder2Test(IronPythonTestCase):
             (  myint(100), _merge(_first('M100 M101 M102 M103 M104 M105 M106 M108 M112 '), _second('M107 M109 M111 ')), 'M110 ', '', ),
             (        -100, _merge(_first('M100 M101 M102 M103 M104 M105 M106 M108 M112 '), _second('M107 M109 M111 ')), 'M110 ', '', ),
             (   UInt32Max, _merge(_first('M100 M101 M102 M103 M104 M105 M107 M112 '), _second('M106 M108 M109 M111 ')), 'M110 ', '', ),
-            (   long(200), _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M112 '), _second('M111 ')), '', '', ),
-            (  long(-200), _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M112 '), _second('M111 ')), '', '', ),
+            (   long(200), _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), _second('')), '', '', ),
+            (  long(-200), _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), _second('')), '', '', ),
             (      Byte10, _merge(_first('M100 M101 M103 M112 '), _second('M102 M104 M105 M106 M107 M108 M109 M111 ')), 'M110 ', '', ),
             (    SBytem10, _merge(_first('M100 M101 M102 M104 M106 M108 M112 '), _second('M103 M105 M107 M109 M111 ')), 'M110 ', '', ),
             (     Int1610, _merge(_first('M100 M101 M102 M103 M104 M106 M108 M112 '), _second('M105 M107 M109 M111 ')), 'M110 ', '', ),


### PR DESCRIPTION
This resolves the problem with `System.UIntPtr` from #868.  `BigInteger` to `UInt64` is now performed at narroving level _One_, just like for `Int64`. This puts it at a higher preference level than the conversion from `BigInteger` to `Int32`/`UInt32`, which are done at narrowing level _All_ (lowest).

It does not address the fact that `double`/`float` will be preferred over `ulong`. This is because conversion from `BigInteger` to `Double` and `Single` is already done at narrowing level _None_ (highest priority), which normally means no data loss. This is not entirely accurate:

```
>>> import System 
>>> int(float(System.UInt64.MaxValue)) - System.UInt64.MaxValue
1
>>> int(float(0xFFFFFFFFFFFFFFFF)) - 0xFFFFFFFFFFFFFFFF
-2047
>>> System.UInt64.MaxValue - 0xFFFFFFFFFFFFFFFF        
0
```

However the alternative, that is, to prefer `ulong` over `double` seems worse, because `BigInteger` can really be out of range. But I think that to prefer the conversion to `Single` is really a mistake. And this is what is happening with `Math.Max`:

```
>>> hex(int(System.Math.Max(0xFFFFFFF000000000,1)))    
'0x10000000000000000'
>>> type(System.Math.Max(0xFFFFFFF000000000,1))    
<class 'Single'>
```

Therefore at least I would like to remove the preference of `Single`.