### PR TITLE
Implement Bytes.__new__

### DIFF
--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -545,7 +545,7 @@ namespace IronPython.Runtime.Operations {
             bool isLittle = byteorder == "little";
             if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
 
-            return FromBytes((Bytes)Bytes.__new__(context, TypeCache.Bytes, bytes), isLittle, signed);
+            return FromBytes(Bytes.FromObject(context, bytes), isLittle, signed);
         }
 
         private static BigInteger FromBytes(IList<byte> bytes, bool isLittle, bool signed) {

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -545,7 +545,7 @@ namespace IronPython.Runtime.Operations {
             bool isLittle = byteorder == "little";
             if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
 
-            return FromBytes(new Bytes(context, bytes), isLittle, signed);
+            return FromBytes((Bytes)Bytes.__new__(context, TypeCache.Bytes, bytes), isLittle, signed);
         }
 
         private static BigInteger FromBytes(IList<byte> bytes, bool isLittle, bool signed) {

--- a/Src/IronPython/Runtime/Types/TypeCache.Generated.cs
+++ b/Src/IronPython/Runtime/Types/TypeCache.Generated.cs
@@ -28,6 +28,7 @@ namespace IronPython.Runtime.Types {
         private static PythonType setcollection;
         private static PythonType pythontype;
         private static PythonType str;
+        private static PythonType bytes;
         private static PythonType pythontuple;
         private static PythonType weakreference;
         private static PythonType pythonlist;
@@ -120,6 +121,13 @@ namespace IronPython.Runtime.Types {
             get {
                 if (str == null) str = DynamicHelpers.GetPythonTypeFromType(typeof(String));
                 return str;
+            }
+        }
+
+        public static PythonType Bytes {
+            get {
+                if (bytes == null) bytes = DynamicHelpers.GetPythonTypeFromType(typeof(Bytes));
+                return bytes;
             }
         }
 

--- a/Src/Scripts/generate_typecache.py
+++ b/Src/Scripts/generate_typecache.py
@@ -44,6 +44,7 @@ data = [
     TypeData('SetCollection', entryName='Set'),
     TypeData('PythonType'),
     TypeData('String', 'str'),
+    TypeData('Bytes'),
     TypeData('PythonTuple'),
     TypeData('WeakReference'),
     TypeData('PythonList'),

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -182,6 +182,7 @@ class BytesTest(IronPythonTestCase):
 
         self.assertEquals(bytes(A4()), b'abc')
         self.assertEquals(bytearray(A4()), bytearray(42))
+        self.assertEquals(int.from_bytes(A4(), 'big'), 0x616263)
 
         class EmptyClass: pass
         t = EmptyClass()
@@ -574,6 +575,8 @@ class BytesTest(IronPythonTestCase):
 
         x = bytearray(x)
         self.assertTrue(id(x.join(b'')) != id(x))
+
+        self.assertEqual(id(b'foo'.join([])), id(b'bar'.join([])))
 
         x = b'abc'
         self.assertEqual(id(b'foo'.join([x])), id(x))

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -31,6 +31,10 @@ class BytesTest(IronPythonTestCase):
 
     def test_init(self):
         b = bytes(b'abcd')
+        self.assertIs(bytes(b), b)
+
+        sb = BytesSubclass(b)
+        self.assertIsNot(BytesSubclass(sb), sb)
 
         for testType in types:
             self.assertEqual(testType(b), b)
@@ -189,7 +193,6 @@ class BytesTest(IronPythonTestCase):
         t.__bytes__ = lambda: b"1"
         self.assertRaisesRegex(TypeError, "'EmptyClass' object is not iterable", bytes, t)
 
-        class BytesSubclass(bytes): pass
         class OtherBytesSubclass(bytes): pass
 
         class SomeClass:

--- a/Tests/test_bytes_stdlib.py
+++ b/Tests/test_bytes_stdlib.py
@@ -177,7 +177,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_bytes.BytesTest('test_contains'))
         suite.addTest(test.test_bytes.BytesTest('test_copy'))
         suite.addTest(test.test_bytes.BytesTest('test_count'))
-        #suite.addTest(test.test_bytes.BytesTest('test_custom'))
+        suite.addTest(test.test_bytes.BytesTest('test_custom'))
         suite.addTest(test.test_bytes.BytesTest('test_decode'))
         suite.addTest(test.test_bytes.BytesTest('test_empty_sequence'))
         suite.addTest(test.test_bytes.BytesTest('test_encoding'))


### PR DESCRIPTION
This is primarily to support the following case (from stdlib tests):

```python
class BytesSubclass(bytes):
    pass

class SomeClass:
    def __bytes__(self):
        return BytesSubclass(b'abc')

assert type(bytes(SomeClas())) is BytesSubclass
```

Also an opportunity to clean up constructor overloads in `Bytes`.