### PR TITLE
Resolve test_smtplib failures

### DIFF
--- a/Src/StdLib/Lib/test/support/__init__.py
+++ b/Src/StdLib/Lib/test/support/__init__.py
@@ -1893,6 +1893,7 @@ def modules_cleanup(oldmodules):
 
 def threading_setup():
     if _thread:
+        threading.current_thread() # ironpython: register the current thread if not running on a known thread
         return _thread._count(), threading._dangling.copy()
     else:
         return 1, ()


### PR DESCRIPTION
The `test.support.reap_threads` method takes a snapshot of known threads and then after the test complets it does repeated `gc.collect` calls until the until the threads created by the test are cleaned up.

Since our threads run in a .NET thread, it may not be a thread know to the `threading` module when the snapshot is taken. Because of this the `gc.collect` loop only ends after 100 iterations. This modification ensures that the current thread is present in the snapshot and so the loop ends.