### PR TITLE
Fix some .NET 5.0 compile issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
+    - name: Setup .NET 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.100-rc.1.20452.10'
     - name: Set Mono Version
       if: matrix.os == 'macos-latest'
       run: echo ::add-path::/Library/Frameworks/Mono.framework/Versions/6.4.0/bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100-rc.1.20452.10'
+        dotnet-version: '5.0.100-rc.2.20479.15'
     - name: Set Mono Version
       if: matrix.os == 'macos-latest'
       run: echo ::add-path::/Library/Frameworks/Mono.framework/Versions/6.4.0/bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,3 +56,6 @@ jobs:
     - name: Test (netcoreapp3.1)
       run: ./make.ps1 -frameworks netcoreapp3.1 test-all
       shell: pwsh
+    - name: Test (net5.0)
+      run: ./make.ps1 -frameworks net5.0 test-all
+      shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,12 +41,12 @@ jobs:
       shell: pwsh
     - name: Build
       run: pwsh make.ps1
-    - name: Package
-      run: pwsh make.ps1 package
-    - uses: actions/upload-artifact@v2
-      with:
-        name: packages
-        path: Package/Release/Packages
+#    - name: Package
+#      run: pwsh make.ps1 package
+#    - uses: actions/upload-artifact@v2
+#      with:
+#        name: packages
+#        path: Package/Release/Packages
     - name: Test (net46)
       run: ./make.ps1 -frameworks net46 test-all
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100-rc.2.20479.15'
+        dotnet-version: '5.0.x'
     - name: Set Mono Version
       if: matrix.os == 'macos-latest'
       run: echo ::add-path::/Library/Frameworks/Mono.framework/Versions/6.4.0/bin

--- a/Build/net5.0-windows.props
+++ b/Build/net5.0-windows.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath Condition=" '$(TargetFramework)' == 'net5.0-windows' ">$(BaseOutputPath)\net5.0</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="net5.0.props" />
+</Project>

--- a/Build/net5.0.props
+++ b/Build/net5.0.props
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IsFullFramework>false</IsFullFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Features>$(Features);FEATURE_APARTMENTSTATE</Features>
+    <Features>$(Features);FEATURE_ASSEMBLY_GETFORWARDEDTYPES</Features>
+    <Features>$(Features);FEATURE_ASSEMBLY_RESOLVE</Features>
+    <Features>$(Features);FEATURE_ASSEMBLYBUILDER_DEFINEDYNAMICASSEMBLY</Features>
+    <Features>$(Features);FEATURE_BASIC_CONSOLE</Features>
+    <Features>$(Features);FEATURE_CODEDOM</Features>
+    <Features>$(Features);FEATURE_COM</Features>
+    <Features>$(Features);FEATURE_CONFIGURATION</Features>
+    <Features>$(Features);FEATURE_CTYPES</Features>
+    <Features>$(Features);FEATURE_CUSTOM_TYPE_DESCRIPTOR</Features>
+    <Features>$(Features);FEATURE_DYNAMIC_EXPRESSION_VISITOR</Features>
+    <Features>$(Features);FEATURE_EXCEPTION_STATE</Features>
+    <Features>$(Features);FEATURE_FILESYSTEM</Features>
+    <Features>$(Features);FEATURE_FULL_CONSOLE</Features>
+    <Features>$(Features);FEATURE_FULL_CRYPTO</Features>
+    <Features>$(Features);FEATURE_FULL_NET</Features>
+    <Features>$(Features);FEATURE_LCG</Features>
+    <Features>$(Features);FEATURE_LOADWITHPARTIALNAME</Features>
+    <Features>$(Features);FEATURE_METADATA_READER</Features>
+    <Features>$(Features);FEATURE_MMAP</Features>
+    <Features>$(Features);FEATURE_NATIVE</Features>
+    <Features>$(Features);FEATURE_PIPES</Features>
+    <Features>$(Features);FEATURE_PROCESS</Features>
+    <Features>$(Features);FEATURE_REFEMIT</Features>
+    <Features>$(Features);FEATURE_REGISTRY</Features>
+    <Features>$(Features);FEATURE_RUNTIMEINFORMATION</Features>
+    <Features>$(Features);FEATURE_SECURITY_RULES</Features>
+    <Features>$(Features);FEATURE_SERIALIZATION</Features>
+    <Features>$(Features);FEATURE_STACK_TRACE</Features>
+    <Features>$(Features);FEATURE_SYNC_SOCKETS</Features>
+    <Features>$(Features);FEATURE_THREAD</Features>
+    <Features>$(Features);FEATURE_XMLDOC</Features>
+  </PropertyGroup>
+</Project>

--- a/Build/net5.0.props
+++ b/Build/net5.0.props
@@ -26,6 +26,7 @@
     <Features>$(Features);FEATURE_METADATA_READER</Features>
     <Features>$(Features);FEATURE_MMAP</Features>
     <Features>$(Features);FEATURE_NATIVE</Features>
+    <Features>$(Features);FEATURE_OSPLATFORMATTRIBUTE</Features>
     <Features>$(Features);FEATURE_PIPES</Features>
     <Features>$(Features);FEATURE_PROCESS</Features>
     <Features>$(Features);FEATURE_REFEMIT</Features>

--- a/Build/steps.yml
+++ b/Build/steps.yml
@@ -100,9 +100,9 @@ steps:
       testRunTitle: ${{ parameters.os }}
     condition: succeededOrFailed()
 
-  - powershell: ./make.ps1 package
-    displayName: Package
-    condition: succeededOrFailed()
+#  - powershell: ./make.ps1 package
+#    displayName: Package
+#    condition: succeededOrFailed()
 
   - task: CopyFiles@2
     displayName: Copy NuGet and Zip Packages

--- a/Build/steps.yml
+++ b/Build/steps.yml
@@ -31,10 +31,17 @@ steps:
       version: '2.1.x'
 
   - task: UseDotNet@2
-    displayName: Install .NET Core 3.1 SDK for build
+    displayName: Install .NET Core 3.1 runtime for running tests
+    inputs:
+      packageType: 'runtime'
+      version: '3.1.x'
+
+  - task: UseDotNet@2
+    displayName: Install .NET Core 5.0 SDK for build
     inputs:
       packageType: 'sdk'
-      version: '3.1.x'
+      includePreviewVersions: true
+      version: '5.0.x'
 
   # Set Mono version on macOS
   - ${{ if eq(parameters.os, 'macOS') }}:

--- a/Build/steps.yml
+++ b/Build/steps.yml
@@ -40,7 +40,6 @@ steps:
     displayName: Install .NET Core 5.0 SDK for build
     inputs:
       packageType: 'sdk'
-      includePreviewVersions: true
       version: '5.0.x'
 
   # Set Mono version on macOS

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -94,12 +94,15 @@
     <Configuration Condition="'$(Configuration)' == 'Release'">Release</Configuration>
   </PropertyGroup>
 
-  <!-- References -->
-  <Import Project="$(BuildSysDir)\$(TargetFramework).props" Condition="'$(TargetFramework)' != ''" />
-  
   <PropertyGroup>
     <BaseOutputPath>$(RootDir)bin\$(Configuration)</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
+  </PropertyGroup>
+
+  <!-- References -->
+  <Import Project="$(BuildSysDir)\$(TargetFramework).props" Condition="'$(TargetFramework)' != ''" />
+
+  <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1573;1591</NoWarn>
     <ErrorReport>prompt</ErrorReport>

--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -1,12 +1,12 @@
 # Building IronPython3
 
-To build IronPython3 you will need the .NET SDK (minimum 4.5), a [.NET Core SDK (minimum 3.1)](https://dotnet.microsoft.com/download/visual-studio-sdks) and if building on Linux/macOS you will need [Mono](https://mono-project.com).
+To build IronPython3 you will need the [.NET SDK (minimum v5.0.100)](https://dotnet.microsoft.com/download/visual-studio-sdks).
 
 See [Getting the Sources](getting-the-sources.md) for information on getting the source for IronPython3.
 
 ## Building from Visual Studio
 
-Visual Studio 16.4(2019) or above is required to build IronPython3.
+Visual Studio 2019 v16.8 or above is required to build IronPython3.
 
  * Open `c:\path\to\ironpython3\IronPython.sln` solution file
  * Select the configuration options (Release,Debug, etc)
@@ -38,8 +38,7 @@ There are also other targets available for use with packaging and testing, most 
 package                         Creates packages supported by the current platform
 stage                           Stages files ready for packaging
 test-*                          Runs tests from `all` categories, `ironpython` specific tests, 
-                                `cpython` tests from the CPython stdlib test suite, `smoke` a small
-                                set of tests
+                                `cpython` tests from the CPython stdlib test suite
 ```
 
-If the build is successful the binaries are stored in ironpython3/bin/{ConfigurationName}/{Framework}
+If the build is successful the binaries are stored in ironpython3/bin/{Configuration}/{TargetFramework}

--- a/IronPython.sln
+++ b/IronPython.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{17737ACB
 	ProjectSection(SolutionItems) = preProject
 		Build\After.targets = Build\After.targets
 		Build\net46.props = Build\net46.props
+		Build\net5.0.props = Build\net5.0.props
 		Build\netcoreapp2.1.props = Build\netcoreapp2.1.props
 		Build\netcoreapp3.1.props = Build\netcoreapp3.1.props
 		Build\netstandard2.0.props = Build\netstandard2.0.props

--- a/IronPython.sln
+++ b/IronPython.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{17737ACB
 	ProjectSection(SolutionItems) = preProject
 		Build\After.targets = Build\After.targets
 		Build\net46.props = Build\net46.props
+		Build\net5.0-windows.props = Build\net5.0-windows.props
 		Build\net5.0.props = Build\net5.0.props
 		Build\netcoreapp2.1.props = Build\netcoreapp2.1.props
 		Build\netcoreapp3.1.props = Build\netcoreapp3.1.props

--- a/IronPythonAnalyzer/IronPythonAnalyzer/IronPythonAnalyzer.csproj
+++ b/IronPythonAnalyzer/IronPythonAnalyzer/IronPythonAnalyzer.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/IronPythonAnalyzer/IronPythonAnalyzer/IronPythonAnalyzerAnalyzer.cs
+++ b/IronPythonAnalyzer/IronPythonAnalyzer/IronPythonAnalyzerAnalyzer.cs
@@ -17,9 +17,11 @@ namespace IronPythonAnalyzer {
     public class IronPythonAnalyzerAnalyzer : DiagnosticAnalyzer {
         public const string DiagnosticId = "IronPythonAnalyzer";
 
+#pragma warning disable RS2008 // Enable analyzer release tracking
         private static readonly DiagnosticDescriptor Rule1 = new DiagnosticDescriptor("IPY01", title: "Parameter which is marked not nullable does not have the NotNullAttribute", messageFormat: "Parameter '{0}' does not have the NotNullAttribute", category: "Usage", DiagnosticSeverity.Warning, isEnabledByDefault: true, description: "Non-nullable reference type parameters should have the NotNullAttribute.");
         private static readonly DiagnosticDescriptor Rule2 = new DiagnosticDescriptor("IPY02", title: "Parameter which is marked nullable has the NotNullAttribute", messageFormat: "Parameter '{0}' should not have the NotNullAttribute", category: "Usage", DiagnosticSeverity.Warning, isEnabledByDefault: true, description: "Nullable reference type parameters should not have the NotNullAttribute.");
         private static readonly DiagnosticDescriptor Rule3 = new DiagnosticDescriptor("IPY03", title: "BytesLikeAttribute used on a not supported type", messageFormat: "Parameter '{0}' declared bytes-like on unsupported type '{1}'", category: "Usage", DiagnosticSeverity.Warning, isEnabledByDefault: true, description: "BytesLikeAttribute is only allowed on parameters of type IReadOnlyList<byte>, or IList<byte>.");
+#pragma warning restore RS2008 // Enable analyzer release tracking
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule1, Rule2, Rule3); } }
 

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Since the main development is on Windows, Mono bugs may inadvertantly be introdu
 - please report them!
 
 ## Supported Platforms
-IronPython 3 targets .NET 4.6 and .NET Core 2.1/3.1.
+IronPython 3 targets .NET Framework 4.6, .NET Core 2.1/3.1 and .NET 5.0. The support for .NET Core and .NET 5 will follow the lifecycle defined on [.NET Core and .NET 5 Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).

--- a/Src/IronPython.Modules/IronPython.Modules.csproj
+++ b/Src/IronPython.Modules/IronPython.Modules.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0-rc.1.20451.14 " />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0 " />
   </ItemGroup>
 
   <Import Project="$(AfterTargetFiles)" />

--- a/Src/IronPython.Modules/IronPython.Modules.csproj
+++ b/Src/IronPython.Modules/IronPython.Modules.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;netstandard2.0;net5.0</TargetFrameworks>
     <BaseAddress>885063680</BaseAddress>
     <CodeAnalysisRuleSet>..\..\IronPython.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -47,6 +47,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0-rc.1.20451.14 " />
   </ItemGroup>
 
   <Import Project="$(AfterTargetFiles)" />

--- a/Src/IronPython.Modules/NtSignalState.cs
+++ b/Src/IronPython.Modules/NtSignalState.cs
@@ -4,12 +4,15 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
 using IronPython.Runtime;
 
 #if FEATURE_PROCESS
 
 namespace IronPython.Modules {
     public static partial class PythonSignal {
+        [SupportedOSPlatform("windows")]
         internal class NtSignalState : PythonSignalState {
             //We use a single Windows event handler to process all signals. This handler simply
             //delegates the work out to PySignalToPyHandler.

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -10,13 +10,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
-
-using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
+
+using Microsoft.Scripting.Runtime;
 
 using DisallowNullAttribute = System.Diagnostics.CodeAnalysis.DisallowNullAttribute;
 
@@ -214,13 +215,13 @@ namespace IronPython.Modules {
 
         #region MBCS Functions
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static PythonTuple mbcs_decode(CodeContext/*!*/ context, [NotNull]IBufferProtocol input, string? errors = null, bool final = false) {
             using IPythonBuffer buffer = input.GetBuffer();
             return DoDecode(context, "mbcs", StringOps.CodecsInfo.MbcsEncoding, buffer, errors).ToPythonTuple();
         }
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static PythonTuple mbcs_encode(CodeContext/*!*/ context, [NotNull]string input, string? errors = null)
             => DoEncode(context, "mbcs", StringOps.CodecsInfo.MbcsEncoding, input, errors).ToPythonTuple();
 
@@ -228,7 +229,7 @@ namespace IronPython.Modules {
 
         #region Code Page Functions
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static PythonTuple code_page_decode(CodeContext context, int codepage, [NotNull]IBufferProtocol input, string? errors = null, bool final = false) {
             // TODO: Use Win32 API MultiByteToWideChar https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
             string encodingName = $"cp{codepage}";
@@ -237,7 +238,7 @@ namespace IronPython.Modules {
             return DoDecode(context, encodingName, encoding, buffer, errors).ToPythonTuple();
         }
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static PythonTuple code_page_encode(CodeContext context, int codepage, [NotNull]string input, string? errors = null) {
             // TODO: Use Win32 API WideCharToMultiByte https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
             string encodingName = $"cp{codepage}";

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable SYSLIB0001 // UTF-7 code paths are obsolete in .NET 5
+
 #nullable enable
 
 using System;

--- a/Src/IronPython.Modules/_ctypes/MemoryHolder.cs
+++ b/Src/IronPython.Modules/_ctypes/MemoryHolder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #if FEATURE_CTYPES
+#pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported in .NET 5.0.
 
 using System;
 using System.IO;

--- a/Src/IronPython.Modules/_ctypes/NativeFunctions.cs
+++ b/Src/IronPython.Modules/_ctypes/NativeFunctions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #if FEATURE_CTYPES
+#pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported in .NET 5.0.
 
 using System;
 using System.Runtime.ConstrainedExecution;

--- a/Src/IronPython.Modules/_multiprocessing.cs
+++ b/Src/IronPython.Modules/_multiprocessing.cs
@@ -1,6 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using Microsoft.Scripting.Runtime;
 using Microsoft.Win32.SafeHandles;
@@ -17,7 +22,7 @@ namespace IronPython.Modules {
         [DllImport("ws2_32.dll", ExactSpelling = true, SetLastError = true)]
         private static extern SocketError closesocket([In] IntPtr socketHandle);
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static object closesocket(int handle) {
             var error = closesocket(new IntPtr(handle));
             // TODO: raise error
@@ -32,7 +37,7 @@ namespace IronPython.Modules {
                                      [In] SocketFlags socketFlags
                                      );
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static Bytes recv(int handle, int size) {
             var buf = new byte[size];
             recv(new IntPtr(handle), buf, size, 0);
@@ -47,7 +52,7 @@ namespace IronPython.Modules {
                                          [In] SocketFlags socketFlags
                                          );
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static unsafe int send(int handle, [NotNull] IBufferProtocol data) {
             using var buffer = data.GetBuffer();
             var span = buffer.AsReadOnlySpan();

--- a/Src/IronPython.Modules/_socket.cs
+++ b/Src/IronPython.Modules/_socket.cs
@@ -1845,12 +1845,10 @@ namespace IronPython.Modules {
         public const int TCP_NODELAY = (int)SocketOptionName.NoDelay;
 
         // Windows only
-        [SupportedOSPlatform("windows")]
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static readonly BigInteger SIO_RCVALL = (long)IOControlCode.ReceiveAll;
 
-        [SupportedOSPlatform("windows")]
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static readonly BigInteger SIO_KEEPALIVE_VALS = (long)IOControlCode.KeepAliveValues;
 
         public const int RCVALL_ON = 1;

--- a/Src/IronPython.Modules/_socket.cs
+++ b/Src/IronPython.Modules/_socket.cs
@@ -14,6 +14,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -485,11 +486,9 @@ namespace IronPython.Modules {
 
             }
 
-
             public int recv_into(object buffer, int nbytes = 0, int flags = 0) {
                 throw PythonOps.TypeError(string.Format("recv_into() argument 1 must be read-write buffer, not {0}", PythonOps.GetPythonTypeName(buffer)));
             }
-
 
             [Documentation("recvfrom(bufsize[, flags]) -> (string, address)\n\n"
                 + "Receive data from the socket, up to bufsize bytes. string is the data\n"
@@ -911,6 +910,9 @@ namespace IronPython.Modules {
             public int proto => (int)_socket.ProtocolType;
 
             public int ioctl(BigInteger cmd, object option) {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    throw PythonOps.ValueError(string.Format("invalid ioctl command {0}", cmd));
+
                 if (cmd == SIO_KEEPALIVE_VALS) {
                     if (!(option is PythonTuple))
                         throw PythonOps.TypeError("option must be 3-item sequence, not int");
@@ -935,8 +937,9 @@ namespace IronPython.Modules {
                         throw PythonOps.TypeError("option integer required");
 
                     return _socket.IOControl((IOControlCode)(long)cmd, BitConverter.GetBytes((int)option), null);
-                } else
+                } else {
                     throw PythonOps.ValueError(string.Format("invalid ioctl command {0}", cmd));
+                }
             }
 
             public override string ToString() {
@@ -1841,9 +1844,18 @@ namespace IronPython.Modules {
         public const int SO_USELOOPBACK = (int)SocketOptionName.UseLoopback;
         public const int TCP_NODELAY = (int)SocketOptionName.NoDelay;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+        // Windows only
+#if NET5_0
+        [SupportedOSPlatform("windows")]
+#endif
+        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static readonly BigInteger SIO_RCVALL = (long)IOControlCode.ReceiveAll;
+#if NET5_0
+        [SupportedOSPlatform("windows")]
+#endif
+        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static readonly BigInteger SIO_KEEPALIVE_VALS = (long)IOControlCode.KeepAliveValues;
+
         public const int RCVALL_ON = 1;
         public const int RCVALL_OFF = 0;
         public const int RCVALL_SOCKETLEVELONLY = 2;

--- a/Src/IronPython.Modules/_socket.cs
+++ b/Src/IronPython.Modules/_socket.cs
@@ -1845,14 +1845,11 @@ namespace IronPython.Modules {
         public const int TCP_NODELAY = (int)SocketOptionName.NoDelay;
 
         // Windows only
-#if NET5_0
         [SupportedOSPlatform("windows")]
-#endif
         [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static readonly BigInteger SIO_RCVALL = (long)IOControlCode.ReceiveAll;
-#if NET5_0
+
         [SupportedOSPlatform("windows")]
-#endif
         [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static readonly BigInteger SIO_KEEPALIVE_VALS = (long)IOControlCode.KeepAliveValues;
 

--- a/Src/IronPython.Modules/_thread.cs
+++ b/Src/IronPython.Modules/_thread.cs
@@ -71,7 +71,9 @@ namespace IronPython.Modules {
         public static void interrupt_main(CodeContext context) {
             var thread = context.LanguageContext.MainThread;
             if (thread != null) {
+#pragma warning disable SYSLIB0006 // Thread.Abort is not supported and throws PlatformNotSupportedException on .NET Core.
                 thread.Abort(new KeyboardInterruptException(""));
+#pragma warning restore SYSLIB0006
             } else {
                 throw PythonOps.SystemError("no main thread has been registered");
             }

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -61,7 +62,7 @@ namespace IronPython.Modules {
         [DllImport("kernel32.dll", EntryPoint = "GetFinalPathNameByHandleW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern int GetFinalPathNameByHandle([In] SafeFileHandle hFile, [Out] StringBuilder lpszFilePath, [In] int cchFilePath, [In] int dwFlags);
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static string _getfinalpathname(string path) {
             var hFile = CreateFile(path, 0, 0, IntPtr.Zero, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero);
             if (hFile.IsInvalid) {
@@ -854,7 +855,7 @@ namespace IronPython.Modules {
         }
 
 #if FEATURE_PROCESS
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public static void startfile(string filename, string operation = "open") {
             System.Diagnostics.Process process = new System.Diagnostics.Process();
             process.StartInfo.FileName = filename;

--- a/Src/IronPython.Modules/signal.cs
+++ b/Src/IronPython.Modules/signal.cs
@@ -4,8 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
@@ -55,6 +58,7 @@ the first is the signal number, the second is the interrupted stack frame.";
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static PythonSignalState MakeNtSignalState(PythonContext context) {
+            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             return new NtSignalState(context);
         }
 
@@ -77,15 +81,15 @@ the first is the signal number, the second is the interrupted stack frame.";
         public const int SIG_IGN = 1;
 
         //Windows signals
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public const int CTRL_C_EVENT = 0;
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public const int CTRL_BREAK_EVENT = 1;
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public const int CTRL_CLOSE_EVENT = 2;
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public const int CTRL_LOGOFF_EVENT = 5;
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
+        [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
         public const int CTRL_SHUTDOWN_EVENT = 6;
 
         public static BuiltinFunction default_int_handler = BuiltinFunction.MakeFunction("default_int_handler",

--- a/Src/IronPython.Modules/winreg.cs
+++ b/Src/IronPython.Modules/winreg.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security;
 using System.Security.AccessControl;
 using System.Text;
@@ -23,6 +24,9 @@ using IronPython.Runtime.Types;
 
 [assembly: PythonModule("winreg", typeof(IronPython.Modules.PythonWinReg), PlatformsAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
+#if NET5_0
+    [SupportedOSPlatform("windows")]
+#endif
     public static class PythonWinReg {
         public const string __doc__ = "Provides access to the Windows registry.";
 

--- a/Src/IronPython.Modules/winreg.cs
+++ b/Src/IronPython.Modules/winreg.cs
@@ -24,9 +24,7 @@ using IronPython.Runtime.Types;
 
 [assembly: PythonModule("winreg", typeof(IronPython.Modules.PythonWinReg), PlatformsAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
-#if NET5_0
     [SupportedOSPlatform("windows")]
-#endif
     public static class PythonWinReg {
         public const string __doc__ = "Provides access to the Windows registry.";
 

--- a/Src/IronPython.Modules/winsound.cs
+++ b/Src/IronPython.Modules/winsound.cs
@@ -1,24 +1,23 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 using IronPython.Runtime;
-using IronPython.Runtime.Binding;
-using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
-using IronPython.Runtime.Types;
 
-using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
-
 
 #if FEATURE_NATIVE
 [assembly: PythonModule("winsound", typeof(IronPython.Modules.PythonWinsoundModule), PlatformsAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
+    [SupportedOSPlatform("windows")]
     public static class PythonWinsoundModule {
         public static readonly string __doc__ = @"PlaySound(sound, flags) - play a sound
 SND_FILENAME - sound is a wav file name

--- a/Src/IronPython.SQLite/IronPython.SQLite.csproj
+++ b/Src/IronPython.SQLite/IronPython.SQLite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;netstandard2.0;net5.0</TargetFrameworks>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <SQLiteCommon>SQLITE_DEBUG;TRUE;WIN32;_MSC_VER;SQLITE_ASCII;SQLITE_MEM_POOL;SQLITE_ENABLE_COLUMN_METADATA;SQLITE_OS_WIN;SQLITE_SYSTEM_MALLOC;VDBE_PROFILE_OFF</SQLiteCommon>
     <SQLiteCommonOmit>SQLITE_OMIT_AUTHORIZATION;SQLITE_OMIT_DEPRECATED;SQLITE_OMIT_GET_TABLE;SQLITE_OMIT_INCRBLOB;SQLITE_OMIT_LOOKASIDE;SQLITE_OMIT_SHARED_CACHE;SQLITE_OMIT_UTF16;SQLITE_OMIT_WAL</SQLiteCommonOmit>

--- a/Src/IronPython.SQLite/c#sqlite/os_win_c.cs
+++ b/Src/IronPython.SQLite/c#sqlite/os_win_c.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
 using DWORD = System.UInt64;
@@ -1249,6 +1250,9 @@ return SQLITE_OK;
       int res = 0;
       if ( isNT() )
       {
+#if FEATURE_RUNTIMEINFORMATION
+        Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
         res = lockingStrategy.SharedLockFile( pFile, SHARED_FIRST, SHARED_SIZE );
       }
       /* isNT() is 1 if SQLITE_OS_WINCE==1, so this else is never executed.
@@ -3708,6 +3712,9 @@ Debug.Assert(winSysInfo.dwAllocationGranularity > 0);
             pFile.fs.Lock( offset, length );
         }
 
+#if FEATURE_OSPLATFORMATTRIBUTE
+      [SupportedOSPlatform("windows")]
+#endif
       public virtual int SharedLockFile( sqlite3_file pFile, long offset, long length )
         {
 #if !(SQLITE_SILVERLIGHT || WINDOWS_MOBILE || SQLITE_WINRT)
@@ -3782,6 +3789,6 @@ Debug.Assert(winSysInfo.dwAllocationGranularity > 0);
         }
         return exists;
     }
-#endif 
+#endif
   }
 }

--- a/Src/IronPython.Wpf/DynamicXamlReader.cs
+++ b/Src/IronPython.Wpf/DynamicXamlReader.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Xaml;

--- a/Src/IronPython.Wpf/IronPython.Wpf.csproj
+++ b/Src/IronPython.Wpf/IronPython.Wpf.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <StoreInDLLs>true</StoreInDLLs>
     <UseWPF Condition=" '$(OS)' == 'Windows_NT' ">true</UseWPF>

--- a/Src/IronPython.Wpf/IronPython.Wpf.csproj
+++ b/Src/IronPython.Wpf/IronPython.Wpf.csproj
@@ -4,8 +4,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
-    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <StoreInDLLs>true</StoreInDLLs>
     <UseWPF Condition=" '$(OS)' == 'Windows_NT' ">true</UseWPF>
   </PropertyGroup>

--- a/Src/IronPython.Wpf/_wpf.cs
+++ b/Src/IronPython.Wpf/_wpf.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_WPF || NETCOREAPP3_1
+#if FEATURE_WPF || NETCOREAPP3_1 || NET5_0
 
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -15,7 +15,7 @@ using Microsoft.Scripting.Runtime;
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 using Microsoft.Internal.Scripting.Runtime; // TODO: get rid of this once DynamicXamlReader is in the DLR
 #endif
 

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;netstandard2.0;net5.0</TargetFrameworks>
     <BaseAddress>879755264</BaseAddress>
     <CodeAnalysisRuleSet>..\..\IronPython.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,7 +59,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nullable" Version="1.2.1">
+    <PackageReference Include="Nullable" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -437,7 +437,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
             }
         }
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
         public static string float_repr_style = "short";
 #else
         public static string float_repr_style = "legacy";

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -778,7 +778,7 @@ namespace IronPython.Runtime {
         }
 
         private void ValidateTable(IList<byte>? table) {
-            if (table != null && table.Count != 256) {
+            if (table is not null && table.Count != 256) {
                 throw PythonOps.ValueError("translation table must be 256 characters long");
             }
         }

--- a/Src/IronPython/Runtime/ClrModule.cs
+++ b/Src/IronPython/Runtime/ClrModule.cs
@@ -1167,7 +1167,9 @@ import Namespace.")]
                     // something more complex, let the binary formatter handle it                    
                     BinaryFormatter bf = new BinaryFormatter();
                     MemoryStream stream = new MemoryStream();
+#pragma warning disable SYSLIB0011 // BinaryFormatter serialization methods are obsolete in .NET 5.0
                     bf.Serialize(stream, self);
+#pragma warning restore SYSLIB0011
                     data = stream.ToArray().MakeString();
                     format = null;
                     break;
@@ -1209,7 +1211,9 @@ import Namespace.")]
 
             MemoryStream stream = new MemoryStream(data.MakeByteArray());
             BinaryFormatter bf = new BinaryFormatter();
+#pragma warning disable SYSLIB0011 // BinaryFormatter serialization methods are obsolete in .NET 5.0
             return bf.Deserialize(stream);
+#pragma warning restore SYSLIB0011
         }
 #endif
     }

--- a/Src/IronPython/Runtime/MemoryView.cs
+++ b/Src/IronPython/Runtime/MemoryView.cs
@@ -186,6 +186,7 @@ namespace IronPython.Runtime {
             } catch {}
         }
 
+        [MemberNotNull(nameof(_buffer))]
         private void CheckBuffer() {
             if (_buffer == null) throw PythonOps.ValueError("operation forbidden on released memoryview object");
         }
@@ -351,7 +352,7 @@ namespace IronPython.Runtime {
         public PythonTuple suboffsets {
             get {
                 CheckBuffer();
-                Debug.Assert(_buffer!.SubOffsets == null); // TODO: implement suboffsets support
+                Debug.Assert(_buffer.SubOffsets == null); // TODO: implement suboffsets support
                 return PythonTuple.EMPTY;
             }
         }
@@ -363,7 +364,7 @@ namespace IronPython.Runtime {
                 return Bytes.Empty;
             }
 
-            var buf = _buffer!.AsReadOnlySpan();
+            var buf = _buffer.AsReadOnlySpan();
 
             if (_isCContig) {
                 return Bytes.Make(buf.Slice(_offset, _numItems * _itemSize).ToArray());
@@ -382,7 +383,7 @@ namespace IronPython.Runtime {
             CheckBuffer();
             TypecodeOps.DecomposeTypecode(_format, out char byteorder, out char typecode);
 
-            return subdimensionToList(_buffer!.AsReadOnlySpan(), _offset, dim: 0);
+            return subdimensionToList(_buffer.AsReadOnlySpan(), _offset, dim: 0);
 
             object subdimensionToList(ReadOnlySpan<byte> source, int ofs, int dim) {
                 if (dim >= _shape.Count) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable SYSLIB0001 // UTF-7 code paths are obsolete in .NET 5
+
 #nullable enable
 
 using System;

--- a/Src/IronPython/SystemRuntimeVersioning.cs
+++ b/Src/IronPython/SystemRuntimeVersioning.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.Versioning {
+#if !FEATURE_OSPLATFORMATTRIBUTE
+    internal abstract class OSPlatformAttribute : Attribute {
+        private protected OSPlatformAttribute(string platformName) {
+            PlatformName = platformName;
+        }
+        public string PlatformName { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly |
+                AttributeTargets.Class |
+                AttributeTargets.Constructor |
+                AttributeTargets.Enum |
+                AttributeTargets.Event |
+                AttributeTargets.Field |
+                AttributeTargets.Method |
+                AttributeTargets.Module |
+                AttributeTargets.Property |
+                AttributeTargets.Struct,
+                AllowMultiple = true, Inherited = false)]
+    internal sealed class SupportedOSPlatformAttribute : OSPlatformAttribute {
+        public SupportedOSPlatformAttribute(string platformName) : base(platformName) {
+        }
+    }
+#endif
+}

--- a/Src/IronPythonConsole/IronPythonConsole.csproj
+++ b/Src/IronPythonConsole/IronPythonConsole.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>IronPythonConsole</RootNamespace>
     <AssemblyName>ipy</AssemblyName>

--- a/Src/IronPythonTest/EncodingTest.cs
+++ b/Src/IronPythonTest/EncodingTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable SYSLIB0001 // UTF-7 code paths are obsolete in .NET 5
+
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
 using NUnit.Framework;

--- a/Src/IronPythonTest/Exceptions.cs
+++ b/Src/IronPythonTest/Exceptions.cs
@@ -45,7 +45,9 @@ namespace IronPythonTest {
             try {
                 CallVirtual();
             } catch (Exception e) {
+#pragma warning disable CA2200 // Rethrow to preserve stack details
                 throw e;
+#pragma warning restore CA2200 // Rethrow to preserve stack details
             }
             return null;
         }

--- a/Src/IronPythonTest/IronPythonTest.csproj
+++ b/Src/IronPythonTest/IronPythonTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/IronPythonTest/IronPythonTest.csproj
+++ b/Src/IronPythonTest/IronPythonTest.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnitLite" Version="3.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 

--- a/Tests/test_re_stdlib.py
+++ b/Tests/test_re_stdlib.py
@@ -10,6 +10,9 @@ import unittest
 import codecs
 import sys
 
+import clr
+is_net50 = clr.TargetFramework == ".NETCoreApp,Version=v5.0"
+
 from iptest import run_test
 
 import test.test_re
@@ -17,7 +20,7 @@ import test.test_re
 def load_tests(loader, standard_tests, pattern):
     if sys.implementation.name == 'ironpython':
         suite = unittest.TestSuite()
-        suite.addTest(test.test_re.ExternalTests('test_re_benchmarks'))
+        if not is_net50: suite.addTest(test.test_re.ExternalTests('test_re_benchmarks'))
         #suite.addTest(test.test_re.ExternalTests('test_re_tests'))
         suite.addTest(test.test_re.ImplementationTest('test_overlap_table'))
         #suite.addTest(test.test_re.PatternReprTests('test_bytes'))
@@ -58,7 +61,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_re.ReTests('test_bug_725106'))
         suite.addTest(test.test_re.ReTests('test_bug_725149'))
         #suite.addTest(test.test_re.ReTests('test_bug_764548'))
-        suite.addTest(test.test_re.ReTests('test_bug_817234'))
+        if not is_net50: suite.addTest(test.test_re.ReTests('test_bug_817234'))
         suite.addTest(test.test_re.ReTests('test_bug_926075'))
         suite.addTest(test.test_re.ReTests('test_bug_931848'))
         suite.addTest(test.test_re.ReTests('test_bytes_str_mixing'))

--- a/Tests/test_re_stdlib.py
+++ b/Tests/test_re_stdlib.py
@@ -7,11 +7,7 @@
 ##
 
 import unittest
-import codecs
 import sys
-
-import clr
-is_net50 = clr.TargetFramework == ".NETCoreApp,Version=v5.0"
 
 from iptest import run_test
 
@@ -20,7 +16,7 @@ import test.test_re
 def load_tests(loader, standard_tests, pattern):
     if sys.implementation.name == 'ironpython':
         suite = unittest.TestSuite()
-        if not is_net50: suite.addTest(test.test_re.ExternalTests('test_re_benchmarks'))
+        suite.addTest(test.test_re.ExternalTests('test_re_benchmarks'))
         #suite.addTest(test.test_re.ExternalTests('test_re_tests'))
         suite.addTest(test.test_re.ImplementationTest('test_overlap_table'))
         #suite.addTest(test.test_re.PatternReprTests('test_bytes'))
@@ -61,7 +57,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_re.ReTests('test_bug_725106'))
         suite.addTest(test.test_re.ReTests('test_bug_725149'))
         #suite.addTest(test.test_re.ReTests('test_bug_764548'))
-        if not is_net50: suite.addTest(test.test_re.ReTests('test_bug_817234'))
+        suite.addTest(test.test_re.ReTests('test_bug_817234'))
         suite.addTest(test.test_re.ReTests('test_bug_926075'))
         suite.addTest(test.test_re.ReTests('test_bug_931848'))
         suite.addTest(test.test_re.ReTests('test_bytes_str_mixing'))
@@ -127,7 +123,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_re.ReTests('test_unlimited_zero_width_repeat'))
         suite.addTest(test.test_re.ReTests('test_weakref'))
         return suite
-        
+
     else:
         return loader.loadTestsFromModule(test.test_re, pattern)
 

--- a/make.ps1
+++ b/make.ps1
@@ -4,7 +4,7 @@ Param(
     [Parameter(Position=1)]
     [String] $target = "release",
     [String] $configuration = "Release",
-    [String[]] $frameworks=@('net46','netcoreapp2.1','netcoreapp3.1'),
+    [String[]] $frameworks=@('net46','netcoreapp2.1','netcoreapp3.1','net5.0'),
     [String] $platform = "x64",
     [switch] $runIgnored,
     [int] $jobs = [System.Environment]::ProcessorCount


### PR DESCRIPTION
This is prep work to enable testing with .NET 5.0.

There are still some failures with `test_re_stdlib` which are due to some bugs in .NET 5.0 which should be fixed before its release (https://github.com/dotnet/runtime/issues/42390, https://github.com/dotnet/runtime/issues/42392, https://github.com/dotnet/runtime/issues/42448).

**SupportedOSPlatform**
Should see if we can make use of this to annotate and guard our code (e.g. wherever we use `PythonHidden`).

**SYSLIB0001**
UTF-7 has been obsolete in .NET 5. In particular the `string.GetEncoding` methods will no longer return UTF-7. @BCSharp I believe we are not using this to obtain a UTF-7 encoding anywhere? See https://docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0#utf-7-code-paths-are-obsolete for details.

**SYSLIB0004**
The Constrained Execution Region (CER) feature is not supported. I don't think this is a change specific to .NET 5, just a new warning. This comes up in `ctypes`. Need to file an issue to investigate what the consequences are.

**SYSLIB0006**
Thread.Abort is not supported and throws PlatformNotSupportedException. I don't think this is a change specific to .NET 5, just a new warning. Should investigate to see if there's anything we can use in place of this.

**SYSLIB0011**
BinaryFormatter serialization is obsolete and should not be used. Should be investigated, maybe we can remove the `clr.Serialize/clr.Deserialize` methods.