### PR TITLE
Fix test__socket failure on macOS

### DIFF
--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -198,6 +198,9 @@ RetryCount=2
 [IronPython.modules.misc.test_system_namespaces]
 Timeout=120000 # 2 minute timeout
 
+[IronPython.modules.network_related.test__socket]
+IsolationLevel=PROCESS # needed on (some?) Linux systems to avoid "Connection refused"
+
 [IronPython.modules.system_related.test__locale]
 IsolationLevel=PROCESS # changes the locale which can cause other tests to fail
 

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -198,9 +198,6 @@ RetryCount=2
 [IronPython.modules.misc.test_system_namespaces]
 Timeout=120000 # 2 minute timeout
 
-[IronPython.modules.network_related.test__socket]
-IsolationLevel=PROCESS # needed on (some?) Linux systems to avoid "Connection refused"
-
 [IronPython.modules.system_related.test__locale]
 IsolationLevel=PROCESS # changes the locale which can cause other tests to fail
 

--- a/Tests/modules/network_related/test__socket.py
+++ b/Tests/modules/network_related/test__socket.py
@@ -381,7 +381,7 @@ s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
 s.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1) # prevents an "Address already in use" error when the socket is in a TIME_WAIT state
 s.settimeout(20) # prevents the server from staying open if the client never connects
 s.bind((HOST, PORT))
-with open("{PORTFILE}", "w") as f:
+with open(r"{PORTFILE}", "w") as f:
     print(s.getsockname()[1], file=f)
 
 try:
@@ -403,7 +403,7 @@ try:
 finally:
     conn.close()
     try:
-        os.remove("{PORTFILE}")
+        os.remove(r"{PORTFILE}")
     except:
         pass
 """.format(PORTFILE=portFile)
@@ -506,7 +506,7 @@ s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
 s.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1) # prevents an "Address already in use" error when the socket is in a TIME_WAIT state
 s.settimeout(20) # prevents the server from staying open if the client never connects
 s.bind((HOST, PORT))
-with open("{PORTFILE}", "w") as f:
+with open(r"{PORTFILE}", "w") as f:
     print(s.getsockname()[1], file=f)
 
 try:
@@ -527,7 +527,7 @@ try:
 finally:
     conn.close()
     try:
-        os.remove("{PORTFILE}")
+        os.remove(r"{PORTFILE}")
     except:
         pass
 """.format(PORTFILE=portFile)


### PR DESCRIPTION
Fixes one of the remaining problems from the change in #916.

It appears that without process isolation, the server port is owned by the kernel, which then refuses connections from a regular user process. With process isolation, the server process is `ipy` and runs under the same user ID as the client.

I am not sure whether this patch is not simply masking a deeper issue with the current `_socket` implementation.