### PR TITLE
Fix #880 

### DIFF
--- a/Src/IronPythonTest/Cases/CaseGenerator.cs
+++ b/Src/IronPythonTest/Cases/CaseGenerator.cs
@@ -62,6 +62,7 @@ namespace IronPythonTest.Cases {
                     .SetCategory(category)
                     .SetName(name)
                     .Returns(0);
+                result.Properties.Add("_CodeFilePath", testcase.Path);
 
                 var runIgnored = !string.IsNullOrWhiteSpace(TestContext.Parameters["RUN_IGNORED"]);
 

--- a/Tests/interop/net/method/test_operators.py
+++ b/Tests/interop/net/method/test_operators.py
@@ -28,22 +28,22 @@ class OperatorsTest(IronPythonTestCase):
         z = AllOpsClass(-6)
 
         #if x: pass
-        #else: self.assertUnreachable()
+        #else: self.fail("Unreachable code reached")
         #
         #Flag.Check(100)
         #
-        #if z: self.assertUnreachable()
+        #if z: self.fail("Unreachable code reached")
         #else: pass
         #
         #Flag.Check(100)
         #
-        #if not x: self.assertUnreachable()
+        #if not x: self.fail("Unreachable code reached")
         #else: pass
         #
         #Flag.Check(100)
         #
         #if not z: pass
-        #else: self.assertUnreachable()
+        #else: self.fail("Unreachable code reached")
         #
         #Flag.Check(100)
 

--- a/Tests/interop/net/type/test_reachtype.py
+++ b/Tests/interop/net/type/test_reachtype.py
@@ -73,7 +73,7 @@ class ReachTypeTest(IronPythonTestCase):
     def test_nothing_public(self):
         try:
             import NothingPublic
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except ImportError:
             pass
 
@@ -129,7 +129,7 @@ class ReachTypeTest(IronPythonTestCase):
         # internal type
         try:
             import InternalRefTypeWithoutNS
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except ImportError:
             pass
 
@@ -206,7 +206,7 @@ class ReachTypeTest(IronPythonTestCase):
         B = 10
         try:
             from PossibleLoadException import B
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except ImportError:
             pass
 

--- a/Tests/modules/io_related/test_cPickle.py
+++ b/Tests/modules/io_related/test_cPickle.py
@@ -631,7 +631,7 @@ class CPickleTest(IronPythonTestCase):
             # exceptions vary between cPickle & Pickle
             try:
                 up.load()
-                self.assertUnreachable()
+                self.fail("Unreachable code reached")
             except Exception as e:
                 pass
 

--- a/Tests/modules/misc/test__weakref.py
+++ b/Tests/modules/misc/test__weakref.py
@@ -79,7 +79,7 @@ class _WeakrefTest(IronPythonTestCase):
         try:
             type(wr).__add__.__get__(wr, None)() # object is dead, should throw
         except: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
 
         # kwarg call
@@ -100,14 +100,14 @@ class _WeakrefTest(IronPythonTestCase):
         try:
             type(x).__sub__.__get(x, None)('abc')
         except AttributeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         if is_cli:      # cli accepts kw-args everywhere
             # calling non-existent method should raise attribute error (kw-arg version)
             try:
                 type(x).__sub__.__get(x, None)(other='abc')
             except AttributeError: pass
-            else: self.assertUnreachable()
+            else: self.fail("Unreachable code reached")
 
     def test_slot_repr(self):
         class C: pass

--- a/Tests/modules/type_related/test__struct.py
+++ b/Tests/modules/type_related/test__struct.py
@@ -190,7 +190,7 @@ class _StructTest(IronPythonTestCase):
         a = _struct.Struct('c')
         try:
             a.__init__('bad')
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except _struct.error as e:
             pass
 

--- a/Tests/test_builtinfunc.py
+++ b/Tests/test_builtinfunc.py
@@ -552,22 +552,22 @@ class BuiltinsTest2(IronPythonTestCase):
 
         try:
             eval('1+')
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except Exception as exp:
             pass
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         # gh1636 - don't use self.assertRaises since it hides the error
         zzz = 1
         try:
             eval("zzz", {})
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except NameError:
             pass
         try:
             eval("zzz", {}, None)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except NameError:
             pass
 
@@ -791,11 +791,11 @@ class BuiltinsTest2(IronPythonTestCase):
 
         try:
             round(number=2.5, ndigits=1.1)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("'float' object cannot be interpreted as an integer", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         # type implements __round__
         # correct number of arguments
@@ -814,47 +814,47 @@ class BuiltinsTest2(IronPythonTestCase):
         # too many arguments
         try:
             round(roundable, 1, 2)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("round() takes at most 2 arguments (3 given)", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         # type does not implement __round__
         # too few arguments
         try:
             round(self.NotRoundable())
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("type NotRoundable doesn't define __round__ method", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         # correct number of arguments
         try:
             round(self.NotRoundable(), 1)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("type NotRoundable doesn't define __round__ method", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         try:
             round(number=self.NotRoundable(), ndigits=1)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("type NotRoundable doesn't define __round__ method", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         # too many arguments
         try:
             round(self.NotRoundable(), 1, 2)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("round() takes at most 2 arguments (3 given)", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         
         self.assertEqualAndCheckType(round(3), 3, int)
         self.assertEqualAndCheckType(round(3, 0), 3, int)
@@ -892,51 +892,51 @@ class BuiltinsTest2(IronPythonTestCase):
 
         try:
             round(number=2, ndigits=1.1)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("'float' object cannot be interpreted as an integer", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         try:
             round(number=111111111111111111111111111111, ndigits=1.1)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("'float' object cannot be interpreted as an integer", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         try:
             round(float('nan'))
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except ValueError as err:
             self.assertEqual("cannot convert float NaN to integer", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         try:
             round(float('inf'))
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except OverflowError as err:
             self.assertEqual("cannot convert float infinity to integer", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         try:
             round(float('-inf'))
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except OverflowError as err:
             self.assertEqual("cannot convert float infinity to integer", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         try:
             round(sys.float_info.max, -307)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except OverflowError as err:
             self.assertEqual("rounded value too large to represent", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         actual = round(float('inf'), 1)
         self.assertTrue(math.isinf(actual) and actual > 0)
@@ -981,11 +981,11 @@ class BuiltinsTest2(IronPythonTestCase):
 
         try:
             round(5.5, self.NonIntegralIndex())
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as err:
             self.assertEqual("__index__ returned non-int (type str)", str(err))
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
     def test_cp16000(self):
         class K(object):

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -515,7 +515,7 @@ class ClassTest(IronPythonTestCase):
             if object in C.__bases__:
                 try:
                     C.__dict__[2] = '2'
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except TypeError: pass
                 self.assertEqual(2 in C.__dict__, False)
 
@@ -536,7 +536,7 @@ class ClassTest(IronPythonTestCase):
             else:
                 try:
                     C.__dict__ = {}
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except AttributeError:
                     pass
 
@@ -736,13 +736,13 @@ class ClassTest(IronPythonTestCase):
 
         try:
             class N(A, B,C): pass
-            self.assertUnreachable("impossible MRO created")
+            self.fail("Unreachable code reached: impossible MRO created")
         except TypeError:
             pass
 
         try:
             class N(A, A): pass
-            self.assertUnreachable("can't dervie from the same base type twice")
+            self.fail("Unreachable code reached: can't dervie from the same base type twice")
         except TypeError:
             pass
 
@@ -850,7 +850,7 @@ class ClassTest(IronPythonTestCase):
 
         try:
             class H(A,B,E): pass
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError:
             pass
 
@@ -978,7 +978,7 @@ class ClassTest(IronPythonTestCase):
 
                 try:
                     eval(testCase)
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except TypeError as e:
                     pass
 
@@ -1016,7 +1016,7 @@ class ClassTest(IronPythonTestCase):
 
                 try:
                     exec(testCase, globals(), locals())
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except TypeError:
                     pass
 
@@ -1049,7 +1049,7 @@ class ClassTest(IronPythonTestCase):
 
                 try:
                     eval(testCase)
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except TypeError:
                     pass
 
@@ -1078,7 +1078,7 @@ class ClassTest(IronPythonTestCase):
 
                 try:
                     eval(testCase)
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except TypeError:
                     pass
 
@@ -1106,7 +1106,7 @@ class ClassTest(IronPythonTestCase):
 
                 try:
                     eval(testCase)
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except (TypeError, ValueError) as e:
                     self.assertEqual(e.args[0].find('returned') == -1, True)    # shouldn't have returned '__complex__ returned ...'
 
@@ -1328,7 +1328,7 @@ class ClassTest(IronPythonTestCase):
             try:
                 class C(object):
                     __slots__ = x
-                self.assertUnreachable()
+                self.fail("Unreachable code reached")
             except TypeError:
                 pass
 
@@ -1546,13 +1546,13 @@ class ClassTest(IronPythonTestCase):
 
         try:
             CycleA.__bases__ = (CycleA,)
-            self.self.assertUnreachable()
+            self.self.fail("Unreachable code reached")
         except TypeError: pass
 
         try:
             CycleA.__bases__ = (CycleB,)
             CycleB.__bases__ = (CycleA,)
-            self.self.assertUnreachable()
+            self.self.fail("Unreachable code reached")
         except TypeError: pass
 
 
@@ -1624,7 +1624,7 @@ class ClassTest(IronPythonTestCase):
             a = foo()
             try:
                 a.__dict__ = x
-                self.assertUnreachable()
+                self.fail("Unreachable code reached")
             except TypeError: pass
 
     def test_default_new_init(self):
@@ -1770,7 +1770,7 @@ class ClassTest(IronPythonTestCase):
     def test_NoneSelf(seld):
         try:
             set.add(None)
-            self.self.assertUnreachable()
+            self.self.fail("Unreachable code reached")
         except TypeError:
             pass
 
@@ -1808,19 +1808,19 @@ class ClassTest(IronPythonTestCase):
         prop = property()
         try: prop.fget = self.test_classmethod
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         try: prop.fdel = self.test_classmethod
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         try: prop.__doc__ = 'abc'
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         try: prop.fset = self.test_classmethod
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
     @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_override_mro(self):

--- a/Tests/test_cliclass.py
+++ b/Tests/test_cliclass.py
@@ -193,7 +193,7 @@ class CliClassTestCase(IronPythonTestCase):
             else:
                 try:
                     C.__dict__ = {}
-                    self.assertUnreachable()
+                    self.fail("Unreachable code reached")
                 except AttributeError:
                     pass
 
@@ -242,12 +242,12 @@ class CliClassTestCase(IronPythonTestCase):
         try:
             System.IComparable[int, int]
         except ValueError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         try:
             System.EventHandler(None)
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         def handler():
             pass
@@ -255,7 +255,7 @@ class CliClassTestCase(IronPythonTestCase):
         try:
             System.EventHandler(handler)("sender", None)
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         def handler(s,a):
             pass
@@ -275,7 +275,7 @@ class CliClassTestCase(IronPythonTestCase):
         try:
             class MyDerivedClass(genericTypes): pass
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
         # Use a TypeGroup to index a TypeGroup
         t = genericTypes[System.IComparable]
@@ -283,7 +283,7 @@ class CliClassTestCase(IronPythonTestCase):
         try:
             System.IComparable[genericTypes]
         except TypeError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
     def test_generic_only_TypeGroup(self):
         from IronPythonTest import BinderTest
@@ -454,7 +454,7 @@ class CliClassTestCase(IronPythonTestCase):
             if prop.Name == 'abc':
                 break
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
     def test_char(self):
         for x in range(256):
@@ -531,7 +531,7 @@ class CliClassTestCase(IronPythonTestCase):
         try:
             IOverrideTestInterface.__setitem__(otdc, 2, 3)
         except NotImplementedError: pass
-        else: self.assertUnreachable()
+        else: self.fail("Unreachable code reached")
 
     def test_field_helpers(self):
         from IronPythonTest import OverrideTestDerivedClass
@@ -826,8 +826,8 @@ End Class""")
         from System import Single, Byte, SByte, Int16, UInt16, Int64, UInt64
         for t in [Single, Byte, SByte, Int16, UInt16, Int64, UInt64]:
             self.assertTrue(hasattr(t, '__nonzero__'))
-            if t(0): self.assertUnreachable()
-            if not t(1): self.assertUnreachable()
+            if t(0): self.fail("Unreachable code reached")
+            if not t(1): self.fail("Unreachable code reached")
 
     def test_virtual_event(self):
         from IronPythonTest import VirtualEvent, OverrideVirtualEvent, SimpleDelegate, UseEvent

--- a/Tests/test_delegate.py
+++ b/Tests/test_delegate.py
@@ -313,7 +313,7 @@ class DelegateTest(IronPythonTestCase):
         try:
             pts = ParameterizedThreadStart(foo.baz)
             pts("Hello")
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError: pass
 
 # SuperDelegate Tests

--- a/Tests/test_file.py
+++ b/Tests/test_file.py
@@ -557,7 +557,7 @@ class FileTest(IronPythonTestCase):
         except IOError as e:
             pass
         else:
-            self.assertUnreachable() # should throw
+            self.fail("Unreachable code reached") # should throw
         #any other exceptions fail
 
     def test_inheritance_kwarg_override(self):
@@ -771,14 +771,14 @@ class FileTest(IronPythonTestCase):
         except Exception as e:
             self.assertEqual(e.errno, 2)
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
         try:
             open('path_too_long' * 100)
         except Exception as e:
             self.assertEqual(e.errno, 2)
         else:
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
 
     def test_write_bytes(self):
         fname = "temp_ip_%d" % os.getpid()

--- a/Tests/test_function.py
+++ b/Tests/test_function.py
@@ -623,13 +623,13 @@ class FunctionTest(IronPythonTestCase):
         # invalid super cases
         try:
             x = super(B, 'abc')
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError:
             pass
 
         try:
             super(B,A)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError:
             pass
 
@@ -934,12 +934,12 @@ class FunctionTest(IronPythonTestCase):
 
         try:
             f(*(1, ))
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError: pass
 
         try:
             f(**{'abc':'def'})
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError: pass
 
 

--- a/Tests/test_isinstance.py
+++ b/Tests/test_isinstance.py
@@ -804,7 +804,7 @@ class IsInstanceTest(IronPythonTestCase):
 
         try:
             class E(C,D): pass
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError:
             pass
 
@@ -815,7 +815,7 @@ class IsInstanceTest(IronPythonTestCase):
     def test_bad_addition(self):
         try:
             2.0 + "2.0"
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError: pass
 
     def test_class_property(self):

--- a/Tests/test_kwarg.py
+++ b/Tests/test_kwarg.py
@@ -539,7 +539,7 @@ class KwargTest(unittest.TestCase):
     def test_NewSetCls(self):
         try:
             NewAll(cls=NewAll)
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError:
             pass
 
@@ -650,7 +650,7 @@ class KwargTest(unittest.TestCase):
         # should raise because only strings are allowed
         try:
             foo(**{2:3})
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError:
             pass
             
@@ -669,7 +669,7 @@ class KwargTest(unittest.TestCase):
         
         try:
             f(**{'a':2, 'b':3, 'c':4})
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError:
             pass
     

--- a/Tests/test_list.py
+++ b/Tests/test_list.py
@@ -335,7 +335,7 @@ class ListTest(IronPythonTestCase):
         for left_operand, right_operand in neg_cases:
             try:
                 left_operand += right_operand
-                self.assertUnreachable()
+                self.fail("Unreachable code reached")
             except TypeError:
                 pass
 

--- a/Tests/test_namebinding.py
+++ b/Tests/test_namebinding.py
@@ -914,7 +914,7 @@ class NameBindingTest(IronPythonTestCase):
 
         try:
             del pow
-            self.assertUnreachable("should have thrown")
+            self.fail("Unreachable code reached: should have thrown")
         except NameError: pass
 
     def test_class_var(self):

--- a/Tests/test_number.py
+++ b/Tests/test_number.py
@@ -240,7 +240,7 @@ class NumberTest(IronPythonTestCase):
         self.assertEqual(None == False, False)
         self.assertEqual(None == True, False)
 
-        if None: self.assertUnreachable("none shouldn't be true")
+        if None: self.fail("Unreachable code reached: none shouldn't be true")
 
         a = None
         if a: self.assertEqual(False, True)

--- a/Tests/test_property.py
+++ b/Tests/test_property.py
@@ -217,7 +217,7 @@ class PropertyTest(IronPythonTestCase):
         property in the class dictionary"""
         class x(object):
             def set(self, value):
-                self.assertUnreachable()
+                self.fail("Unreachable code reached")
             prop = property(lambda x:42, set)
 
         x.prop = 42

--- a/Tests/test_syntax.py
+++ b/Tests/test_syntax.py
@@ -16,7 +16,7 @@ def run_compile_test(self, code, msg, lineno):
         self.assertEqual(e.lineno, lineno)
         self.assertEqual(e.filename, filename)
     else:
-        self.assertUnreachable("Expected exception, got none")
+        self.fail("Unreachable code reached: Expected exception, got none")
 
 def test_compile(self):
 
@@ -627,7 +627,7 @@ class HasASyntaxException:
             #print repr(input), flags
             try:
                 code3 = compile(input, "dummy", "single", flags, 1)
-                self.assertUnreachable()
+                self.fail("Unreachable code reached")
             except SyntaxError as err:
                 self.assertEqual(err.args, res)
 
@@ -637,7 +637,7 @@ class HasASyntaxException:
             def f():
                 x = 3
                     y = 5""")
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except IndentationError as e:
             self.assertEqual(e.lineno, 2)
 

--- a/Tests/test_tuple.py
+++ b/Tests/test_tuple.py
@@ -110,7 +110,7 @@ class TupleTest(IronPythonTestCase):
     def test_sequence_assign(self):
         try:
             a, b = None
-            self.assertUnreachable()
+            self.fail("Unreachable code reached")
         except TypeError as e:
             self.assertEqual(e.args[0], "'NoneType' object is not iterable")
 


### PR DESCRIPTION
Fix #880 

The addition to `CaseGenerator` provides the specific file that the test cases are being pulled from. It makes the `Go To Test` VS action go to the actual test source file and not the C# adapter file. This is a new feature in the most recent release of the Nunit Test Adapter [here](https://docs.nunit.org/articles/vs-test-adapter/Adapter-Release-Notes.html#nunit3-test-adapter-for-visual-studio---version-3170---july-11-2020) and [here](https://github.com/nunit/nunit3-vs-adapter/issues/735)
