### PR TITLE
Validate arguments are not duplicated in kwargs

### DIFF
--- a/Src/IronPython/Runtime/Binding/MetaPythonFunction.cs
+++ b/Src/IronPython/Runtime/Binding/MetaPythonFunction.cs
@@ -445,8 +445,8 @@ namespace IronPython.Runtime.Binding {
                                 if (_func.Value.ArgNames[j] == Signature.GetArgumentName(i)) {
                                     if (exprArgs[j] != null) {
                                         // kw-argument provided for already provided normal argument.
-                                        // Since the repeated kwargs is caught by a syntaxerror, this
-                                        // error can only occur with a positional-keyward arg conflict
+                                        // Since the repeated kwargs is caught by a SyntaxError, this
+                                        // error can only occur with a positional-keyword arg conflict
                                         if (_error == null) {
                                             _error = _call.Throw(
                                                 Expression.Call(

--- a/Src/IronPython/Runtime/Binding/MetaPythonFunction.cs
+++ b/Src/IronPython/Runtime/Binding/MetaPythonFunction.cs
@@ -445,10 +445,12 @@ namespace IronPython.Runtime.Binding {
                                 if (_func.Value.ArgNames[j] == Signature.GetArgumentName(i)) {
                                     if (exprArgs[j] != null) {
                                         // kw-argument provided for already provided normal argument.
+                                        // Since the repeated kwargs is caught by a syntaxerror, this
+                                        // error can only occur with a positional-keyward arg conflict
                                         if (_error == null) {
                                             _error = _call.Throw(
                                                 Expression.Call(
-                                                    typeof(PythonOps).GetMethod(nameof(PythonOps.MultipleKeywordArgumentError)),
+                                                    typeof(PythonOps).GetMethod(nameof(PythonOps.MultipleArgumentError)),
                                                     GetFunctionParam(),
                                                     Expression.Constant(_func.Value.ArgNames[j])
                                                 ),
@@ -725,6 +727,8 @@ namespace IronPython.Runtime.Binding {
                     );
                 }
                 if (_dict != null) {
+                    // A code test is needed because the kwargs can only conflict
+                    // with arguments on the basis of their names
                     _needCodeTest = true;
                     statements.Add(
                         Ast.Call(

--- a/Src/IronPython/Runtime/Binding/MetaPythonFunction.cs
+++ b/Src/IronPython/Runtime/Binding/MetaPythonFunction.cs
@@ -731,20 +731,21 @@ namespace IronPython.Runtime.Binding {
                             typeof(PythonOps).GetMethod(nameof(PythonOps.VerifyUnduplicatedByName)),
                             AstUtils.Convert(GetFunctionParam(), typeof(PythonFunction)), // function
                             AstUtils.Constant(name, typeof(string)),                      // name
-                            AstUtils.Convert(_dict, typeof(PythonDictionary))             // params dict
+                            AstUtils.Convert(_dict, typeof(PythonDictionary)),            // params dict
+                            AstUtils.Constant(                                            // keywordArg
+                                position >= Signature.GetProvidedPositionalArgumentCount(), typeof(bool))
                         )
                     );
                 }
 
                 // Return the value of the argument once we know that we don't have
                 // a duplicate
-                statements.Add(value);
-
-                if (statements.Count == 1) {
+                if (statements.Count == 0) {
                     return value;
-                } else {
-                    return Ast.Block(statements);
                 }
+
+                statements.Add(value);
+                return Ast.Block(statements);
             }
 
             /// <summary>

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2340,10 +2340,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void AddDictionaryArgument(PythonFunction function, string name, object value, PythonDictionary dict) {
-            if (dict.ContainsKey(name)) {
-                throw MultipleKeywordArgumentError(function, name);
-            }
-
+            VerifyUnduplicatedByName(function, name, dict);
             dict[name] = value;
         }
 
@@ -2352,6 +2349,13 @@ namespace IronPython.Runtime.Operations {
                 throw MultipleKeywordArgumentError(function, name);
             }
         }
+
+        public static void VerifyUnduplicatedByName(PythonFunction function, string name, PythonDictionary dict) {
+            if (dict.ContainsKey(name)) {
+                throw MultipleKeywordArgumentError(function, name);
+            }
+        }
+
 
         public static PythonList CopyAndVerifyParamsList(PythonFunction function, object list) {
             return new PythonList(list);

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2340,7 +2340,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void AddDictionaryArgument(PythonFunction function, string name, object value, PythonDictionary dict) {
-            VerifyUnduplicatedByName(function, name, dict);
+            VerifyUnduplicatedByName(function, name, dict, true);
             dict[name] = value;
         }
 
@@ -2350,9 +2350,13 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        public static void VerifyUnduplicatedByName(PythonFunction function, string name, PythonDictionary dict) {
+        public static void VerifyUnduplicatedByName(PythonFunction function, string name, PythonDictionary dict, bool keywordArg) {
             if (dict.ContainsKey(name)) {
-                throw MultipleKeywordArgumentError(function, name);
+                if (keywordArg) {
+                    throw MultipleKeywordArgumentError(function, name);
+                } else {
+                    throw MultipleArgumentError(function, name);
+                }
             }
         }
 
@@ -3513,6 +3517,10 @@ namespace IronPython.Runtime.Operations {
         #endregion
 
         #region Exception Factories
+
+        public static Exception MultipleArgumentError(PythonFunction function, string name) {
+            return TypeError("{0}() got multiple values for argument '{1}'", function.__name__, name);
+        }
 
         public static Exception MultipleKeywordArgumentError(PythonFunction function, string name) {
             return TypeError("{0}() got multiple values for keyword argument '{1}'", function.__name__, name);

--- a/Tests/test_kwarg.py
+++ b/Tests/test_kwarg.py
@@ -447,11 +447,8 @@ class KwargTest(unittest.TestCase):
             testFunc_pw_kw('234', a='234')
         with self.assertRaises(TypeError):
             testFunc_pw_kw(*['234'], a='234')
-        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/866
+        with self.assertRaises(TypeError):
             testFunc_pw_kw('234', **{"a":'234'})
-        else:
-            with self.assertRaises(TypeError):
-                testFunc_pw_kw('234', **{"a":'234'})
         with self.assertRaises(TypeError):
             testFunc_pw_kw(*['234'], **{"a":'234'})
 
@@ -460,11 +457,8 @@ class KwargTest(unittest.TestCase):
             testFunc_kw('234', a='234')
         with self.assertRaises(TypeError):
             testFunc_kw(*['234'], a='234')
-        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/866
+        with self.assertRaises(TypeError):
             testFunc_kw('234', **{"a":'234'})
-        else:
-            with self.assertRaises(TypeError):
-                testFunc_kw('234', **{"a":'234'})
         with self.assertRaises(TypeError):
             testFunc_kw(*['234'], **{"a":'234'})
 
@@ -472,21 +466,15 @@ class KwargTest(unittest.TestCase):
         o = ObjectSubClass()
         with self.assertRaises(TypeError):
             o.testFunc_pw_kw(a='234')
-        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/866
+        with self.assertRaises(TypeError):
             o.testFunc_pw_kw(**{"a":'234'})
-        else:
-            with self.assertRaises(TypeError):
-                o.testFunc_pw_kw(**{"a":'234'})
 
     def test_negTestFunc_ObjectSubClass_testFunc_kw_dupArg(self):
         o = ObjectSubClass()
         with self.assertRaises(TypeError):
             o.testFunc_kw(a='234')
-        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/866
+        with self.assertRaises(TypeError):
             o.testFunc_kw(**{"a":'234'})
-        else:
-            with self.assertRaises(TypeError):
-                o.testFunc_kw(**{"a":'234'})
 
     def test_negTestFunc_ObjectSubClass_testFunc_pw_kw_2_dupArg(self):
         o = ObjectSubClass()
@@ -508,11 +496,8 @@ class KwargTest(unittest.TestCase):
             o.testFunc_pw_kw_2('abc', b='cde')
         with self.assertRaises(TypeError):
             o.testFunc_pw_kw_2(*['abc'], b='cde')
-        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/866
+        with self.assertRaises(TypeError):
             o.testFunc_pw_kw_2('abc', **{"b":'cde'})
-        else:
-            with self.assertRaises(TypeError):
-                o.testFunc_pw_kw_2('abc', **{"b":'cde'})
         with self.assertRaises(TypeError):
             o.testFunc_pw_kw_2(*['abc'], **{"b":'cde'})
 
@@ -522,11 +507,8 @@ class KwargTest(unittest.TestCase):
             o.testFunc_kw_2('abc', b='cde')
         with self.assertRaises(TypeError):
             o.testFunc_kw_2(*['abc'], b='cde')
-        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/866
+        with self.assertRaises(TypeError):
             o.testFunc_kw_2('abc', **{"b":'cde'})
-        else:
-            with self.assertRaises(TypeError):
-                o.testFunc_kw_2('abc', **{"b":'cde'})
         with self.assertRaises(TypeError):
             o.testFunc_kw_2(*['abc'], **{"b":'cde'})
 

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -510,8 +510,12 @@ with open(r"%s", "w") as f:
         def f(a=None):
             pass
 
-        self.assertRaisesRegex(TypeError, "f\(\) got multiple values for keyword argument 'a'" if is_cli else "f\(\) got multiple values for argument 'a'",
+        self.assertRaisesRegex(TypeError, "f\(\) got multiple values for argument 'a'",
                             lambda: f(1, a=3))
+        self.assertRaisesRegex(TypeError, "f\(\) got multiple values for argument 'a'",
+                            lambda: f(1, **{"a":3}))
+        self.assertRaisesRegex(TypeError, "f\(\) got multiple values for keyword argument 'a'",
+                            lambda: f(a=1, **{"a": 3}))
 
     @unittest.skipIf(is_netcoreapp, 'requires System.Drawing.Common dependency')
     @skipUnlessIronPython()


### PR DESCRIPTION
In cases where a parameter is pulled from a positional argument or
keyword argument, ensure that it does not also appear in an unpacked
dictionary going to kwargs.

Resolves #866 