### PR TITLE
Enable some tests

### DIFF
--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -91,9 +91,6 @@ Ignore=true
 Ignore=true
 Reason=Fails intermittently - https://github.com/IronLanguages/ironpython3/issues/508
 
-[IronPython.test_methoddispatch]
-Ignore=true
-
 [IronPython.test_namebinding]
 RunCondition=NOT $(IS_POSIX)
 Reason=See https://bugzilla.xamarin.com/show_bug.cgi?id=45677 and https://github.com/IronLanguages/main/issues/1473

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -91,9 +91,6 @@ Ignore=true
 Ignore=true
 Reason=Fails intermittently - https://github.com/IronLanguages/ironpython3/issues/508
 
-[IronPython.test_methodbinder2]
-Ignore=true
-
 [IronPython.test_methoddispatch]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -91,9 +91,6 @@ Ignore=true
 Ignore=true
 Reason=Fails intermittently - https://github.com/IronLanguages/ironpython3/issues/508
 
-[IronPython.test_methodbinder1]
-Ignore=true
-
 [IronPython.test_methodbinder2]
 Ignore=true
 

--- a/Tests/test_methodbinder1.py
+++ b/Tests/test_methodbinder1.py
@@ -110,7 +110,7 @@ class MethodBinder1Test(IronPythonTestCase):
     (       "UInt64Max", OverF, OverF, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, True,  TypeE, True,  True,  ),
     (      "DecimalMax", OverF, OverF, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
     (       "SingleMax", OverF, OverF, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, OverF, True,  ),
-    (        "floatMax", OverF, OverF, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, OverF, True,  ),
+    (        "floatMax", TypeE, TypeE, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, OverF, True,  ),
     ####                 M201   M680   M202   M203   M204   M205   M301   M302   M303   M304   M310   M311   M312   M313   M320   M321   M400
     ####                 int    int?   double bigint bool   str    sbyte  i16    i64    single byte   ui16   ui32   ui64   char   decm   obj
     (        "SByteMin", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
@@ -123,7 +123,7 @@ class MethodBinder1Test(IronPythonTestCase):
     (       "UInt64Min", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE, True,  True,  ),
     (      "DecimalMin", OverF, OverF, True , True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, True , True,  ),
     (       "SingleMin", OverF, OverF, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, OverF, True,  ),
-    (        "floatMin", OverF, OverF, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, OverF, True,  ),
+    (        "floatMin", TypeE, TypeE, True,  True,  True,  TypeE, OverF, OverF, OverF, True,  OverF, OverF, OverF, OverF, TypeE, OverF, True,  ),
     ####                 M201   M680   M202   M203   M204   M205   M301   M302   M303   M304   M310   M311   M312   M313   M320   M321   M400
     ####                 int    int?   double bigint bool   str    sbyte  i16    i64    single byte   ui16   ui32   ui64   char   decm   obj
     (    "SBytePlusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE, True,  True,  ),
@@ -137,7 +137,7 @@ class MethodBinder1Test(IronPythonTestCase):
     (   "UInt64PlusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE, True,  True,  ),
     (  "DecimalPlusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE,  True,  True,  ),
     (   "SinglePlusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE, True,  True,  ),
-    (    "floatPlusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE, True,  True,  ),
+    (    "floatPlusOne", TypeE, TypeE, True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE, True,  True,  ),
     (          myfloat1, True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  True,  True,  True,  True,  TypeE, True,  True,  ),
     ####                 M201   M680   M202   M203   M204   M205   M301   M302   M303   M304   M310   M311   M312   M313   M320   M321   M400
     ####                 int    int?   double bigint bool   str    sbyte  i16    i64    single byte   ui16   ui32   ui64   char   decm   obj
@@ -148,7 +148,7 @@ class MethodBinder1Test(IronPythonTestCase):
     (   "Int64MinusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
     ( "DecimalMinusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
     (  "SingleMinusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
-    (   "floatMinusOne", True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
+    (   "floatMinusOne", TypeE, TypeE, True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
     (          myfloat2, True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ),
     ##################################################   pass in bool   #########################################################
     ####                 M201   M680   M202   M203   M204   M205   M301   M302   M303   M304   M310   M311   M312   M313   M320   M321   M400
@@ -182,10 +182,10 @@ class MethodBinder1Test(IronPythonTestCase):
         ##################################################  pass in float   #########################################################
         ####    single/double becomes Int32, but this does not apply to other primitive types
         ####                                                           int    int?  double  bigint bool   str    sbyte i16   i64   single byte   ui16   ui32   ui64   char   decm   obj
-        matrix.append((System.Single.Parse("8.01", InvariantCulture), True,  True, True,  True,  True,  TypeE, True, True, True, True,  True,  True,  True,  True,  TypeE, True,  True,  ))
-        matrix.append((System.Double.Parse("10.2", InvariantCulture), True,  True, True,  True,  True,  TypeE, True, True, True, True,  True,  True,  True,  True,  TypeE, True,  True,  ))
-        matrix.append((System.Single.Parse("-8.1", InvariantCulture), True,  True, True,  True,  True,  TypeE, True, True, True, True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ))
-        matrix.append((System.Double.Parse("-1.8", InvariantCulture), True,  True, True,  True,  True,  TypeE, True, True, True, True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ))
+        matrix.append((System.Single.Parse("8.01", InvariantCulture), True,  True,  True,  True,  True,  TypeE, True, True, True, True,  True,  True,  True,  True,  TypeE, True,  True,  ))
+        matrix.append((System.Double.Parse("10.2", InvariantCulture), TypeE, TypeE, True,  True,  True,  TypeE, True, True, True, True,  True,  True,  True,  True,  TypeE, True,  True,  ))
+        matrix.append((System.Single.Parse("-8.1", InvariantCulture), True,  True,  True,  True,  True,  TypeE, True, True, True, True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ))
+        matrix.append((System.Double.Parse("-1.8", InvariantCulture), TypeE, TypeE, True,  True,  True,  TypeE, True, True, True, True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ))
         matrix = tuple(matrix)
         
         for scenario in matrix:
@@ -322,7 +322,7 @@ class MethodBinder1Test(IronPythonTestCase):
         self._helper(self.target.M411, [C6(), cp2, cp4, ], 411, [C3(), object(), C1(), cp1, cp3,], TypeError)
         
     def test_nullable_int(self):
-        self._helper(self.target.M680, [None, 100, 100, System.Byte.MaxValue, System.UInt32.MinValue, myint1, mylong2, 3.6, ], 680, [(), 3+1j], TypeError)
+        self._helper(self.target.M680, [None, 100, 100, System.Byte.MaxValue, System.UInt32.MinValue, myint1, mylong2, ], 680, [(), 3+1j], TypeError)
         
     def test_out_int(self):
         self._helper(self.target.M701, [], 701, [1, 10, None, System.Byte.Parse('3')], TypeError)    # not allow to pass in anything
@@ -470,8 +470,9 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt
         # generic method
         self.target.M200[int](100)
         self.assertEqual(Flag.Value, 200); Flag.Value = 99
-        self.target.M200[int](100.1234)
-        self.assertEqual(Flag.Value, 200); Flag.Value = 99
+        with self.assertRaises(TypeError):
+            self.target.M200[int](100.1234)
+        self.assertEqual(Flag.Value, 99)
         self.target.M200[int](100)
         self.assertEqual(Flag.Value, 200); Flag.Value = 99
         self.assertRaises(OverflowError, self.target.M200[System.Byte], 300)
@@ -596,7 +597,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt
         
         # GOtherConcern<T>
         self.target = GOtherConcern[int]()
-        for x in [100, 200, 4.56, myint1]:
+        for x in [100, 200, myint1]:
             self.target.M100(x)
             self.assertEqual(Flag.Value, 100); Flag.Value = 99
         
@@ -642,13 +643,19 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt
                 self.assertEqual(Flag.Value, len(x))
 
             # IEnumerable<char> / IEnumerator<char>
-            self.target.M630(x)
-            self.assertEqual(Flag.Value, len(x)); Flag.Value = 0
+            if not isinstance(x, C):
+                self.target.M630(x)
+                self.assertEqual(Flag.Value, len(x)); Flag.Value = 0
+            else:
+                self.assertRaises(TypeError, self.target.M630, x)
             self.assertRaises(TypeError, self.target.M631, x)
 
             # IEnumerable<int> / IEnumerator<int>
-            self.target.M640(x)
-            self.assertEqual(Flag.Value, len(x)); Flag.Value = 0
+            if not isinstance(x, C):
+                self.target.M640(x)
+                self.assertEqual(Flag.Value, len(x)); Flag.Value = 0
+            else:
+                self.assertRaises(TypeError, self.target.M640, x)
             self.assertRaises(TypeError, self.target.M641, x)
 
         # IList / IList<char> / IList<int>
@@ -668,7 +675,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt
             self.assertRaises(TypeError, self.target.M642, x)
        
     def test_explicit_inheritance(self):
-        from IronPythonTest.BinderTest import *
+        from IronPythonTest.BinderTest import CInheritMany1, CInheritMany2, CInheritMany3, CInheritMany4, CInheritMany5, CInheritMany6, CInheritMany7, CInheritMany8, Flag, I1, I2, I3, I4
         self.target = CInheritMany1()
         self.assertTrue(hasattr(self.target, "M"))
         self.target.M()

--- a/Tests/test_methodbinder2.py
+++ b/Tests/test_methodbinder2.py
@@ -365,7 +365,7 @@ class MethodBinder2Test(IronPythonTestCase):
             (        -100, _merge(_first('M100 '), _second('M104 M105 M106 ')), 'M101 M102 M103 ', '', ),
             (   long(200), _merge(_first('M106 M105 '), _second('M100 M102 M101 ')), 'M103 M104 ', '', ),
             (      Byte10, _merge(_first('M103 '), _second('M100 M105 M106 ')), 'M101 M102 M104 ', '', ),
-            (       12.34, _merge(_first('M105 M106 '), _second('M101 M102 M100 ')), 'M103 M104 ', '', ),
+            (       12.34, _merge(_first('M104 M105 M106 '), _second('M101 M102 M100 ')), 'M103 ', '', ),
             ]:
             self._try_arg(target, arg, mapping, funcTypeError, funcOverflowError)
 
@@ -503,7 +503,7 @@ class MethodBinder2Test(IronPythonTestCase):
             (    SBytem10, _merge(_first('M100 M101 M102 M104 M106 M107 M108 M109 M110 M111 M112 '), _second('M103 M105 ')), '', '', ),
             (     Int1610, _merge(_first('M100 M101 M102 M103 M104 M106 M107 M108 M109 M110 M111 M112 '), _second('M105 ')), '', '', ),
             (    Int16m20, _merge(_first('M100 M101 M102 M103 M104 M106 M107 M108 M109 M110 M111 M112 '), _second('M105 ')), '', '', ),
-            (       12.34, _merge(_first('M101 M108 M109 M110 '), _second('M100 M106 M111 M112 M102 M103 M104 M105 M107 ')), '', '', ),
+            (       12.34, _merge(_first(''), _second('M100 M106 M108 M109 M110 M111 M112 M102 M103 M104 M105 M107 ')), 'M101 ', '', ),
             ]:
             self._try_arg(target, arg, mapping, funcTypeError, funcOverflowError)
 

--- a/Tests/test_methodbinder2.py
+++ b/Tests/test_methodbinder2.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, long, run_test, skipUnlessIronPython
 from iptest.type_util import array_int, array_byte, array_object, myint, mystr, types
 
 class PT_int_old:
@@ -22,7 +22,7 @@ def _self_defined_method(name): return len(name) == 4 and name[0] == "M"
 def _result_pair(s, offset=0):
     fn = s.split()
     val = [int(x[1:]) + offset for x in fn]
-    return dict(list(zip(fn, val)))
+    return dict(zip(fn, val))
 
 def _first(s): return _result_pair(s, 0)
 def _second(s): return _result_pair(s, 100)
@@ -61,7 +61,7 @@ if is_cli:
     arrayInt = array_int((10, 20))
     tupleInt = ((10, 20), )
     listInt  = ([10, 20], )
-    tupleLong1, tupleLong2  = ((10, 20), ), ((System.Int64.MaxValue, System.Int32.MaxValue * 2),)
+    tupleLong1, tupleLong2  = ((long(10), long(20)), ), ((System.Int64.MaxValue, System.Int32.MaxValue * 2),)
     arrayByte = array_byte((10, 20))
     arrayObj = array_object(['str', 10])
 
@@ -118,13 +118,13 @@ class MethodBinder2Test(IronPythonTestCase):
                 if expectError == None:
                     self.fail("unexpected exception %s when func %s with arg %s (%s)\n%s" % (e, funcname, arg, type(arg), func.__doc__))
 
-                if funcname in list(mapping.keys()):  # No exception expected:
+                if funcname in mapping.keys():  # No exception expected:
                     self.fail("unexpected exception %s when func %s with arg %s (%s)\n%s" % (e, funcname, arg, type(arg), func.__doc__))
 
                 if not isinstance(e, expectError):
                     self.fail("expect '%s', but got '%s' (flag %s) when func %s with arg %s (%s)\n%s" % (expectError, e, Flag.Value, funcname, arg, type(arg), func.__doc__))
             else:
-                if not funcname in list(mapping.keys()): # Expecting exception
+                if not funcname in mapping.keys(): # Expecting exception
                     self.fail("expect %s, but got no exception (flag %s) when func %s with arg %s (%s)\n%s" % (expectError, Flag.Value, funcname, arg, type(arg), func.__doc__))
                 
                 left, right = Flag.Value, mapping[funcname]
@@ -179,9 +179,11 @@ class MethodBinder2Test(IronPythonTestCase):
         target.M130(C1())
         self.assertEqual(Flag.Value, 230); Flag.Value = 99
 
-        for x in [100, 100.1234]:
-            target.M130[int](x)
-            self.assertEqual(Flag.Value, 230); Flag.Value = 99
+        target.M130[int](100)
+        self.assertEqual(Flag.Value, 230); Flag.Value = 99
+
+        with self.assertRaises(TypeError):
+            target.M130[int](100.1234)
 
         class PT_C3_int(C3):
             def __int__(self): return 1
@@ -361,7 +363,7 @@ class MethodBinder2Test(IronPythonTestCase):
             (        None, _merge(_first('M106 '), _second('M102 M103 ')), 'M100 M101 M104 M105 ', '', ),
             (        True, _merge(_first('M100 M103 '), _second('M104 M105 M106 ')), 'M101 M102 ', '', ),
             (        -100, _merge(_first('M100 '), _second('M104 M105 M106 ')), 'M101 M102 M103 ', '', ),
-            (        200, _merge(_first('M106 M105 '), _second('M100 M102 M101 ')), 'M103 M104 ', '', ),
+            (   long(200), _merge(_first('M106 M105 '), _second('M100 M102 M101 ')), 'M103 M104 ', '', ),
             (      Byte10, _merge(_first('M103 '), _second('M100 M105 M106 ')), 'M101 M102 M104 ', '', ),
             (       12.34, _merge(_first('M105 M106 '), _second('M101 M102 M100 ')), 'M103 M104 ', '', ),
             ]:
@@ -403,8 +405,8 @@ class MethodBinder2Test(IronPythonTestCase):
             myint(100): [   o.M100],
             -100 : [        o.M100],
             UInt32Max: [    o.M100, o.M106],
-            200 : [        o.M100, o.M106, o.M109],
-            -200 : [       o.M100, o.M106, o.M109],
+            long(200) : [   o.M100, o.M106, o.M109],
+            long(-200) : [  o.M100, o.M106, o.M109],
             Byte10 : [      o.M100],
             SBytem10 : [    o.M100],
             Int1610 : [     o.M100],
@@ -413,7 +415,7 @@ class MethodBinder2Test(IronPythonTestCase):
             
         }
         
-        for param in list(param_method_map.keys()):
+        for param in param_method_map.keys():
             for meth in param_method_map[param]:
                 expected_flag = int(meth.__name__[1:])
                 meth(param)
@@ -431,8 +433,8 @@ class MethodBinder2Test(IronPythonTestCase):
             (  myint(100), _merge(_first('M100 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
             (        -100, _merge(_first('M100 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
             (   UInt32Max, _merge(_first('M100 M106 '), _second('M105 M107 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M104 ', '', ),
-            (        200, _merge(_first('M100 M106 M109 '), _second('M108 M112 M110 M111 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
-            (       -200, _merge(_first('M100 M106 M109 '), _second('M108 M112 M110 M111 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
+            (   long(200), _merge(_first('M100 M106 M109 '), _second('M108 M112 M110 M111 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
+            (  long(-200), _merge(_first('M100 M106 M109 '), _second('M108 M112 M110 M111 ')), 'M101 M102 M103 M104 M105 M107 ', '', ),
             (      Byte10, _merge(_first('M100 '), _second('M101 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 ')), 'M102 ', '', ),
             (    SBytem10, _merge(_first('M100 '), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), 'M101 M103 M105 M107 ', '', ),
             (     Int1610, _merge(_first('M100 '), _second('M104 M106 M108 M109 M110 M111 M112 ')), 'M101 M102 M103 M105 M107 ', '', ),
@@ -453,8 +455,8 @@ class MethodBinder2Test(IronPythonTestCase):
             (  myint(100), _merge(_first('M101 M102 M103 M104 M105 M107 '), _second('M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
             (        -100, _merge(_first(''), _second('M106 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M102 M103 M104 M105 M107 ', ),
             (   UInt32Max, _merge(_first(''), _second('M105 M107 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M102 M103 M104 M106 ', ),
-            (        200, _merge(_first('M101 M102 M103 M104 M105 M106 M107 M109 '), _second('M108 M112 M110 M111 ')), 'M100 ', '', ),
-            (       -200, _merge(_first(''), _second('M108 M112 M110 M111 ')), 'M100 ', 'M101 M102 M103 M104 M105 M106 M107 M109 ', ),
+            (   long(200), _merge(_first('M101 M102 M103 M104 M105 M106 M107 M109 '), _second('M108 M112 M110 M111 ')), 'M100 ', '', ),
+            (  long(-200), _merge(_first(''), _second('M108 M112 M110 M111 ')), 'M100 ', 'M101 M102 M103 M104 M105 M106 M107 M109 ', ),
             (      Byte10, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
             (    SBytem10, _merge(_first(''), _second('M102 M104 M106 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M103 M105 M107 ', ),
             (     Int1610, _merge(_first('M101 M102 M103 M105 M107 '), _second('M104 M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
@@ -474,8 +476,8 @@ class MethodBinder2Test(IronPythonTestCase):
             (  myint(100), _merge(_first('M101 '), _second('M102 M103 M104 M105 M107 M106 M108 M109 M110 M111 M112 ')), 'M100 ', '', ),
             (        -100, _merge(_first('M101 '), _second('M103 M106 M108 M109 M110 M111 M112 ')), 'M100 ', 'M102 M104 M105 M107 ', ),
             (   UInt32Max, _merge(_first(''), _second('M105 M107 M108 M109 M110 M111 M112 ')), 'M100 ', 'M101 M102 M103 M104 M106 ', ),
-            (        200, _merge(_first('M101 M106 M109 '), _second('M102 M104 M105 M107 M108 M110 M111 M112 ')), 'M100 ', 'M103 ', ),
-            (       -200, _merge(_first('M101 M106 M109 '), _second('M108 M110 M111 M112 ')), 'M100 ', 'M102 M103 M104 M105 M107 ', ),
+            (   long(200), _merge(_first('M101 M106 M109 '), _second('M102 M104 M105 M107 M108 M110 M111 M112 ')), 'M100 ', 'M103 ', ),
+            (  long(-200), _merge(_first('M101 M106 M109 '), _second('M108 M110 M111 M112 ')), 'M100 ', 'M102 M103 M104 M105 M107 ', ),
             (      Byte10, _merge(_first('M100 M101 M103 M106 M108 M109 M110 M111 M112'), _second('M102 M104 M105 M107 ')), '', '', ),
             (    SBytem10, _merge(_first('M100 M101 M102 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), _second('M103 ')), '', '', ),
             (     Int1610, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
@@ -494,9 +496,9 @@ class MethodBinder2Test(IronPythonTestCase):
             (         100, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
             (  myint(100), _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
             (        -100, _first('M100 M101 M102 M103 M104 M105 M106 M107 M108 M109 M110 M111 M112 '), '', '', ),
-            (    UInt32Max, _merge(_first(''), _second('M100 M106 M107 M108 M109 M110 M111 M112 ')), '', 'M101 M102 M103 M104 M105 ', ),
-            (        200, _merge(_first('M101 M109 '), _second('M100 M102 M104 M105 M106 M107 M108 M110 M111 M112 ')), '', 'M103 ', ),
-            (       -200, _merge(_first('M101 M109 '), _second('M100 M105 M108 M110 M111 M112 ')), '', 'M102 M103 M104 M106 M107 ', ),
+            (   UInt32Max, _merge(_first(''), _second('M100 M106 M107 M108 M109 M110 M111 M112 ')), '', 'M101 M102 M103 M104 M105 ', ),
+            (   long(200), _merge(_first('M101 M109 '), _second('M100 M102 M104 M105 M106 M107 M108 M110 M111 M112 ')), '', 'M103 ', ),
+            (  long(-200), _merge(_first('M101 M109 '), _second('M100 M105 M108 M110 M111 M112 ')), '', 'M102 M103 M104 M106 M107 ', ),
             (      Byte10, _merge(_first('M100 M101 M103 M108 M109 M110 M111 M112'), _second('M102 M104 M105 M106 M107 ')), '', '', ),
             (    SBytem10, _merge(_first('M100 M101 M102 M104 M106 M107 M108 M109 M110 M111 M112 '), _second('M103 M105 ')), '', '', ),
             (     Int1610, _merge(_first('M100 M101 M102 M103 M104 M106 M107 M108 M109 M110 M111 M112 '), _second('M105 ')), '', '', ),
@@ -516,8 +518,8 @@ class MethodBinder2Test(IronPythonTestCase):
             (  myint(100), _merge(_first('M100 M101 M102 M103 M104 M105 M106 M108 M112 '), _second('M107 M109 M111 ')), 'M110 ', '', ),
             (        -100, _merge(_first('M100 M101 M102 M103 M104 M105 M106 M108 M112 '), _second('M107 M109 M111 ')), 'M110 ', '', ),
             (   UInt32Max, _merge(_first('M100 M101 M102 M103 M104 M105 M107 M112 '), _second('M106 M108 M109 M111 ')), 'M110 ', '', ),
-            (        200, _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M112 '), _second('M111 ')), '', '', ),
-            (       -200, _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M112 '), _second('M111 ')), '', '', ),
+            (   long(200), _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M112 '), _second('M111 ')), '', '', ),
+            (  long(-200), _merge(_first('M101 M100 M102 M103 M104 M105 M106 M107 M108 M109 M110 M112 '), _second('M111 ')), '', '', ),
             (      Byte10, _merge(_first('M100 M101 M103 M112 '), _second('M102 M104 M105 M106 M107 M108 M109 M111 ')), 'M110 ', '', ),
             (    SBytem10, _merge(_first('M100 M101 M102 M104 M106 M108 M112 '), _second('M103 M105 M107 M109 M111 ')), 'M110 ', '', ),
             (     Int1610, _merge(_first('M100 M101 M102 M103 M104 M106 M108 M112 '), _second('M105 M107 M109 M111 ')), 'M110 ', '', ),


### PR DESCRIPTION
Enables test_methodbinder1, test_methodbinder2 and test_methoddispatch.

Related PRs:
- https://github.com/IronLanguages/ironpython3/pull/828
- https://github.com/IronLanguages/ironpython3/pull/891