### PR TITLE
Support custom encoding error handler

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -671,12 +671,17 @@ namespace IronPython.Modules {
         }
     }
 
+    /// <remarks>
+    /// This implementation is not suitable for incremental encoding.
+    /// </remarks>
     internal class EncodingMapEncoding : Encoding {
         private readonly EncodingMap _map;
 
         public EncodingMapEncoding(EncodingMap map) {
             _map = map;
         }
+
+        public override string EncodingName => "charmap";
 
         public override int GetByteCount(char[] chars, int index, int count)
             => GetBytes(chars, index, count, null, 0);
@@ -721,7 +726,7 @@ namespace IronPython.Modules {
                             }
                         }
                     } catch (EncoderFallbackException) {
-                        throw PythonOps.UnicodeEncodeError("charmap", new string(chars), charIndex, charIndex + 1, "character maps to <undefined>");
+                        throw PythonOps.UnicodeEncodeError(EncodingName, new string(chars), charIndex, charIndex + 1, "character maps to <undefined>");
                     }
                 } else {
                     if (bytes != null) bytes[byteIndex] = val;
@@ -787,6 +792,9 @@ namespace IronPython.Modules {
         }
     }
 
+    /// <remarks>
+    /// This implementation is not suitable for incremental encoding.
+    /// </remarks>
     internal class CharmapEncoding : Encoding {
         private readonly IDictionary<object, object> _map;
         private int _maxEncodingReplacementLength;
@@ -795,6 +803,8 @@ namespace IronPython.Modules {
         public CharmapEncoding(IDictionary<object, object> map) {
             _map = map;
         }
+
+        public override string EncodingName => "charmap";
 
         public override int GetByteCount(char[] chars, int index, int count)
             => GetBytes(chars, index, count, null, 0);
@@ -841,7 +851,7 @@ namespace IronPython.Modules {
 
                         }
                     } catch (EncoderFallbackException) {
-                        throw PythonOps.UnicodeEncodeError("charmap", new string(chars), charIndex, nextIndex, "character maps to <undefined>");
+                        throw PythonOps.UnicodeEncodeError(EncodingName, new string(chars), charIndex, nextIndex, "character maps to <undefined>");
                     }
                     charIndex = nextIndex;
                 } else {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3605,7 +3605,7 @@ namespace IronPython.Runtime.Operations {
             return (EncoderFallbackException)ctor.Invoke(new object[] { message, charUnknownHigh, charUnknownLow, index });
         }
 
-        public static Exception UnicodeEncodeError(string message, int runeUnknown, int index) {
+        internal static Exception UnicodeEncodeError(string message, int runeUnknown, int index) {
             if (runeUnknown <= char.MaxValue) {
                 return PythonOps.UnicodeEncodeError(message, (char)runeUnknown, index);
             } else {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3605,6 +3605,15 @@ namespace IronPython.Runtime.Operations {
             return (EncoderFallbackException)ctor.Invoke(new object[] { message, charUnknownHigh, charUnknownLow, index });
         }
 
+        public static Exception UnicodeEncodeError(string message, int runeUnknown, int index) {
+            if (runeUnknown <= char.MaxValue) {
+                return PythonOps.UnicodeEncodeError(message, (char)runeUnknown, index);
+            } else {
+                string s = char.ConvertFromUtf32(runeUnknown);
+                return PythonOps.UnicodeEncodeError(message, s[0], s[1], index);
+            }
+        }
+
         public static Exception IOError(Exception inner) {
             return OSError(inner.Message, inner);
         }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -2030,8 +2030,8 @@ namespace IronPython.Runtime.Operations {
                 return d;
             }
 
-            internal static Dictionary<string, object> MakeErrorHandlersDict() {
-                var d = new Dictionary<string, object>();
+            internal static ConcurrentDictionary<string, object> MakeErrorHandlersDict() {
+                var d = new ConcurrentDictionary<string, object>();
 
                 d["strict"] = BuiltinFunction.MakeFunction(
                     "strict_errors",

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
@@ -59,7 +60,7 @@ namespace IronPython.Runtime {
         private string _initialVersionString;
         private PythonModule _clrModule;
         private PythonFileManager _fileManager;
-        private Dictionary<string, object> _errorHandlers;
+        private ConcurrentDictionary<string, object> _errorHandlers;
         private List<object> _searchFunctions;
         private Dictionary<object, object> _moduleState;
         /// <summary> stored for copyreg module, used for reduce protocol </summary>
@@ -1872,7 +1873,7 @@ namespace IronPython.Runtime {
         }
 
         /// <summary> Dictionary of error handlers for string codecs. </summary>
-        internal Dictionary<string, object> ErrorHandlers {
+        internal ConcurrentDictionary<string, object> ErrorHandlers {
             get {
                 if (_errorHandlers == null) {
                     Interlocked.CompareExchange(ref _errorHandlers, StringOps.CodecsInfo.MakeErrorHandlersDict(), null);

--- a/Src/IronPython/Runtime/PythonEncoding.cs
+++ b/Src/IronPython/Runtime/PythonEncoding.cs
@@ -2,9 +2,14 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
+
+using Microsoft.Scripting.Runtime;
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace IronPython.Runtime {
@@ -22,6 +27,7 @@ namespace IronPython.Runtime {
     /// This class extends the standard .NET fallback protocol to allow fallbacks to provide values normally
     /// not allowed by .NET but allowed by Python. It also allows the fallbacks to provide fallback values
     /// as a sequence of bytes.
+    /// <br/>
     ///
     /// Note: Currently, it is not possible to set the fallbacks through assignment to
     /// <see cref="EncoderFallback"/> or <see cref="DecoderFallback"/>; the fallbacks have to be provided
@@ -39,20 +45,29 @@ namespace IronPython.Runtime {
         private Encoding Pass1Encoding { get; }
         private Encoding Pass2Encoding { get; }
 
+        private readonly string _name;
         private Decoder _residentDecoder;
         private Encoder _residentEncoder;
 
-        public PythonEncoding(Encoding encoding, PythonEncoderFallback encoderFallback, PythonDecoderFallback decoderFallback)
-        //: base(0, encoderFallback, decoderFallback)  // unfortunately, this constructor is internal until .NET Framework 4.6
-        {
+        public PythonEncoding(Encoding encoding, PythonEncoderFallback encoderFallback, PythonDecoderFallback decoderFallback, string name)
+            : base(0, encoderFallback, decoderFallback) {
 
             if (encoding == null) throw new ArgumentNullException(nameof(encoding));
             if (encoderFallback == null) throw new ArgumentNullException(nameof(encoderFallback));
             if (decoderFallback == null) throw new ArgumentNullException(nameof(decoderFallback));
 
-            byte[] markerBytes = encoding.GetBytes(new[] { Pass1Marker });
-            CharacterWidth = markerBytes.Length;
-            IsBigEndian = markerBytes[0] == 0;
+            _name = name ?? "<unknown>";
+
+            // TODO: make lazy
+            try {
+                byte[] markerBytes = encoding.GetBytes(new[] { Pass1Marker });
+                CharacterWidth = markerBytes.Length;
+                IsBigEndian = markerBytes[0] == 0;
+            } catch (EncoderFallbackException) {
+                // Q: What encoding cannot encode '?' A: Incomplete charmap.
+                CharacterWidth = 1;
+                IsBigEndian = false;
+            }
 
             // set up pass 1 Encoding, using provided fallback instances
             encoderFallback.Encoding = decoderFallback.Encoding = this;
@@ -121,7 +136,8 @@ namespace IronPython.Runtime {
         public override int CodePage => Pass1Encoding.CodePage;
         public override int WindowsCodePage => Pass1Encoding.WindowsCodePage;
 
-        public override string EncodingName => Pass1Encoding.EncodingName;
+        public string PythonEncodingName => _name;
+        public override string EncodingName => Pass1Encoding.EncodingName ?? _name;
 
         public override string HeaderName => Pass1Encoding.HeaderName;
         public override string BodyName => Pass1Encoding.BodyName;
@@ -153,60 +169,131 @@ namespace IronPython.Runtime {
         }
         private static bool? _hasBugCorefx29898;
 
+        private class ProxyEncoder : Encoder {
+            private Encoding _encoding;
+            private readonly Encoder _encoder;
+
+            public ProxyEncoder(Encoding encoding) {
+                _encoding = (Encoding)encoding.Clone();
+                _encoding.EncoderFallback = new ProxyEncoderFallback(_encoding.EncoderFallback.CreateFallbackBuffer(), _encoding.EncoderFallback.MaxCharCount);
+                _encoder = _encoding.GetEncoder();
+                Fallback = _encoder.Fallback = _encoding.EncoderFallback;
+            }
+
+            public override int GetByteCount(char[] chars, int index, int count, bool flush)
+                => _encoder.GetByteCount(chars, index, count, flush);
+
+            public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, bool flush)
+                => _encoder.GetBytes(chars, charIndex, charCount, bytes, byteIndex, flush);
+
+            public override void Reset() => _encoder.Reset();
+
+            private class ProxyEncoderFallback : EncoderFallback {
+                private readonly EncoderFallbackBuffer _buffer;
+                private readonly int _maxCharCount;
+
+                public ProxyEncoderFallback(EncoderFallbackBuffer buffer, int maxCharCount) {
+                    _buffer = buffer;
+                    _maxCharCount = maxCharCount;
+                }
+
+                public override EncoderFallbackBuffer CreateFallbackBuffer() => _buffer;
+                public override int MaxCharCount => _maxCharCount;
+            }
+        }
+
         public class PythonEncoder : Encoder {
             private readonly PythonEncoding _parentEncoding;
             private readonly Encoder _pass1encoder;
             private Encoder _pass2encoder;
-            private readonly int _characterWidth;
 
             public PythonEncoder(PythonEncoding parentEncoding) {
                 _parentEncoding = parentEncoding;
-                _characterWidth = _parentEncoding.CharacterWidth;
+                _pass1encoder = parentEncoding.Pass1Encoding.GetEncoder();
 
-                _pass1encoder = _parentEncoding.Pass1Encoding.GetEncoder();
+                if (!(_pass1encoder.Fallback is PythonEncoderFallback) && _parentEncoding.Pass1Encoding.EncoderFallback is PythonEncoderFallback) {
+                    // Non-conformant Encoder implementation, the challenge is to get to the fallback buffer used by such encoder.
+
+                    // Possibility 1: _pass1encoder is EncoderNLS .
+                    // This weirdo (.NET Core only) doe not use Falback and FallbackBuffer properties from its Encoder base class;
+                    // it redefines them as new properties and uses them instead.
+                    // Although the new FallbackBuffer is public, it is not easilly accessible because the EncoderNLS class is internal.
+                    // One way of accessing it is by reflection. This will be handled by GetPythonEncoderFallbackBuffer()
+                    if (_pass1encoder.GetType().FullName == "System.Text.EncoderNLS") return;
+
+                    // Possibility 2: _pass1encoder is DefaultEncoder or another stateless encoder;
+                    // This makes sense only if the encoding process of the given encoding is stateless too.
+                    // This should not be common: because .NET strings are UTF-16, it is practically impossible to have a universally-applicable stateless encoding.
+                    // However, such encoding may still be useful in some specifc cases, like non-incremental encoding
+                    // or if the input is guaranteed to never contain surrogate pairs.
+                    // We use ProxyEncoder to access EncoderFallbackBuffer used by such stateless encoder.
+                    _pass1encoder = new ProxyEncoder(parentEncoding.Pass1Encoding);
+
+                    // Possibility 3: Some 3rd party non-compliant encoder. Too bad...
+                }
+            }
+
+            private static PythonEncoderFallbackBuffer GetPythonEncoderFallbackBuffer(Encoder enc) {
+                if (enc == null) return null;
+
+                // This should be as simple as enc.FallbackBuffer as PythonEncoderFallbackBuffer
+                // but it requires a workaround for a design oddity in System.Text.EncoderNLS on .NET Core
+                var fbuf = enc.FallbackBuffer as PythonEncoderFallbackBuffer;
+#if NETCOREAPP
+                if (fbuf == null) {
+                    fbuf = enc.GetType().GetProperty(nameof(enc.FallbackBuffer)).GetValue(enc) as PythonEncoderFallbackBuffer;
+                }
+#endif
+                return fbuf;
             }
 
             public override int GetByteCount(char[] chars, int index, int count, bool flush) {
-                int numBytes;
+                var fbuf1 = GetPythonEncoderFallbackBuffer(_pass1encoder);
 
-                var fbuf1 = _pass1encoder.FallbackBuffer as PythonEncoderFallbackBuffer;
-                if (fbuf1 != null) fbuf1.ByteCountingMode = true;
-                try {
-                    numBytes = _pass1encoder.GetByteCount(chars, index, count, flush);
-                    fbuf1?.ThrowIfNotEmpty(count, flush);
-                } finally {
-                    if (fbuf1 != null) fbuf1.ByteCountingMode = false;
-                }
+                fbuf1?.Prepare(chars, forEncoding: false);
+                int numBytes = _pass1encoder.GetByteCount(chars, index, count, flush);
+                fbuf1?.ThrowIfNotEmpty(count, flush);
+
                 return numBytes;
             }
 
             public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, bool flush) {
-                var fbuf1 = _pass1encoder.FallbackBuffer as PythonEncoderFallbackBuffer;
-                var fbuf2 = _pass2encoder?.FallbackBuffer as PythonEncoderFallbackBuffer;
-                int? fbkIdxStart = fbuf1?.FallbackByteCount;
+                var fbuf1 = GetPythonEncoderFallbackBuffer(_pass1encoder);
+                var fbuf2 = GetPythonEncoderFallbackBuffer(_pass2encoder);
+                fbuf1?.Prepare(chars, forEncoding: true);
 
                 int written = _pass1encoder.GetBytes(chars, charIndex, charCount, bytes, byteIndex, flush);
 
-                // If the final increment and there were no fallback bytes, the job is done
-                if (fbuf1 == null || flush && fbuf1.FallbackByteCount == fbkIdxStart && fbuf1.IsEmpty && (fbuf2?.IsEmpty ?? true)) {
+                // If the final increment and there were no more fallback bytes, the job is done
+                if (fbuf1 == null || flush && fbuf1.IsEmpty && (fbuf2?.IsEmpty ?? true)) {
+                    fbuf1?.Reset();
+                    fbuf2?.Reset();
                     return written;
                 }
 
                 // Lazy creation of _pass2encoder
                 if (_pass2encoder == null) {
                     _pass2encoder = _parentEncoding.Pass2Encoding.GetEncoder();
-                    fbuf2 = (PythonEncoderFallbackBuffer)_pass2encoder.FallbackBuffer;
+                    fbuf2 = GetPythonEncoderFallbackBuffer(_pass2encoder);
+                    if (fbuf2 == null && _parentEncoding.Pass2Encoding.EncoderFallback is PythonEncoderFallback && _pass2encoder.GetType().FullName != "System.Text.EncoderNLS") {
+                        // _pass2encoder must be DefaultEncoder or another stateless encoder
+                        _pass2encoder = new ProxyEncoder(_parentEncoding.Pass2Encoding);
+                        fbuf2 = (PythonEncoderFallbackBuffer)_pass2encoder.FallbackBuffer;
+                    }
                 }
+                fbuf2.Prepare(chars, forEncoding: true);
 
                 // Restore original fallback bytes
                 var bytes2 = new byte[written];
                 _pass2encoder.GetBytes(chars, charIndex, charCount, bytes2, 0, flush);
 
+                int cwidth = _parentEncoding.CharacterWidth;
                 for (int i = 0, j = byteIndex; i < written; i++, j++) {
                     if (bytes[j] != bytes2[i]) {
-                        int ofs = (j / _characterWidth) * _characterWidth;
-                        for (int p = 0; p < _characterWidth; p++) {
+                        int ofs = (j / cwidth) * cwidth;
+                        for (int p = 0; p < cwidth; p++) {
                             bytes[ofs++] = fbuf2.GetFallbackByte();
+                            fbuf1.GetFallbackByte(); // count the byte as consumed in fbuf1 too
                         }
                         int skip = ofs - j - 1;
                         i += skip;
@@ -235,123 +322,178 @@ namespace IronPython.Runtime {
         }
 
         protected abstract class PythonEncoderFallbackBuffer : EncoderFallbackBuffer {
-            private readonly char _marker;
-            private readonly Queue<byte> _fallbackBytes;
+            protected struct DualInt {
+                private int _bcmValue; // used when only counting bytes
+                private int _encValue; // used during actual encoding
 
-            private struct ByteCounter {
-                private int _bcmCounter; // used when only counting bytes
-                private int _encCounter; // used during actual encoding
+                public bool EncodingMode { get; set; }
 
-                public bool ByteCountingMode { get; set; }
+                public static implicit operator int(DualInt dc) => dc.EncodingMode ? dc._encValue : dc._bcmValue;
 
-                public int Value => ByteCountingMode ? _bcmCounter : _encCounter;
-
-                public void AddNumBytes(int numBytes) {
-                    if (ByteCountingMode) {
-                        _bcmCounter += numBytes;
+                /// <summary>Selective assignment</summary>
+                public static DualInt operator << (DualInt dc, int value) {
+                    if (dc.EncodingMode) {
+                        dc._encValue = value;
                     } else {
-                        _encCounter += numBytes;
+                        dc._bcmValue = value;
                     }
+                    return dc;
                 }
 
-                public void Reset() => _bcmCounter = _encCounter = 0;
+                public static DualInt operator + (DualInt dc, int value) {
+                    if (dc.EncodingMode) {
+                        dc._encValue += value;
+                    } else {
+                        dc._bcmValue += value;
+                    }
+                    return dc;
+                }
+
+                public void Reset(int value) => _bcmValue = _encValue = value;
             }
-            private ByteCounter _byteCnt;
-            private int _fbkCnt;
+
+            private readonly char _marker;
+
+            private readonly Queue<byte> _allFallbackBytes;  // collects all fallback bytes for the whole pass, only used during actual encoding, pass 2
+            private int _fbkByteCnt; // only used during actual encoding; proxy for _fallbackBytes.Count but valid in pass 1 too
+            private DualInt _byteCnt; // counts unreported bytes in the buffer from the last fallback; used during both counting and encoding, but counts separately
+
+            private ReadOnlyMemory<char> _fallbackChars;  // fallback chars (if any) from the last fallback
+            private int _charCnt; // counts unreported chars in the buffer from the last fallback
+            private int _fbkNumChars; // number of all (virtual) chars in the buffer from the last fallback; proxy for _fallbackChars.Length but valid for fallback bytes too
 
             // for error reporting
-            private char _lastCharUnknown;
-            private int _lastIndexUnknown = -1;
+            private int _lastRuneUnknown; // in UTF-32, "rune" is an alias for "Unicode codepoint"
+            private DualInt _lastIndexUnknown;
 
             public PythonEncoderFallbackBuffer(bool isPass1, PythonEncoding encoding) {
                 _marker = isPass1 ? Pass1Marker : Pass2Marker;
-                _fallbackBytes = isPass1 ? null : new Queue<byte>();
+                _allFallbackBytes = isPass1 ? null : new Queue<byte>();
                 this.EncodingCharWidth = encoding.CharacterWidth;
                 this.CodePage = encoding.CodePage;
+                _lastIndexUnknown.Reset(-1);
             }
 
             protected int EncodingCharWidth { get; }
             protected int CodePage { get; }
+            protected char[] Data { get; private set; }
 
-            public abstract byte[] GetFallbackBytes(char charUnknown, int index);
-
-            public override bool Fallback(char charUnknown, int index) {
-                // The design limitation for wide-char encodings is that
-                // fallback bytes must be char-aligned.
-                if (_byteCnt.Value % EncodingCharWidth != 0) {
-                    // bytes are not char-aligned, the fallback chars must be consecutive
-                    if (index != _lastIndexUnknown + 1) {
-                        throw PythonOps.UnicodeEncodeError($"incomplete input sequence", _lastCharUnknown, _lastIndexUnknown);
-                    }
-                }
-                byte[] newFallbackBytes = GetFallbackBytes(charUnknown, index);
-
-                if (!ByteCountingMode) {
-                    if (_fallbackBytes != null) {
-                        foreach (byte b in newFallbackBytes) {
-                            _fallbackBytes.Enqueue(b);
-                        }
-                    }
-                    _fbkCnt += newFallbackBytes.Length;
-                }
-                _byteCnt.AddNumBytes(newFallbackBytes.Length);
-                _lastCharUnknown = charUnknown;
-                _lastIndexUnknown = index;
-                return _byteCnt.Value >= EncodingCharWidth;
+            public virtual void Prepare(char[] data, bool forEncoding) {
+                Data = data;
+                _byteCnt.EncodingMode = _lastIndexUnknown.EncodingMode = forEncoding;
             }
 
-            public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index)
-                => Fallback(charUnknownHigh, index) | Fallback(charUnknownLow, index + 1);
+            public abstract Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>> GetFallbackCharsOrBytes(int runeUnknown, int index);
 
-            public override int Remaining => _byteCnt.Value / EncodingCharWidth;
+            public override bool Fallback(char charUnknown, int index)
+                => FallbackImpl(charUnknown, index);
+
+            public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index)
+                => FallbackImpl(char.ConvertToUtf32(charUnknownHigh, charUnknownLow), index);
+
+            private bool FallbackImpl(int runeUnknown, int index) {
+                if (_charCnt > 0) {
+                    // There are some unread characters from the previous fallback
+                    // InvalidOperationException would be a better choice, but ArgumentException is what .NET fallback buffers throw
+                    if (_lastRuneUnknown <= char.MaxValue) {
+                        throw new ArgumentException($"Recursive fallback not allowed for character '\\u{_lastRuneUnknown:X4}'");
+                    } else {
+                        throw new ArgumentException($"Recursive fallback not allowed for character '\\U{_lastRuneUnknown:X8}'");
+                    }
+                }
+
+                // The design limitation for wide-char encodings is that
+                // fallback bytes must be char-aligned (to fill in marker chars)
+                if (_byteCnt > 0) {
+                    // bytes are not char-aligned yet, so the fallback chars must be consecutive
+                    if (index != _lastIndexUnknown + (_lastRuneUnknown > char.MaxValue ? 2 : 1)) {
+                        throw PythonOps.UnicodeEncodeError("incomplete input sequence", _lastRuneUnknown, _lastIndexUnknown);
+                    }
+                }
+
+                var fallbackData = GetFallbackCharsOrBytes(runeUnknown, index);
+                var newFallbackChars = fallbackData.Item1;
+                var newFallbackBytes = fallbackData.Item2;
+
+                if (newFallbackBytes.IsEmpty) {
+                    if (_byteCnt > 0 && !newFallbackChars.IsEmpty) {
+                        // bytes are not char-aligned yet, so the fallback should have produced remaining bytes, not chars
+                        throw PythonOps.UnicodeEncodeError("incomplete fallback sequence", _lastRuneUnknown, _lastIndexUnknown);
+                    }
+                    // use fallback chars, may be none
+                    _fallbackChars = newFallbackChars;
+                    _charCnt = _fbkNumChars = _fallbackChars.Length;
+                } else {
+                    if (!newFallbackChars.IsEmpty) {
+                        throw new NotSupportedException("Encoding error handler may produce either chars or bytes, not both at the same time.");
+                    }
+                    // use fallback bytes
+                    if (_byteCnt.EncodingMode) {
+                        if (_allFallbackBytes != null) { // pass 2
+                            foreach (byte b in newFallbackBytes.Span) {
+                                _allFallbackBytes.Enqueue(b);
+                            }
+                        }
+                        _fbkByteCnt += newFallbackBytes.Length;
+                    }
+                    _fallbackChars = default; // will report _marker instead
+                    _byteCnt += newFallbackBytes.Length;
+                    _charCnt = _fbkNumChars = _byteCnt / EncodingCharWidth;
+                }
+
+                _lastRuneUnknown = runeUnknown;
+                _lastIndexUnknown <<= index;
+                return _charCnt > 0;
+            }
+
+            public override int Remaining => _charCnt;
 
             public override char GetNextChar() {
-                if (_byteCnt.Value < EncodingCharWidth) return char.MinValue;
+                if (_charCnt == 0) return '\0';
 
-                _byteCnt.AddNumBytes(-EncodingCharWidth);
-                return _marker;
+                if (_fallbackChars.IsEmpty) {
+                    _charCnt--;
+                    _byteCnt += -EncodingCharWidth;
+                    return _marker;
+                } else {
+                    return _fallbackChars.Span[_fallbackChars.Length - _charCnt--];
+                }
             }
 
             public override bool MovePrevious() {
-                if (_byteCnt.Value > 0) return false;
+                if (_charCnt == _fbkNumChars) return false;
 
-                _byteCnt.AddNumBytes(EncodingCharWidth);
+                if (_fallbackChars.IsEmpty) {
+                    _byteCnt += EncodingCharWidth;
+                }
+                _charCnt++;
                 return true;
             }
 
             public byte GetFallbackByte() {
-                _fbkCnt--;
-                return _fallbackBytes.Dequeue();
+                _fbkByteCnt--;
+                return _allFallbackBytes?.Dequeue() ?? 0;
             }
 
-            public virtual bool IsEmpty => (_fallbackBytes?.Count ?? 0) == 0;
-
-            public int FallbackByteCount => _fbkCnt;
-
-            public virtual bool ByteCountingMode {
-                get { return _byteCnt.ByteCountingMode; }
-                set { _byteCnt.ByteCountingMode = value; }
-            }
+            public virtual bool IsEmpty => _charCnt == 0 && (_fbkByteCnt == 0 || !_byteCnt.EncodingMode) && _byteCnt == 0;
 
             public virtual void ThrowIfNotEmpty(int endIndex, bool flush) {
-                if (flush && !IsEmpty || _byteCnt.Value % EncodingCharWidth != 0 && endIndex != _lastIndexUnknown + 1) {
-                    throw PythonOps.UnicodeEncodeError($"incomplete input sequence", _lastCharUnknown, _lastIndexUnknown);
+                if (flush && !IsEmpty || _byteCnt > 0 && endIndex != _lastIndexUnknown + (_lastRuneUnknown > char.MaxValue ? 2 : 1)) {
+                    throw PythonOps.UnicodeEncodeError($"incomplete input sequence", _lastRuneUnknown, _lastIndexUnknown);
                 }
-                if (ByteCountingMode) {
-                    // This increment has successfully been counted.
-                    // Therefore there will be no errors during translation.
-                    _lastIndexUnknown = -1;
-                } else {
-                    _lastIndexUnknown -= endIndex; // prep. for next incremental encoding step
-                }
+                Data = null; // release input data for possible collection
+                _lastIndexUnknown += -endIndex; // prep. for next incremental encoding step
             }
 
             public override void Reset() {
-                _fallbackBytes?.Clear();
-                _fbkCnt = 0;
-                _byteCnt.Reset();
-                _lastCharUnknown = '\0';
-                _lastIndexUnknown = -1;
+                _allFallbackBytes?.Clear();
+                _fbkByteCnt = 0;
+                _byteCnt.Reset(0);
+                _charCnt = _fbkNumChars = 0;
+                _fallbackChars = default;
+                _lastRuneUnknown = '\0';
+                _lastIndexUnknown.Reset(-1);
+                Data = null;
             }
         }
 
@@ -521,8 +663,8 @@ namespace IronPython.Runtime {
         // Defined in PEP 383
         private const ushort LoneSurrogateBase = 0xdc00;
 
-        public PythonSurrogateEscapeEncoding(Encoding encoding)
-            : base(encoding, new SurrogateEscapeEncoderFallback(), new SurrogateEscapeDecoderFallback()) { }
+        public PythonSurrogateEscapeEncoding(Encoding encoding, string name = null)
+            : base(encoding, new SurrogateEscapeEncoderFallback(), new SurrogateEscapeDecoderFallback(), name ?? encoding.WebName) { }
 
         public class SurrogateEscapeEncoderFallback : PythonEncoderFallback {
             public override int MaxCharCount => 1;
@@ -535,25 +677,25 @@ namespace IronPython.Runtime {
             public SurrogateEscapeEncoderFallbackBuffer(bool isPass1, PythonEncoding encoding)
                 : base(isPass1, encoding) { }
 
-            public override byte[] GetFallbackBytes(char charUnknown, int index) {
-                if ((charUnknown & ~0xff) != LoneSurrogateBase) {
+            public override Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>> GetFallbackCharsOrBytes(int runeUnknown, int index) {
+                if ((runeUnknown & ~0xff) != LoneSurrogateBase) {
                     // EncoderFallbackException(string, char, int) is not accessible here
                     throw PythonOps.UnicodeEncodeError(
                         $"'surrogateescape' error handler: value not in range(0x{LoneSurrogateBase:x4}, 0x{LoneSurrogateBase+0x100:x4})",
-                        charUnknown,
+                        runeUnknown,
                         index
                     );
                 }
-                byte b = (byte)(charUnknown & 0xff);
+                byte b = (byte)(runeUnknown & 0xff);
                 if (b < 128) {
                     throw PythonOps.UnicodeEncodeError(
                         "'surrogateescape' error handler: bytes below 128 cannot be smuggled (PEP 383)",
-                        charUnknown,
+                        runeUnknown,
                         index
                     );
                 }
-
-                return new[] { b };
+                var fallbackBytes = new byte[] { b };
+                return new Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>>(default, fallbackBytes.AsMemory());
             }
 
         }
@@ -601,8 +743,8 @@ namespace IronPython.Runtime {
         private const byte Utf8ContByte = 0b_10_000000;
         private const byte Utf8ContBytePayload = 0b_111111;
 
-        public PythonSurrogatePassEncoding(Encoding encoding)
-            : base(encoding, new SurrogatePassEncoderFallback(), new SurrogatePassDecoderFallback()) { }
+        public PythonSurrogatePassEncoding(Encoding encoding, string name = null)
+            : base(encoding, new SurrogatePassEncoderFallback(), new SurrogatePassDecoderFallback(), name ?? encoding.WebName) { }
 
         public class SurrogatePassEncoderFallback : PythonEncoderFallback {
             public override int MaxCharCount => 1;
@@ -621,19 +763,19 @@ namespace IronPython.Runtime {
                 _isBigEndianEncoding = encoding.IsBigEndian;
             }
 
-            public override byte[] GetFallbackBytes(char charUnknown, int index) {
-                if (charUnknown < SurrogateRangeStart || SurrogateRangeEnd < charUnknown) {
+            public override Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>> GetFallbackCharsOrBytes(int runeUnknown, int index) {
+                if (runeUnknown < SurrogateRangeStart || SurrogateRangeEnd < runeUnknown) {
                     // EncoderFallbackException(string, char, int) is not accessible here
                     throw PythonOps.UnicodeEncodeError(
                         $"'surrogatepass' error handler: value not in range(0x{SurrogateRangeStart:x4}, 0x{SurrogateRangeEnd + 1:x4})",
-                        charUnknown,
+                        runeUnknown,
                         index
                     );
                 }
 
                 byte[] fallbackBytes;
                 if (this.EncodingCharWidth > 1) {
-                    fallbackBytes = BitConverter.GetBytes(charUnknown);
+                    fallbackBytes = BitConverter.GetBytes((ushort)runeUnknown);
                     if (fallbackBytes.Length == this.EncodingCharWidth) {
                         // UTF-16LE or UTF-16BE
                         if (BitConverter.IsLittleEndian == _isBigEndianEncoding) {
@@ -660,17 +802,16 @@ namespace IronPython.Runtime {
                 } else if (_codePage == 65001) {
                     // UTF-8
                     fallbackBytes = new byte[3]; // UTF-8 for range U+0800 to U+FFFF
-                    ushort codepoint = charUnknown;
-                    fallbackBytes[0] = (byte)(Utf8LeadByte | codepoint >> 12);
-                    codepoint &= 0b_111111_111111;
-                    fallbackBytes[1] = (byte)(Utf8ContByte | codepoint >> 6);
-                    codepoint &= 0b_111111;
-                    fallbackBytes[2] = (byte)(Utf8ContByte | codepoint);
+                    fallbackBytes[0] = (byte)(Utf8LeadByte | runeUnknown >> 12);
+                    runeUnknown &= 0b_111111_111111;
+                    fallbackBytes[1] = (byte)(Utf8ContByte | runeUnknown >> 6);
+                    runeUnknown &= 0b_111111;
+                    fallbackBytes[2] = (byte)(Utf8ContByte | runeUnknown);
                 } else {
-                    throw PythonOps.UnicodeEncodeError($"'surrogatepass' error handler does not support this encoding (cp{_codePage})", charUnknown, index);
+                    throw PythonOps.UnicodeEncodeError($"'surrogatepass' error handler does not support this encoding (cp{_codePage})", runeUnknown, index);
                 }
 
-                return fallbackBytes;
+                return new Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>>(default, fallbackBytes.AsMemory());
             }
 
         }
@@ -855,5 +996,107 @@ namespace IronPython.Runtime {
             protected void Throw(byte[] bytesUnknown, int index) 
                 => throw new DecoderFallbackException($"'surrogatepass' error handler: not a surrogate character", bytesUnknown, index);
         }
+    }
+
+    internal class PythonErrorHandlerEncoding : PythonEncoding {
+        private readonly CodeContext _context;
+        private readonly string _errors;
+
+        public PythonErrorHandlerEncoding(CodeContext context, Encoding encoding, string name, string errors)
+            : base(encoding, new PythonHandlerEncoderFallback(), new PythonHandlerDecoderFallback(), name) {
+            _context = context;
+            _errors = errors;
+        }
+
+        private class PythonHandlerEncoderFallback : PythonEncoderFallback {
+            public override int MaxCharCount => int.MaxValue;
+
+            public override EncoderFallbackBuffer CreateFallbackBuffer() {
+                return new PythonHandlerEncoderFallbackBuffer(this.IsPass1, (PythonErrorHandlerEncoding)this.Encoding);
+            }
+        }
+
+        private class PythonHandlerEncoderFallbackBuffer : PythonEncoderFallbackBuffer {
+            private readonly PythonErrorHandlerEncoding _encoding;
+            private object _handler;
+            private DualInt _lastChar;
+
+            public PythonHandlerEncoderFallbackBuffer(bool isPass1, PythonErrorHandlerEncoding encoding)
+                : base(isPass1, encoding) {
+                _encoding = encoding;
+            }
+
+            public override void Prepare(char[] data, bool forEncoding) {
+                _lastChar.EncodingMode = forEncoding;
+                if (Data != null && Data.Length > 0) _lastChar <<= Data[0];
+                base.Prepare(data, forEncoding);
+            }
+
+            public override Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>> GetFallbackCharsOrBytes(int runeUnknown, int index) {
+                if (_handler == null) {
+                    _handler = LightExceptions.CheckAndThrow(PythonOps.LookupEncodingError(_encoding._context, _encoding._errors));
+                }
+
+                // create the exception object to hand to the user-function...
+                int runeLen = runeUnknown > char.MaxValue ? 2 : 1;
+                char[] data = Data;
+                if (index < 0) {
+                    // corner case, the unknown data starts at the end of the previous increment
+                    Debug.Assert(index == -1); // only one char back allowed
+                    data = new char[Data.Length + 1];
+                    data[0] = (char)_lastChar;
+                    Array.Copy(Data, 0, data, 1, Data.Length);
+                    index = 0;
+                }
+                var exObj = PythonExceptions.CreatePythonThrowable(
+                    PythonExceptions.UnicodeEncodeError,
+                    StringOps.GetEncodingName(_encoding, normalize: false),
+                    new string(data),
+                    index,
+                    index + runeLen,
+                    "ordinal not in range for this codec");
+
+                // call the user function...
+                object res = PythonCalls.Call(_handler, exObj);
+
+                return ExtractEncodingReplacement(res, index + runeLen);
+            }
+
+            private static Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>> ExtractEncodingReplacement(object res, int cursorPos) {
+                // verify the result is sane...
+                if (res is PythonTuple tres && tres.__len__() == 2 && Converter.TryConvertToInt32(tres[1], out int newPos)) {
+
+                    if (newPos != cursorPos) throw new NotImplementedException($"Moving encoding cursor not implemented yet");
+
+                    if (Converter.TryConvertToString(tres[0], out string str)) {
+                        return new Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>>(str.AsMemory(), default);
+                    } else if (tres[0] is Bytes bytes) {
+                        return new Tuple<ReadOnlyMemory<char>, ReadOnlyMemory<byte>>(default, bytes.AsMemory());
+                    }
+                }
+
+                throw PythonOps.TypeError("encoding error handler must return (str/bytes, int) tuple");
+            }
+        }
+
+        private class PythonHandlerDecoderFallback : PythonDecoderFallback {
+
+            public override int MaxCharCount => int.MaxValue;
+
+            public override DecoderFallbackBuffer CreateFallbackBuffer()
+                => new PythonHandlerDecoderFallbackBuffer(this.IsPass1, this.Encoding);
+
+            private class PythonHandlerDecoderFallbackBuffer : PythonDecoderFallbackBuffer {
+
+                public PythonHandlerDecoderFallbackBuffer(bool isPass1, PythonEncoding encoding)
+                    : base(isPass1, encoding) { }
+
+                public override char[] GetFallbackChars(byte[] bytesUnknown, int index) {
+                    throw new NotImplementedException();
+                }
+
+            }
+        }
+
     }
 }

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -132,8 +132,8 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.escape_encode, "abc")
         self.assertRaises(TypeError, codecs.escape_encode, None)
         self.assertRaises(TypeError, codecs.escape_encode, None, None)
-        self.assertEquals(codecs.escape_encode(b"\\", None), (b"\\\\", 1))
-        self.assertEquals(codecs.escape_encode(b"\\", 'strict'), (b"\\\\", 1))
+        self.assertEqual(codecs.escape_encode(b"\\", None), (b"\\\\", 1))
+        self.assertEqual(codecs.escape_encode(b"\\", 'strict'), (b"\\\\", 1))
 
         self.assertRaises(TypeError, codecs.escape_encode, bytearray(b"abc"))
         self.assertRaises(TypeError, codecs.escape_encode, memoryview(b"abc"))
@@ -885,7 +885,7 @@ class CodecTest(IronPythonTestCase):
         def garbage_error2(someError): pass
         codecs.register_error("some other dummy", garbage_error2)
         self.assertEqual(codecs.lookup_error("some other dummy"), garbage_error2)
-        return # TODO
+        #return # TODO
 
         # register under the same name, overriding the previous registration
         def garbage_error3(someError): return ("<garbage>", someError.end)
@@ -1065,7 +1065,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_16_be_decode, "abc")
         self.assertRaises(TypeError, codecs.utf_16_be_decode, None)
         self.assertRaises(TypeError, codecs.utf_16_be_decode, None, None)
-        self.assertEquals(codecs.utf_16_be_decode(b"", None), ("", 0))
+        self.assertEqual(codecs.utf_16_be_decode(b"", None), ("", 0))
 
     def test_utf_16_be_decode_incremental(self):
         b = b"\xff\xfe\x00\x41\xd9\x00\xdd\x00\xdc\x00\xd8\x00\xdc\x00"
@@ -1106,7 +1106,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_16_be_encode, b"abc")
         self.assertRaises(TypeError, codecs.utf_16_be_encode, None)
         self.assertRaises(TypeError, codecs.utf_16_be_encode, None, None)
-        self.assertEquals(codecs.utf_16_be_encode("", None), (b"", 0))
+        self.assertEqual(codecs.utf_16_be_encode("", None), (b"", 0))
 
     def test_utf_16_le_decode(self):
         string, num_processed = codecs.utf_16_le_decode(b'a\0b\0c\0')
@@ -1122,7 +1122,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_16_le_decode, "abc")
         self.assertRaises(TypeError, codecs.utf_16_le_decode, None)
         self.assertRaises(TypeError, codecs.utf_16_le_decode, None, None)
-        self.assertEquals(codecs.utf_16_le_decode(b"", None), ("", 0))
+        self.assertEqual(codecs.utf_16_le_decode(b"", None), ("", 0))
 
     def test_utf_16_le_decode_incremental(self):
         b = b"\xfe\xff\x41\x00\x00\xd9\x00\xdd\x00\xdc\x00\xd8\x00\xdc"
@@ -1163,7 +1163,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_16_le_encode, b"abc")
         self.assertRaises(TypeError, codecs.utf_16_le_encode, None)
         self.assertRaises(TypeError, codecs.utf_16_le_encode, None, None)
-        self.assertEquals(codecs.utf_16_le_encode("", None), (b"", 0))
+        self.assertEqual(codecs.utf_16_le_encode("", None), (b"", 0))
 
     def test_utf_16_ex_decode(self):
         #sanity
@@ -1186,7 +1186,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_16_ex_decode, "abc")
         self.assertRaises(TypeError, codecs.utf_16_ex_decode, None)
         self.assertRaises(TypeError, codecs.utf_16_ex_decode, None, None)
-        self.assertEquals(codecs.utf_16_ex_decode(b"", None), ("", 0, 0))
+        self.assertEqual(codecs.utf_16_ex_decode(b"", None), ("", 0, 0))
 
     def test_utf_16_decode(self):
         # When BOM present: it is removed and the proper UTF-16 variant is automatically selected
@@ -1208,7 +1208,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_16_decode, "abc")
         self.assertRaises(TypeError, codecs.utf_16_decode, None)
         self.assertRaises(TypeError, codecs.utf_16_decode, None, None)
-        self.assertEquals(codecs.utf_16_decode(b"", None), ("", 0))
+        self.assertEqual(codecs.utf_16_decode(b"", None), ("", 0))
 
     def test_utf_16_encode(self):
         # On little-endian systems, UTF-16 encodes in UTF-16-LE prefixed with BOM
@@ -1219,7 +1219,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_16_encode, b"abc")
         self.assertRaises(TypeError, codecs.utf_16_encode, None)
         self.assertRaises(TypeError, codecs.utf_16_encode, None, None)
-        self.assertEquals(codecs.utf_16_encode("", None), (codecs.BOM_UTF16, 0))
+        self.assertEqual(codecs.utf_16_encode("", None), (codecs.BOM_UTF16, 0))
 
     def test_utf_16_le_encode_alias(self):
         for x in ('utf_16_le', 'UTF-16LE', 'utf-16le', 'utf-16-le'):
@@ -1239,7 +1239,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_32_be_decode, "abc")
         self.assertRaises(TypeError, codecs.utf_32_be_decode, None)
         self.assertRaises(TypeError, codecs.utf_32_be_decode, None, None)
-        self.assertEquals(codecs.utf_32_be_decode(b"", None), ("", 0))
+        self.assertEqual(codecs.utf_32_be_decode(b"", None), ("", 0))
 
     def test_utf_32_be_encode(self):
         data, num_processed = codecs.utf_32_be_encode("abc")
@@ -1249,7 +1249,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_32_be_encode, b"abc")
         self.assertRaises(TypeError, codecs.utf_32_be_encode, None)
         self.assertRaises(TypeError, codecs.utf_32_be_encode, None, None)
-        self.assertEquals(codecs.utf_32_be_encode("", None), (b"", 0))
+        self.assertEqual(codecs.utf_32_be_encode("", None), (b"", 0))
 
     def test_utf_32_le_decode(self):
         string, num_processed = codecs.utf_32_le_decode(b'a\0\0\0b\0\0\0c\0\0\0')
@@ -1265,7 +1265,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_32_le_decode, "abc")
         self.assertRaises(TypeError, codecs.utf_32_le_decode, None)
         self.assertRaises(TypeError, codecs.utf_32_le_decode, None, None)
-        self.assertEquals(codecs.utf_32_le_decode(b"", None), ("", 0))
+        self.assertEqual(codecs.utf_32_le_decode(b"", None), ("", 0))
 
     def test_utf_32_le_encode(self):
         data, num_processed = codecs.utf_32_le_encode("abc")
@@ -1275,7 +1275,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_32_le_encode, b"abc")
         self.assertRaises(TypeError, codecs.utf_32_le_encode, None)
         self.assertRaises(TypeError, codecs.utf_32_le_encode, None, None)
-        self.assertEquals(codecs.utf_32_le_encode("", None), (b"", 0))
+        self.assertEqual(codecs.utf_32_le_encode("", None), (b"", 0))
 
     def test_utf_32_ex_decode(self):
         self.utf_ex_decode_test_helper(
@@ -1292,7 +1292,7 @@ class CodecTest(IronPythonTestCase):
         self.assertRaises(TypeError, codecs.utf_32_ex_decode, "abc")
         self.assertRaises(TypeError, codecs.utf_32_ex_decode, None)
         self.assertRaises(TypeError, codecs.utf_32_ex_decode, None, None)
-        self.assertEquals(codecs.utf_32_ex_decode(b"", None), ("", 0, 0))
+        self.assertEqual(codecs.utf_32_ex_decode(b"", None), ("", 0, 0))
 
     def test_utf_32_decode(self):
         # When BOM present: it is removed and the proper UTF-32 variant is automatically selected

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -875,7 +875,6 @@ class CodecTest(IronPythonTestCase):
         ute = UnicodeTranslateError("abcd", 1, 3, "UnicodeTranslateError not supported with surrogatepass")
         self.assertRaisesRegex(TypeError, "don't know how to handle UnicodeTranslateError in error callback", surrogatepass, ute)
 
-    #TODO: @skip("multiple_execute")
     def test_lookup_error(self):
         #sanity
         self.assertRaises(LookupError, codecs.lookup_error, "blah garbage xyz")
@@ -885,13 +884,15 @@ class CodecTest(IronPythonTestCase):
         def garbage_error2(someError): pass
         codecs.register_error("some other dummy", garbage_error2)
         self.assertEqual(codecs.lookup_error("some other dummy"), garbage_error2)
-        #return # TODO
 
         # register under the same name, overriding the previous registration
         def garbage_error3(someError): return ("<garbage>", someError.end)
         codecs.register_error("some other dummy", garbage_error3)
         self.assertEqual(codecs.lookup_error("some other dummy"), garbage_error3)
         self.assertEqual(codecs.utf_8_decode(b"a\xffz", "some other dummy"), ("a<garbage>z", 3))
+        self.assertEqual(codecs.latin_1_encode("a\u20ACz", "some other dummy"), (b"a<garbage>z", 3))
+        self.assertEqual(codecs.encode("a\u20ACz", "iso8859-2", "some other dummy"), b"a<garbage>z")
+        return # TODO
 
         # override default 'strict'
         self.assertEqual(codecs.lookup_error('strict'), codecs.strict_errors)


### PR DESCRIPTION
`PythonEncoderFallback` in `StringOps` had the ability to support custom encoding error handlers, but only those that provide fallback data as string. On the other hand, `PythonEncoderFallback` in `PythonEncoding` has the ability to process fallback data in a form of raw bytes, but not string and it did not support custom error handlers. In Python, a custom error handler may produce fallback data as either string or bytes.

This PR merges both solutions into one: `PythonErrorHandlerEncoding.PythonHandlerEncoderFallback` so that custom error handlers during encoding may be correctly supported.

Moving the encoding cursor from a custom error handler is still not supported.