### PR TITLE
Fix the sort on the builtin module names array (#875)

### DIFF
--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -589,6 +589,8 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
             foreach (object key in context.BuiltinModules.Keys) {
                 keys[index++] = key;
             }
+            //fix the sort of the keys prior to publication in sys.builtin_module_names for issue #875
+            Array.Sort(keys);
             dict["builtin_module_names"] = PythonTuple.MakeTuple(keys);
         }
 

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -590,6 +590,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
                 keys[index++] = key;
             }
             //fix the sort of the keys prior to publication in sys.builtin_module_names for issue #875
+            // See issue https://github.com/IronLanguages/ironpython3/issues/875 for full details
             Array.Sort(keys);
             dict["builtin_module_names"] = PythonTuple.MakeTuple(keys);
         }

--- a/Tests/modules/system_related/test_sys.py
+++ b/Tests/modules/system_related/test_sys.py
@@ -231,7 +231,8 @@ f()
         self.assertTrue('dummy result' in str(w[0].message))
     
     def test_builtin_module_names(self):
-        ''' Validate properly sorted module names for issue #875 '''
+        ''' Validate properly sorted module names for issue #875 
+            See issue https://github.com/IronLanguages/ironpython3/issues/875 for full details '''
         self.assertTrue(sys.builtin_module_names == tuple(sorted(sys.builtin_module_names)))
 
 run_test(__name__)

--- a/Tests/modules/system_related/test_sys.py
+++ b/Tests/modules/system_related/test_sys.py
@@ -229,5 +229,9 @@ f()
         self.assertNotEqual(0, count)
         self.assertTrue(w)
         self.assertTrue('dummy result' in str(w[0].message))
+    
+    def test_builtin_module_names(self):
+        ''' Validate properly sorted module names for issue #875 '''
+        self.assertTrue(sys.builtin_module_names == tuple(sorted(sys.builtin_module_names)))
 
 run_test(__name__)


### PR DESCRIPTION
Add Array.Sort to the keys array prior to publication in sys.builtin_module_names so that it is properly sorted as expected.