### PR TITLE
Fix hashlib copy on .NET Core

### DIFF
--- a/Src/IronPython.Modules/hashlib/MD5CryptoServiceProvider.cs
+++ b/Src/IronPython.Modules/hashlib/MD5CryptoServiceProvider.cs
@@ -31,7 +31,6 @@
 #if FEATURE_FULL_CRYPTO
 
 using System;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace Mono.Security.Cryptography {

--- a/Src/IronPython.Modules/hashlib/SHA1CryptoServiceProvider.cs
+++ b/Src/IronPython.Modules/hashlib/SHA1CryptoServiceProvider.cs
@@ -1,0 +1,352 @@
+//
+// System.Security.Cryptography.SHA1CryptoServiceProvider.cs
+//
+// Authors:
+//	Matthew S. Ford (Matthew.S.Ford@Rose-Hulman.Edu)
+//	Sebastien Pouliot (sebastien@ximian.com)
+//
+// Copyright 2001 by Matthew S. Ford.
+// Copyright (C) 2004, 2005, 2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// Note:
+// The MS Framework includes two (almost) identical class for SHA1.
+//	SHA1Managed is a 100% managed implementation.
+//	SHA1CryptoServiceProvider (this file) is a wrapper on CryptoAPI.
+// Mono must provide those two class for binary compatibility.
+// In our case both class are wrappers around a managed internal class SHA1Internal.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Mono.Security.Cryptography {
+
+    internal class SHA1Internal {
+        private const int BLOCK_SIZE_BYTES = 64;
+        private uint[] _H;  // these are my chaining variables
+        private ulong count;
+        private byte[] _ProcessingBuffer;   // Used to start data when passed less than a block worth.
+        private int _ProcessingBufferCount; // Counts how much data we have stored that still needs processed.
+        private uint[] buff;
+
+        public SHA1Internal() {
+            _H = new uint[5];
+            _ProcessingBuffer = new byte[BLOCK_SIZE_BYTES];
+            buff = new uint[80];
+
+            Initialize();
+        }
+
+        public void HashCore(byte[] rgb, int ibStart, int cbSize) {
+            int i;
+
+            if (_ProcessingBufferCount != 0) {
+                if (cbSize < (BLOCK_SIZE_BYTES - _ProcessingBufferCount)) {
+                    System.Buffer.BlockCopy(rgb, ibStart, _ProcessingBuffer, _ProcessingBufferCount, cbSize);
+                    _ProcessingBufferCount += cbSize;
+                    return;
+                } else {
+                    i = (BLOCK_SIZE_BYTES - _ProcessingBufferCount);
+                    System.Buffer.BlockCopy(rgb, ibStart, _ProcessingBuffer, _ProcessingBufferCount, i);
+                    ProcessBlock(_ProcessingBuffer, 0);
+                    _ProcessingBufferCount = 0;
+                    ibStart += i;
+                    cbSize -= i;
+                }
+            }
+
+            for (i = 0; i < cbSize - cbSize % BLOCK_SIZE_BYTES; i += BLOCK_SIZE_BYTES) {
+                ProcessBlock(rgb, (uint)(ibStart + i));
+            }
+
+            if (cbSize % BLOCK_SIZE_BYTES != 0) {
+                System.Buffer.BlockCopy(rgb, cbSize - cbSize % BLOCK_SIZE_BYTES + ibStart, _ProcessingBuffer, 0, cbSize % BLOCK_SIZE_BYTES);
+                _ProcessingBufferCount = cbSize % BLOCK_SIZE_BYTES;
+            }
+        }
+
+        public byte[] HashFinal() {
+            byte[] hash = new byte[20];
+
+            ProcessFinalBlock(_ProcessingBuffer, 0, _ProcessingBufferCount);
+
+            for (int i = 0; i < 5; i++) {
+                for (int j = 0; j < 4; j++) {
+                    hash[i * 4 + j] = (byte)(_H[i] >> (8 * (3 - j)));
+                }
+            }
+
+            return hash;
+        }
+
+        public void Initialize() {
+            count = 0;
+            _ProcessingBufferCount = 0;
+
+            _H[0] = 0x67452301;
+            _H[1] = 0xefcdab89;
+            _H[2] = 0x98badcfe;
+            _H[3] = 0x10325476;
+            _H[4] = 0xC3D2E1F0;
+        }
+
+        private void ProcessBlock(byte[] inputBuffer, uint inputOffset) {
+            uint a, b, c, d, e;
+
+            count += BLOCK_SIZE_BYTES;
+
+            // abc removal would not work on the fields
+            uint[] _H = this._H;
+            uint[] buff = this.buff;
+            InitialiseBuff(buff, inputBuffer, inputOffset);
+            FillBuff(buff);
+
+            a = _H[0];
+            b = _H[1];
+            c = _H[2];
+            d = _H[3];
+            e = _H[4];
+
+            // This function was unrolled because it seems to be doubling our performance with current compiler/VM.
+            // Possibly roll up if this changes.
+
+            // ---- Round 1 --------
+            int i = 0;
+            while (i < 20) {
+                e += ((a << 5) | (a >> 27)) + (((c ^ d) & b) ^ d) + 0x5A827999 + buff[i];
+                b = (b << 30) | (b >> 2);
+
+                d += ((e << 5) | (e >> 27)) + (((b ^ c) & a) ^ c) + 0x5A827999 + buff[i + 1];
+                a = (a << 30) | (a >> 2);
+
+                c += ((d << 5) | (d >> 27)) + (((a ^ b) & e) ^ b) + 0x5A827999 + buff[i + 2];
+                e = (e << 30) | (e >> 2);
+
+                b += ((c << 5) | (c >> 27)) + (((e ^ a) & d) ^ a) + 0x5A827999 + buff[i + 3];
+                d = (d << 30) | (d >> 2);
+
+                a += ((b << 5) | (b >> 27)) + (((d ^ e) & c) ^ e) + 0x5A827999 + buff[i + 4];
+                c = (c << 30) | (c >> 2);
+                i += 5;
+            }
+
+            // ---- Round 2 --------
+            while (i < 40) {
+                e += ((a << 5) | (a >> 27)) + (b ^ c ^ d) + 0x6ED9EBA1 + buff[i];
+                b = (b << 30) | (b >> 2);
+
+                d += ((e << 5) | (e >> 27)) + (a ^ b ^ c) + 0x6ED9EBA1 + buff[i + 1];
+                a = (a << 30) | (a >> 2);
+
+                c += ((d << 5) | (d >> 27)) + (e ^ a ^ b) + 0x6ED9EBA1 + buff[i + 2];
+                e = (e << 30) | (e >> 2);
+
+                b += ((c << 5) | (c >> 27)) + (d ^ e ^ a) + 0x6ED9EBA1 + buff[i + 3];
+                d = (d << 30) | (d >> 2);
+
+                a += ((b << 5) | (b >> 27)) + (c ^ d ^ e) + 0x6ED9EBA1 + buff[i + 4];
+                c = (c << 30) | (c >> 2);
+                i += 5;
+            }
+
+            // ---- Round 3 --------
+            while (i < 60) {
+                e += ((a << 5) | (a >> 27)) + ((b & c) | (b & d) | (c & d)) + 0x8F1BBCDC + buff[i];
+                b = (b << 30) | (b >> 2);
+
+                d += ((e << 5) | (e >> 27)) + ((a & b) | (a & c) | (b & c)) + 0x8F1BBCDC + buff[i + 1];
+                a = (a << 30) | (a >> 2);
+
+                c += ((d << 5) | (d >> 27)) + ((e & a) | (e & b) | (a & b)) + 0x8F1BBCDC + buff[i + 2];
+                e = (e << 30) | (e >> 2);
+
+                b += ((c << 5) | (c >> 27)) + ((d & e) | (d & a) | (e & a)) + 0x8F1BBCDC + buff[i + 3];
+                d = (d << 30) | (d >> 2);
+
+                a += ((b << 5) | (b >> 27)) + ((c & d) | (c & e) | (d & e)) + 0x8F1BBCDC + buff[i + 4];
+                c = (c << 30) | (c >> 2);
+                i += 5;
+            }
+
+            // ---- Round 4 --------
+            while (i < 80) {
+                e += ((a << 5) | (a >> 27)) + (b ^ c ^ d) + 0xCA62C1D6 + buff[i];
+                b = (b << 30) | (b >> 2);
+
+                d += ((e << 5) | (e >> 27)) + (a ^ b ^ c) + 0xCA62C1D6 + buff[i + 1];
+                a = (a << 30) | (a >> 2);
+
+                c += ((d << 5) | (d >> 27)) + (e ^ a ^ b) + 0xCA62C1D6 + buff[i + 2];
+                e = (e << 30) | (e >> 2);
+
+                b += ((c << 5) | (c >> 27)) + (d ^ e ^ a) + 0xCA62C1D6 + buff[i + 3];
+                d = (d << 30) | (d >> 2);
+
+                a += ((b << 5) | (b >> 27)) + (c ^ d ^ e) + 0xCA62C1D6 + buff[i + 4];
+                c = (c << 30) | (c >> 2);
+                i += 5;
+            }
+
+            _H[0] += a;
+            _H[1] += b;
+            _H[2] += c;
+            _H[3] += d;
+            _H[4] += e;
+        }
+
+        private static void InitialiseBuff(uint[] buff, byte[] input, uint inputOffset) {
+            buff[0] = (uint)((input[inputOffset + 0] << 24) | (input[inputOffset + 1] << 16) | (input[inputOffset + 2] << 8) | (input[inputOffset + 3]));
+            buff[1] = (uint)((input[inputOffset + 4] << 24) | (input[inputOffset + 5] << 16) | (input[inputOffset + 6] << 8) | (input[inputOffset + 7]));
+            buff[2] = (uint)((input[inputOffset + 8] << 24) | (input[inputOffset + 9] << 16) | (input[inputOffset + 10] << 8) | (input[inputOffset + 11]));
+            buff[3] = (uint)((input[inputOffset + 12] << 24) | (input[inputOffset + 13] << 16) | (input[inputOffset + 14] << 8) | (input[inputOffset + 15]));
+            buff[4] = (uint)((input[inputOffset + 16] << 24) | (input[inputOffset + 17] << 16) | (input[inputOffset + 18] << 8) | (input[inputOffset + 19]));
+            buff[5] = (uint)((input[inputOffset + 20] << 24) | (input[inputOffset + 21] << 16) | (input[inputOffset + 22] << 8) | (input[inputOffset + 23]));
+            buff[6] = (uint)((input[inputOffset + 24] << 24) | (input[inputOffset + 25] << 16) | (input[inputOffset + 26] << 8) | (input[inputOffset + 27]));
+            buff[7] = (uint)((input[inputOffset + 28] << 24) | (input[inputOffset + 29] << 16) | (input[inputOffset + 30] << 8) | (input[inputOffset + 31]));
+            buff[8] = (uint)((input[inputOffset + 32] << 24) | (input[inputOffset + 33] << 16) | (input[inputOffset + 34] << 8) | (input[inputOffset + 35]));
+            buff[9] = (uint)((input[inputOffset + 36] << 24) | (input[inputOffset + 37] << 16) | (input[inputOffset + 38] << 8) | (input[inputOffset + 39]));
+            buff[10] = (uint)((input[inputOffset + 40] << 24) | (input[inputOffset + 41] << 16) | (input[inputOffset + 42] << 8) | (input[inputOffset + 43]));
+            buff[11] = (uint)((input[inputOffset + 44] << 24) | (input[inputOffset + 45] << 16) | (input[inputOffset + 46] << 8) | (input[inputOffset + 47]));
+            buff[12] = (uint)((input[inputOffset + 48] << 24) | (input[inputOffset + 49] << 16) | (input[inputOffset + 50] << 8) | (input[inputOffset + 51]));
+            buff[13] = (uint)((input[inputOffset + 52] << 24) | (input[inputOffset + 53] << 16) | (input[inputOffset + 54] << 8) | (input[inputOffset + 55]));
+            buff[14] = (uint)((input[inputOffset + 56] << 24) | (input[inputOffset + 57] << 16) | (input[inputOffset + 58] << 8) | (input[inputOffset + 59]));
+            buff[15] = (uint)((input[inputOffset + 60] << 24) | (input[inputOffset + 61] << 16) | (input[inputOffset + 62] << 8) | (input[inputOffset + 63]));
+        }
+
+        private static void FillBuff(uint[] buff) {
+            uint val;
+            for (int i = 16; i < 80; i += 8) {
+                val = buff[i - 3] ^ buff[i - 8] ^ buff[i - 14] ^ buff[i - 16];
+                buff[i] = (val << 1) | (val >> 31);
+
+                val = buff[i - 2] ^ buff[i - 7] ^ buff[i - 13] ^ buff[i - 15];
+                buff[i + 1] = (val << 1) | (val >> 31);
+
+                val = buff[i - 1] ^ buff[i - 6] ^ buff[i - 12] ^ buff[i - 14];
+                buff[i + 2] = (val << 1) | (val >> 31);
+
+                val = buff[i + 0] ^ buff[i - 5] ^ buff[i - 11] ^ buff[i - 13];
+                buff[i + 3] = (val << 1) | (val >> 31);
+
+                val = buff[i + 1] ^ buff[i - 4] ^ buff[i - 10] ^ buff[i - 12];
+                buff[i + 4] = (val << 1) | (val >> 31);
+
+                val = buff[i + 2] ^ buff[i - 3] ^ buff[i - 9] ^ buff[i - 11];
+                buff[i + 5] = (val << 1) | (val >> 31);
+
+                val = buff[i + 3] ^ buff[i - 2] ^ buff[i - 8] ^ buff[i - 10];
+                buff[i + 6] = (val << 1) | (val >> 31);
+
+                val = buff[i + 4] ^ buff[i - 1] ^ buff[i - 7] ^ buff[i - 9];
+                buff[i + 7] = (val << 1) | (val >> 31);
+            }
+        }
+
+        private void ProcessFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {
+            ulong total = count + (ulong)inputCount;
+            int paddingSize = (56 - (int)(total % BLOCK_SIZE_BYTES));
+
+            if (paddingSize < 1)
+                paddingSize += BLOCK_SIZE_BYTES;
+
+            int length = inputCount + paddingSize + 8;
+            byte[] fooBuffer = (length == 64) ? _ProcessingBuffer : new byte[length];
+
+            for (int i = 0; i < inputCount; i++) {
+                fooBuffer[i] = inputBuffer[i + inputOffset];
+            }
+
+            fooBuffer[inputCount] = 0x80;
+            for (int i = inputCount + 1; i < inputCount + paddingSize; i++) {
+                fooBuffer[i] = 0x00;
+            }
+
+            // I deal in bytes. The algorithm deals in bits.
+            ulong size = total << 3;
+            AddLength(size, fooBuffer, inputCount + paddingSize);
+            ProcessBlock(fooBuffer, 0);
+
+            if (length == 128)
+                ProcessBlock(fooBuffer, 64);
+        }
+
+        internal void AddLength(ulong length, byte[] buffer, int position) {
+            buffer[position++] = (byte)(length >> 56);
+            buffer[position++] = (byte)(length >> 48);
+            buffer[position++] = (byte)(length >> 40);
+            buffer[position++] = (byte)(length >> 32);
+            buffer[position++] = (byte)(length >> 24);
+            buffer[position++] = (byte)(length >> 16);
+            buffer[position++] = (byte)(length >> 8);
+            buffer[position] = (byte)(length);
+        }
+
+        public SHA1Internal Clone() {
+            return new SHA1Internal {
+                _H = (uint[])_H.Clone(),
+                count = count,
+                _ProcessingBuffer = (byte[])_ProcessingBuffer.Clone(),
+                _ProcessingBufferCount = _ProcessingBufferCount,
+                buff = (uint[])buff.Clone()
+            };
+        }
+    }
+
+    [ComVisible(true)]
+    internal sealed class SHA1CryptoServiceProvider : SHA1, ICloneable {
+        private SHA1Internal sha;
+
+        public SHA1CryptoServiceProvider() {
+            sha = new SHA1Internal();
+        }
+
+        ~SHA1CryptoServiceProvider() {
+            Dispose(false);
+        }
+
+        protected override void Dispose(bool disposing) {
+            // nothing new to do (managed implementation)
+            base.Dispose(disposing);
+        }
+
+        protected override void HashCore(byte[] rgb, int ibStart, int cbSize) {
+            State = 1;
+            sha.HashCore(rgb, ibStart, cbSize);
+        }
+
+        protected override byte[] HashFinal() {
+            State = 0;
+            return sha.HashFinal();
+        }
+
+        public override void Initialize() {
+            sha.Initialize();
+        }
+
+        object ICloneable.Clone() {
+            return new SHA1CryptoServiceProvider() {
+                sha = sha.Clone()
+            };
+        }
+    }
+}

--- a/Src/IronPython.Modules/hashlib/SHA224.cs
+++ b/Src/IronPython.Modules/hashlib/SHA224.cs
@@ -32,37 +32,6 @@ using IronPython.Runtime;
 
 namespace Mono.Security.Cryptography {
 
-    // FIXME: Remove when (or if) SHA224 moves into corlib
-    // (as corlib already have the required constants).
-    internal sealed class SHAConstants {
-
-        private SHAConstants() {
-            // Never instantiated.
-        }
-
-        // SHA-224/256 Constants
-        // Represent the first 32 bits of the fractional parts of the
-        // cube roots of the first sixty-four prime numbers
-        public static readonly uint[] K1 = {
-            0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
-            0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
-            0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
-            0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
-            0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
-            0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
-            0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
-            0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
-            0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
-            0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
-            0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
-            0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
-            0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
-            0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
-            0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
-            0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
-        };
-    }
-
     [PythonHidden]
     public abstract class SHA224 : HashAlgorithm {
 

--- a/Src/IronPython.Modules/hashlib/SHA256Managed.cs
+++ b/Src/IronPython.Modules/hashlib/SHA256Managed.cs
@@ -1,0 +1,210 @@
+//
+// System.Security.Cryptography.SHA256Managed.cs
+//
+// Author:
+//   Matthew S. Ford (Matthew.S.Ford@Rose-Hulman.Edu)
+//
+// (C) 2001 
+// Copyright (C) 2004, 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Mono.Security.Cryptography {
+
+    [ComVisible(true)]
+    internal class SHA256Managed : SHA256 {
+
+        private const int BLOCK_SIZE_BYTES = 64;
+        private uint[] _H;
+        private ulong count;
+        private byte[] _ProcessingBuffer;   // Used to start data when passed less than a block worth.
+        private int _ProcessingBufferCount; // Counts how much data we have stored that still needs processed.
+        private uint[] buff;
+
+        public SHA256Managed() {
+            _H = new uint[8];
+            _ProcessingBuffer = new byte[BLOCK_SIZE_BYTES];
+            buff = new uint[64];
+            Initialize();
+        }
+
+        protected override void HashCore(byte[] rgb, int ibStart, int cbSize) {
+            int i;
+            State = 1;
+
+            if (_ProcessingBufferCount != 0) {
+                if (cbSize < (BLOCK_SIZE_BYTES - _ProcessingBufferCount)) {
+                    System.Buffer.BlockCopy(rgb, ibStart, _ProcessingBuffer, _ProcessingBufferCount, cbSize);
+                    _ProcessingBufferCount += cbSize;
+                    return;
+                } else {
+                    i = (BLOCK_SIZE_BYTES - _ProcessingBufferCount);
+                    System.Buffer.BlockCopy(rgb, ibStart, _ProcessingBuffer, _ProcessingBufferCount, i);
+                    ProcessBlock(_ProcessingBuffer, 0);
+                    _ProcessingBufferCount = 0;
+                    ibStart += i;
+                    cbSize -= i;
+                }
+            }
+
+            for (i = 0; i < cbSize - cbSize % BLOCK_SIZE_BYTES; i += BLOCK_SIZE_BYTES) {
+                ProcessBlock(rgb, ibStart + i);
+            }
+
+            if (cbSize % BLOCK_SIZE_BYTES != 0) {
+                System.Buffer.BlockCopy(rgb, cbSize - cbSize % BLOCK_SIZE_BYTES + ibStart, _ProcessingBuffer, 0, cbSize % BLOCK_SIZE_BYTES);
+                _ProcessingBufferCount = cbSize % BLOCK_SIZE_BYTES;
+            }
+        }
+
+        protected override byte[] HashFinal() {
+            byte[] hash = new byte[32];
+            int i, j;
+
+            ProcessFinalBlock(_ProcessingBuffer, 0, _ProcessingBufferCount);
+
+            for (i = 0; i < 8; i++) {
+                for (j = 0; j < 4; j++) {
+                    hash[i * 4 + j] = (byte)(_H[i] >> (24 - j * 8));
+                }
+            }
+
+            State = 0;
+            return hash;
+        }
+
+        public override void Initialize() {
+            count = 0;
+            _ProcessingBufferCount = 0;
+
+            _H[0] = 0x6A09E667;
+            _H[1] = 0xBB67AE85;
+            _H[2] = 0x3C6EF372;
+            _H[3] = 0xA54FF53A;
+            _H[4] = 0x510E527F;
+            _H[5] = 0x9B05688C;
+            _H[6] = 0x1F83D9AB;
+            _H[7] = 0x5BE0CD19;
+        }
+
+        private void ProcessBlock(byte[] inputBuffer, int inputOffset) {
+            uint a, b, c, d, e, f, g, h;
+            uint t1, t2;
+            int i;
+            uint[] K1 = SHAConstants.K1;
+            uint[] buff = this.buff;
+
+            count += BLOCK_SIZE_BYTES;
+
+            for (i = 0; i < 16; i++) {
+                buff[i] = (uint)(((inputBuffer[inputOffset + 4 * i]) << 24)
+                    | ((inputBuffer[inputOffset + 4 * i + 1]) << 16)
+                    | ((inputBuffer[inputOffset + 4 * i + 2]) << 8)
+                    | ((inputBuffer[inputOffset + 4 * i + 3])));
+            }
+
+
+            for (i = 16; i < 64; i++) {
+                t1 = buff[i - 15];
+                t1 = (((t1 >> 7) | (t1 << 25)) ^ ((t1 >> 18) | (t1 << 14)) ^ (t1 >> 3));
+
+                t2 = buff[i - 2];
+                t2 = (((t2 >> 17) | (t2 << 15)) ^ ((t2 >> 19) | (t2 << 13)) ^ (t2 >> 10));
+                buff[i] = t2 + buff[i - 7] + t1 + buff[i - 16];
+            }
+
+            a = _H[0];
+            b = _H[1];
+            c = _H[2];
+            d = _H[3];
+            e = _H[4];
+            f = _H[5];
+            g = _H[6];
+            h = _H[7];
+
+            for (i = 0; i < 64; i++) {
+                t1 = h + (((e >> 6) | (e << 26)) ^ ((e >> 11) | (e << 21)) ^ ((e >> 25) | (e << 7))) + ((e & f) ^ (~e & g)) + K1[i] + buff[i];
+
+                t2 = (((a >> 2) | (a << 30)) ^ ((a >> 13) | (a << 19)) ^ ((a >> 22) | (a << 10)));
+                t2 = t2 + ((a & b) ^ (a & c) ^ (b & c));
+                h = g;
+                g = f;
+                f = e;
+                e = d + t1;
+                d = c;
+                c = b;
+                b = a;
+                a = t1 + t2;
+            }
+
+            _H[0] += a;
+            _H[1] += b;
+            _H[2] += c;
+            _H[3] += d;
+            _H[4] += e;
+            _H[5] += f;
+            _H[6] += g;
+            _H[7] += h;
+        }
+
+        private void ProcessFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {
+            ulong total = count + (ulong)inputCount;
+            int paddingSize = (56 - (int)(total % BLOCK_SIZE_BYTES));
+
+            if (paddingSize < 1)
+                paddingSize += BLOCK_SIZE_BYTES;
+
+            byte[] fooBuffer = new byte[inputCount + paddingSize + 8];
+
+            for (int i = 0; i < inputCount; i++) {
+                fooBuffer[i] = inputBuffer[i + inputOffset];
+            }
+
+            fooBuffer[inputCount] = 0x80;
+            for (int i = inputCount + 1; i < inputCount + paddingSize; i++) {
+                fooBuffer[i] = 0x00;
+            }
+
+            // I deal in bytes. The algorithm deals in bits.
+            ulong size = total << 3;
+            AddLength(size, fooBuffer, inputCount + paddingSize);
+            ProcessBlock(fooBuffer, 0);
+
+            if (inputCount + paddingSize + 8 == 128) {
+                ProcessBlock(fooBuffer, 64);
+            }
+        }
+
+        internal void AddLength(ulong length, byte[] buffer, int position) {
+            buffer[position++] = (byte)(length >> 56);
+            buffer[position++] = (byte)(length >> 48);
+            buffer[position++] = (byte)(length >> 40);
+            buffer[position++] = (byte)(length >> 32);
+            buffer[position++] = (byte)(length >> 24);
+            buffer[position++] = (byte)(length >> 16);
+            buffer[position++] = (byte)(length >> 8);
+            buffer[position] = (byte)(length);
+        }
+    }
+}

--- a/Src/IronPython.Modules/hashlib/SHA384Managed.cs
+++ b/Src/IronPython.Modules/hashlib/SHA384Managed.cs
@@ -1,0 +1,247 @@
+//
+// System.Security.Cryptography.SHA384Managed.cs
+//
+// Authors:
+//	Dan Lewis (dihlewis@yahoo.co.uk)
+//	Sebastien Pouliot (sebastien@ximian.com)
+//
+// (C) 2002
+// Implementation translated from Bouncy Castle JCE (http://www.bouncycastle.org/)
+// See bouncycastle.txt for license.
+// Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Mono.Security.Cryptography {
+
+    [ComVisible(true)]
+    internal class SHA384Managed : SHA384 {
+
+        private byte[] xBuf;
+        private int xBufOff;
+
+        private ulong byteCount1;
+        private ulong byteCount2;
+
+        private ulong H1, H2, H3, H4, H5, H6, H7, H8;
+        private ulong[] W;
+        private int wOff;
+
+        public SHA384Managed() {
+            xBuf = new byte[8];
+            W = new ulong[80];
+            Initialize(false); // limited initialization
+        }
+
+        private void Initialize(bool reuse) {
+            // SHA-384 initial hash value
+            // The first 64 bits of the fractional parts of the square roots
+            // of the 9th through 16th prime numbers
+            H1 = 0xcbbb9d5dc1059ed8L;
+            H2 = 0x629a292a367cd507L;
+            H3 = 0x9159015a3070dd17L;
+            H4 = 0x152fecd8f70e5939L;
+            H5 = 0x67332667ffc00b31L;
+            H6 = 0x8eb44a8768581511L;
+            H7 = 0xdb0c2e0d64f98fa7L;
+            H8 = 0x47b5481dbefa4fa4L;
+
+            if (reuse) {
+                byteCount1 = 0;
+                byteCount2 = 0;
+
+                xBufOff = 0;
+                for (int i = 0; i < xBuf.Length; i++)
+                    xBuf[i] = 0;
+
+                wOff = 0;
+                for (int i = 0; i != W.Length; i++)
+                    W[i] = 0;
+            }
+        }
+
+        public override void Initialize() {
+            Initialize(true); // reuse instance
+        }
+
+        // protected
+
+        protected override void HashCore(byte[] rgb, int ibStart, int cbSize) {
+            // fill the current word
+            while ((xBufOff != 0) && (cbSize > 0)) {
+                update(rgb[ibStart]);
+                ibStart++;
+                cbSize--;
+            }
+
+            // process whole words.
+            while (cbSize > xBuf.Length) {
+                processWord(rgb, ibStart);
+                ibStart += xBuf.Length;
+                cbSize -= xBuf.Length;
+                byteCount1 += (ulong)xBuf.Length;
+            }
+
+            // load in the remainder.
+            while (cbSize > 0) {
+                update(rgb[ibStart]);
+                ibStart++;
+                cbSize--;
+            }
+        }
+
+        protected override byte[] HashFinal() {
+            adjustByteCounts();
+
+            ulong lowBitLength = byteCount1 << 3;
+            ulong hiBitLength = byteCount2;
+
+            // add the pad bytes.
+            update((byte)128);
+            while (xBufOff != 0)
+                update((byte)0);
+
+            processLength(lowBitLength, hiBitLength);
+            processBlock();
+
+            byte[] output = new byte[48];
+            unpackWord(H1, output, 0);
+            unpackWord(H2, output, 8);
+            unpackWord(H3, output, 16);
+            unpackWord(H4, output, 24);
+            unpackWord(H5, output, 32);
+            unpackWord(H6, output, 40);
+
+            Initialize();
+            return output;
+        }
+
+        private void update(byte input) {
+            xBuf[xBufOff++] = input;
+            if (xBufOff == xBuf.Length) {
+                processWord(xBuf, 0);
+                xBufOff = 0;
+            }
+            byteCount1++;
+        }
+
+        private void processWord(byte[] input, int inOff) {
+            W[wOff++] = ((ulong)input[inOff] << 56)
+                | ((ulong)input[inOff + 1] << 48)
+                | ((ulong)input[inOff + 2] << 40)
+                | ((ulong)input[inOff + 3] << 32)
+                    | ((ulong)input[inOff + 4] << 24)
+                | ((ulong)input[inOff + 5] << 16)
+                | ((ulong)input[inOff + 6] << 8)
+                | ((ulong)input[inOff + 7]);
+            if (wOff == 16)
+                processBlock();
+        }
+
+        private void unpackWord(ulong word, byte[] output, int outOff) {
+            output[outOff] = (byte)(word >> 56);
+            output[outOff + 1] = (byte)(word >> 48);
+            output[outOff + 2] = (byte)(word >> 40);
+            output[outOff + 3] = (byte)(word >> 32);
+            output[outOff + 4] = (byte)(word >> 24);
+            output[outOff + 5] = (byte)(word >> 16);
+            output[outOff + 6] = (byte)(word >> 8);
+            output[outOff + 7] = (byte)word;
+        }
+
+        // adjust the byte counts so that byteCount2 represents the
+        // upper long (less 3 bits) word of the byte count.
+        private void adjustByteCounts() {
+            if (byteCount1 > 0x1fffffffffffffffL) {
+                byteCount2 += (byteCount1 >> 61);
+                byteCount1 &= 0x1fffffffffffffffL;
+            }
+        }
+
+        private void processLength(ulong lowW, ulong hiW) {
+            if (wOff > 14)
+                processBlock();
+            W[14] = hiW;
+            W[15] = lowW;
+        }
+
+        private void processBlock() {
+            ulong a, b, c, d, e, f, g, h;
+
+            // abcrem doesn't work on fields
+            ulong[] W = this.W;
+            ulong[] K2 = SHAConstants.K2;
+
+            adjustByteCounts();
+            // expand 16 word block into 80 word blocks.
+            for (int t = 16; t <= 79; t++) {
+                a = W[t - 15];
+                a = ((a >> 1) | (a << 63)) ^ ((a >> 8) | (a << 56)) ^ (a >> 7);
+                b = W[t - 2];
+                b = ((b >> 19) | (b << 45)) ^ ((b >> 61) | (b << 3)) ^ (b >> 6);
+                W[t] = b + W[t - 7] + a + W[t - 16];
+            }
+            // set up working variables.
+            a = H1;
+            b = H2;
+            c = H3;
+            d = H4;
+            e = H5;
+            f = H6;
+            g = H7;
+            h = H8;
+
+            for (int t = 0; t <= 79; t++) {
+                ulong T1 = ((e >> 14) | (e << 50)) ^ ((e >> 18) | (e << 46)) ^ ((e >> 41) | (e << 23));
+                T1 += h + ((e & f) ^ ((~e) & g)) + K2[t] + W[t];
+
+                ulong T2 = ((a >> 28) | (a << 36)) ^ ((a >> 34) | (a << 30)) ^ ((a >> 39) | (a << 25));
+                T2 += ((a & b) ^ (a & c) ^ (b & c));
+
+                h = g;
+                g = f;
+                f = e;
+                e = d + T1;
+                d = c;
+                c = b;
+                b = a;
+                a = T1 + T2;
+            }
+
+            H1 += a;
+            H2 += b;
+            H3 += c;
+            H4 += d;
+            H5 += e;
+            H6 += f;
+            H7 += g;
+            H8 += h;
+            // reset the offset and clean out the word buffer.
+            wOff = 0;
+            for (int i = 0; i != W.Length; i++)
+                W[i] = 0;
+        }
+    }
+}

--- a/Src/IronPython.Modules/hashlib/SHA512Managed.cs
+++ b/Src/IronPython.Modules/hashlib/SHA512Managed.cs
@@ -1,0 +1,264 @@
+//
+// System.Security.Cryptography.SHA512Managed.cs
+//
+// Authors:
+//	Dan Lewis (dihlewis@yahoo.co.uk)
+//	Sebastien Pouliot (sebastien@ximian.com)
+//
+// (C) 2002
+// Implementation translated from Bouncy Castle JCE (http://www.bouncycastle.org/)
+// See bouncycastle.txt for license.
+// Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Mono.Security.Cryptography {
+
+    [ComVisible(true)]
+    internal class SHA512Managed : SHA512 {
+
+        private byte[] xBuf;
+        private int xBufOff;
+
+        private ulong byteCount1;
+        private ulong byteCount2;
+
+        private ulong H1, H2, H3, H4, H5, H6, H7, H8;
+
+        private ulong[] W;
+        private int wOff;
+
+        public SHA512Managed() {
+            xBuf = new byte[8];
+            W = new ulong[80];
+            Initialize(false); // limited initialization
+        }
+
+        private void Initialize(bool reuse) {
+            // SHA-512 initial hash value
+            // The first 64 bits of the fractional parts of the square roots
+            // of the first eight prime numbers
+            H1 = 0x6a09e667f3bcc908L;
+            H2 = 0xbb67ae8584caa73bL;
+            H3 = 0x3c6ef372fe94f82bL;
+            H4 = 0xa54ff53a5f1d36f1L;
+            H5 = 0x510e527fade682d1L;
+            H6 = 0x9b05688c2b3e6c1fL;
+            H7 = 0x1f83d9abfb41bd6bL;
+            H8 = 0x5be0cd19137e2179L;
+
+            if (reuse) {
+                byteCount1 = 0;
+                byteCount2 = 0;
+
+                xBufOff = 0;
+                for (int i = 0; i < xBuf.Length; i++)
+                    xBuf[i] = 0;
+
+                wOff = 0;
+                for (int i = 0; i != W.Length; i++)
+                    W[i] = 0;
+            }
+        }
+
+        public override void Initialize() {
+            Initialize(true); // reuse instance
+        }
+
+        // protected
+
+        protected override void HashCore(byte[] rgb, int ibStart, int cbSize) {
+            // fill the current word
+            while ((xBufOff != 0) && (cbSize > 0)) {
+                update(rgb[ibStart]);
+                ibStart++;
+                cbSize--;
+            }
+
+            // process whole words.
+            while (cbSize > xBuf.Length) {
+                processWord(rgb, ibStart);
+                ibStart += xBuf.Length;
+                cbSize -= xBuf.Length;
+                byteCount1 += (ulong)xBuf.Length;
+            }
+
+            // load in the remainder.
+            while (cbSize > 0) {
+                update(rgb[ibStart]);
+                ibStart++;
+                cbSize--;
+            }
+        }
+
+        protected override byte[] HashFinal() {
+            adjustByteCounts();
+
+            ulong lowBitLength = byteCount1 << 3;
+            ulong hiBitLength = byteCount2;
+
+            // add the pad bytes.
+            update(128);
+            while (xBufOff != 0)
+                update(0);
+
+            processLength(lowBitLength, hiBitLength);
+            processBlock();
+
+            byte[] output = new byte[64];
+            unpackWord(H1, output, 0);
+            unpackWord(H2, output, 8);
+            unpackWord(H3, output, 16);
+            unpackWord(H4, output, 24);
+            unpackWord(H5, output, 32);
+            unpackWord(H6, output, 40);
+            unpackWord(H7, output, 48);
+            unpackWord(H8, output, 56);
+
+            Initialize();
+            return output;
+        }
+
+        private void update(byte input) {
+            xBuf[xBufOff++] = input;
+            if (xBufOff == xBuf.Length) {
+                processWord(xBuf, 0);
+                xBufOff = 0;
+            }
+            byteCount1++;
+        }
+
+        private void processWord(byte[] input, int inOff) {
+            W[wOff++] = ((ulong)input[inOff] << 56)
+                | ((ulong)input[inOff + 1] << 48)
+                | ((ulong)input[inOff + 2] << 40)
+                | ((ulong)input[inOff + 3] << 32)
+                | ((ulong)input[inOff + 4] << 24)
+                | ((ulong)input[inOff + 5] << 16)
+                | ((ulong)input[inOff + 6] << 8)
+                | ((ulong)input[inOff + 7]);
+            if (wOff == 16)
+                processBlock();
+        }
+
+        private void unpackWord(ulong word, byte[] output, int outOff) {
+            output[outOff] = (byte)(word >> 56);
+            output[outOff + 1] = (byte)(word >> 48);
+            output[outOff + 2] = (byte)(word >> 40);
+            output[outOff + 3] = (byte)(word >> 32);
+            output[outOff + 4] = (byte)(word >> 24);
+            output[outOff + 5] = (byte)(word >> 16);
+            output[outOff + 6] = (byte)(word >> 8);
+            output[outOff + 7] = (byte)word;
+        }
+
+        // adjust the byte counts so that byteCount2 represents the
+        // upper long (less 3 bits) word of the byte count.
+        private void adjustByteCounts() {
+            if (byteCount1 > 0x1fffffffffffffffL) {
+                byteCount2 += (byteCount1 >> 61);
+                byteCount1 &= 0x1fffffffffffffffL;
+            }
+        }
+
+        private void processLength(ulong lowW, ulong hiW) {
+            if (wOff > 14)
+                processBlock();
+            W[14] = hiW;
+            W[15] = lowW;
+        }
+
+        private void processBlock() {
+            adjustByteCounts();
+            // expand 16 word block into 80 word blocks.
+            for (int t = 16; t <= 79; t++)
+                W[t] = Sigma1(W[t - 2]) + W[t - 7] + Sigma0(W[t - 15]) + W[t - 16];
+
+            // set up working variables.
+            ulong a = H1;
+            ulong b = H2;
+            ulong c = H3;
+            ulong d = H4;
+            ulong e = H5;
+            ulong f = H6;
+            ulong g = H7;
+            ulong h = H8;
+
+            for (int t = 0; t <= 79; t++) {
+                ulong T1 = h + Sum1(e) + Ch(e, f, g) + SHAConstants.K2[t] + W[t];
+                ulong T2 = Sum0(a) + Maj(a, b, c);
+                h = g;
+                g = f;
+                f = e;
+                e = d + T1;
+                d = c;
+                c = b;
+                b = a;
+                a = T1 + T2;
+            }
+
+            H1 += a;
+            H2 += b;
+            H3 += c;
+            H4 += d;
+            H5 += e;
+            H6 += f;
+            H7 += g;
+            H8 += h;
+            // reset the offset and clean out the word buffer.
+            wOff = 0;
+            for (int i = 0; i != W.Length; i++)
+                W[i] = 0;
+        }
+
+        private ulong rotateRight(ulong x, int n) {
+            return (x >> n) | (x << (64 - n));
+        }
+
+        /* SHA-512 and SHA-512 functions (as for SHA-256 but for longs) */
+        private ulong Ch(ulong x, ulong y, ulong z) {
+            return ((x & y) ^ ((~x) & z));
+        }
+
+        private ulong Maj(ulong x, ulong y, ulong z) {
+            return ((x & y) ^ (x & z) ^ (y & z));
+        }
+
+        private ulong Sum0(ulong x) {
+            return rotateRight(x, 28) ^ rotateRight(x, 34) ^ rotateRight(x, 39);
+        }
+
+        private ulong Sum1(ulong x) {
+            return rotateRight(x, 14) ^ rotateRight(x, 18) ^ rotateRight(x, 41);
+        }
+
+        private ulong Sigma0(ulong x) {
+            return rotateRight(x, 1) ^ rotateRight(x, 8) ^ (x >> 7);
+        }
+
+        private ulong Sigma1(ulong x) {
+            return rotateRight(x, 19) ^ rotateRight(x, 61) ^ (x >> 6);
+        }
+    }
+}

--- a/Src/IronPython.Modules/hashlib/SHAConstants.cs
+++ b/Src/IronPython.Modules/hashlib/SHAConstants.cs
@@ -1,0 +1,77 @@
+//
+// System.Security.Cryptography.SHAConstants.cs
+//
+// Copyright (C) 2004-2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace Mono.Security.Cryptography {
+
+    internal static class SHAConstants {
+        // SHA-256 Constants
+        // Represent the first 32 bits of the fractional parts of the
+        // cube roots of the first sixty-four prime numbers
+        public static readonly uint[] K1 = {
+            0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+            0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+            0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+            0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+            0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+            0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+            0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+            0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+            0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+            0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+            0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+            0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+            0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+            0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+            0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+            0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
+        };
+
+        // SHA-384 and SHA-512 Constants
+        // Represent the first 64 bits of the fractional parts of the
+        // cube roots of the first sixty-four prime numbers
+        public static readonly ulong[] K2 = {
+            0x428a2f98d728ae22L, 0x7137449123ef65cdL, 0xb5c0fbcfec4d3b2fL, 0xe9b5dba58189dbbcL,
+            0x3956c25bf348b538L, 0x59f111f1b605d019L, 0x923f82a4af194f9bL, 0xab1c5ed5da6d8118L,
+            0xd807aa98a3030242L, 0x12835b0145706fbeL, 0x243185be4ee4b28cL, 0x550c7dc3d5ffb4e2L,
+            0x72be5d74f27b896fL, 0x80deb1fe3b1696b1L, 0x9bdc06a725c71235L, 0xc19bf174cf692694L,
+            0xe49b69c19ef14ad2L, 0xefbe4786384f25e3L, 0x0fc19dc68b8cd5b5L, 0x240ca1cc77ac9c65L,
+            0x2de92c6f592b0275L, 0x4a7484aa6ea6e483L, 0x5cb0a9dcbd41fbd4L, 0x76f988da831153b5L,
+            0x983e5152ee66dfabL, 0xa831c66d2db43210L, 0xb00327c898fb213fL, 0xbf597fc7beef0ee4L,
+            0xc6e00bf33da88fc2L, 0xd5a79147930aa725L, 0x06ca6351e003826fL, 0x142929670a0e6e70L,
+            0x27b70a8546d22ffcL, 0x2e1b21385c26c926L, 0x4d2c6dfc5ac42aedL, 0x53380d139d95b3dfL,
+            0x650a73548baf63deL, 0x766a0abb3c77b2a8L, 0x81c2c92e47edaee6L, 0x92722c851482353bL,
+            0xa2bfe8a14cf10364L, 0xa81a664bbc423001L, 0xc24b8b70d0f89791L, 0xc76c51a30654be30L,
+            0xd192e819d6ef5218L, 0xd69906245565a910L, 0xf40e35855771202aL, 0x106aa07032bbd1b8L,
+            0x19a4c116b8d2d0c8L, 0x1e376c085141ab53L, 0x2748774cdf8eeb99L, 0x34b0bcb5e19b48a8L,
+            0x391c0cb3c5c95a63L, 0x4ed8aa4ae3418acbL, 0x5b9cca4f7763e373L, 0x682e6ff3d6b2b8a3L,
+            0x748f82ee5defb2fcL, 0x78a5636f43172f60L, 0x84c87814a1f0ab72L, 0x8cc702081a6439ecL,
+            0x90befffa23631e28L, 0xa4506cebde82bde9L, 0xbef9a3f7b2c67915L, 0xc67178f2e372532bL,
+            0xca273eceea26619cL, 0xd186b8c721c0c207L, 0xeada7dd6cde0eb1eL, 0xf57d4f7fee6ed178L,
+            0x06f067aa72176fbaL, 0x0a637dc5a2c898a6L, 0x113f9804bef90daeL, 0x1b710b35131c471bL,
+            0x28db77f523047d84L, 0x32caab7b40c72493L, 0x3c9ebe0a15c9bebcL, 0x431d67c49c100d4cL,
+            0x4cc5d4becb3e42b6L, 0x597f299cfc657e2aL, 0x5fcb6fab3ad6faecL, 0x6c44198c4a475817L
+        };
+    }
+}

--- a/Src/IronPython.Modules/hashlib/_hashlib.cs
+++ b/Src/IronPython.Modules/hashlib/_hashlib.cs
@@ -76,6 +76,10 @@ namespace IronPython.Modules {
         }
 
         protected T CloneHasher() {
+            if (_hasher is ICloneable cloneable) {
+                return (T)cloneable.Clone();
+            }
+
             T clone = default(T);
             if (_memberwiseClone == null) {
                 _memberwiseClone = _hasher.GetType().GetMethod("MemberwiseClone", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
@@ -92,8 +96,7 @@ namespace IronPython.Modules {
                 foreach (FieldInfo field in fields) {
                     if (field.FieldType.IsArray) {
                         lock (_hasher) {
-                            Array orig = field.GetValue(_hasher) as Array;
-                            if (orig != null) {
+                            if (field.GetValue(_hasher) is Array orig) {
                                 field.SetValue(clone, orig.Clone());
                             }
                         }

--- a/Src/IronPython.Modules/hashlib/_hashlib.cs
+++ b/Src/IronPython.Modules/hashlib/_hashlib.cs
@@ -9,10 +9,10 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 
-using Microsoft.Scripting.Runtime;
-
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
+
+using Microsoft.Scripting.Runtime;
 
 //[assembly: PythonModule("_hashlib", typeof(IronPython.Modules.PythonHashlib))]
 namespace IronPython.Modules {
@@ -39,11 +39,15 @@ namespace IronPython.Modules {
         protected abstract void CreateHasher();
 
         [Documentation("update(string) -> None (update digest with string data)")]
-        public void update([BytesLike]IList<byte> newBytes) {
-            byte[] bytes = newBytes.ToArray();
+        public void update([NotNull]IBufferProtocol data) {
+            using var buffer = data.GetBuffer();
+            byte[] bytes = buffer.ToArray();
             lock (_hasher) {
                 _hasher.TransformBlock(bytes, 0, bytes.Length, bytes, 0);
             }
+        }
+        public void update([NotNull]string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         [Documentation("digest() -> int (current digest value)")]

--- a/Src/IronPython.Modules/hashlib/_md5.cs
+++ b/Src/IronPython.Modules/hashlib/_md5.cs
@@ -19,11 +19,6 @@ namespace IronPython.Modules {
         private const int DIGEST_SIZE = 16;
         private const int BLOCK_SIZE = 64;
 
-        [Documentation("Size of the resulting digest in bytes (constant)")]
-        public static int digest_size {
-            get { return DIGEST_SIZE; }
-        }
-
         [Documentation("md5([data]) -> object (new md5 object)")]
         public static MD5Object md5([NotNull] IBufferProtocol data) {
             return new MD5Object(data);

--- a/Src/IronPython.Modules/hashlib/_md5.cs
+++ b/Src/IronPython.Modules/hashlib/_md5.cs
@@ -20,25 +20,25 @@ namespace IronPython.Modules {
         private const int BLOCK_SIZE = 64;
 
         [Documentation("md5([data]) -> object (new md5 object)")]
-        public static MD5Object md5([NotNull] IBufferProtocol data) {
-            return new MD5Object(data);
+        public static MD5Type md5([NotNull] IBufferProtocol data) {
+            return new MD5Type(data);
         }
 
-        public static MD5Object md5([NotNull] string data) {
+        public static MD5Type md5([NotNull] string data) {
             throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         [Documentation("md5([data]) -> object (new md5 object)")]
-        public static MD5Object md5() {
-            return new MD5Object();
+        public static MD5Type md5() {
+            return new MD5Type();
         }
 
         [Documentation("md5([data]) -> object (object used to calculate MD5 hash)")]
-        [PythonHidden]
-        public class MD5Object : HashBase<MD5> {
-            public MD5Object() : base("md5", BLOCK_SIZE, DIGEST_SIZE) { }
+        [PythonType("md5")]
+        public sealed class MD5Type : HashBase<MD5> {
+            internal MD5Type() : base("md5", BLOCK_SIZE, DIGEST_SIZE) { }
 
-            internal MD5Object(IBufferProtocol initialBytes) : this() {
+            internal MD5Type(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
@@ -48,7 +48,7 @@ namespace IronPython.Modules {
 
             [Documentation("copy() -> object (copy of this md5 object)")]
             public override HashBase<MD5> copy() {
-                MD5Object res = new MD5Object();
+                MD5Type res = new MD5Type();
                 res._hasher = CloneHasher();
                 return res;
             }

--- a/Src/IronPython.Modules/hashlib/_md5.cs
+++ b/Src/IronPython.Modules/hashlib/_md5.cs
@@ -4,13 +4,12 @@
 
 #if FEATURE_FULL_CRYPTO // MD5
 
-using System.Collections.Generic;
 using System.Security.Cryptography;
-
-using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
+
+using Microsoft.Scripting.Runtime;
 
 [assembly: PythonModule("_md5", typeof(IronPython.Modules.PythonMD5))]
 namespace IronPython.Modules {
@@ -25,17 +24,13 @@ namespace IronPython.Modules {
             get { return DIGEST_SIZE; }
         }
 
-        public static MD5Object md5(string data) {
-            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
-        }
-
-        public static MD5Object md5(ArrayModule.array data) {
-            return new MD5Object(data.ToByteArray());
-        }
-
         [Documentation("md5([data]) -> object (new md5 object)")]
-        public static MD5Object md5([BytesLike]IList<byte> data) {
+        public static MD5Object md5([NotNull] IBufferProtocol data) {
             return new MD5Object(data);
+        }
+
+        public static MD5Object md5([NotNull] string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         [Documentation("md5([data]) -> object (new md5 object)")]
@@ -48,7 +43,7 @@ namespace IronPython.Modules {
         public class MD5Object : HashBase<MD5> {
             public MD5Object() : base("md5", BLOCK_SIZE, DIGEST_SIZE) { }
 
-            internal MD5Object(IList<byte> initialBytes) : this() {
+            internal MD5Object(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 

--- a/Src/IronPython.Modules/hashlib/_sha1.cs
+++ b/Src/IronPython.Modules/hashlib/_sha1.cs
@@ -18,25 +18,25 @@ namespace IronPython.Modules {
         private const int BLOCK_SIZE = 64;
 
         [Documentation("sha1([data]) -> object (object used to calculate hash)")]
-        public static sha sha1([NotNull] IBufferProtocol data) {
-            return new sha(data);
+        public static SHA1Type sha1([NotNull] IBufferProtocol data) {
+            return new SHA1Type(data);
         }
 
-        public static sha sha1([NotNull] string data) {
+        public static SHA1Type sha1([NotNull] string data) {
             throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         [Documentation("sha1([data]) -> object (object used to calculate hash)")]
-        public static sha sha1() {
-            return new sha();
+        public static SHA1Type sha1() {
+            return new SHA1Type();
         }
 
         [Documentation("sha1([data]) -> object (object used to calculate hash)")]
-        [PythonType, PythonHidden]
-        public class sha : HashBase<SHA1> {
-            public sha() : base("sha1", BLOCK_SIZE, DIGEST_SIZE) { }
+        [PythonType("sha1")]
+        public sealed class SHA1Type : HashBase<SHA1> {
+            internal SHA1Type() : base("sha1", BLOCK_SIZE, DIGEST_SIZE) { }
 
-            internal sha(IBufferProtocol initialBytes) : this() {
+            internal SHA1Type(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
@@ -46,7 +46,7 @@ namespace IronPython.Modules {
 
             [Documentation("copy() -> object (copy of this object)")]
             public override HashBase<SHA1> copy() {
-                sha clone = new sha();
+                SHA1Type clone = new SHA1Type();
                 clone._hasher = CloneHasher();
                 return clone;
             }

--- a/Src/IronPython.Modules/hashlib/_sha1.cs
+++ b/Src/IronPython.Modules/hashlib/_sha1.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Security.Cryptography;
-using System.Text;
-
-using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
+
+using Microsoft.Scripting.Runtime;
 
 [assembly: PythonModule("_sha1", typeof(IronPython.Modules.PythonSha))]
 namespace IronPython.Modules {
@@ -34,18 +32,13 @@ namespace IronPython.Modules {
             get { return BLOCK_SIZE; }
         }
 
-        public static sha sha1(string data) {
-            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
-        }
-
         [Documentation("sha1([data]) -> object (object used to calculate hash)")]
-        public static sha sha1(ArrayModule.array data) {
-            return new sha(data.ToByteArray());
-        }
-
-        [Documentation("sha1([data]) -> object (object used to calculate hash)")]
-        public static sha sha1([BytesLike]IList<byte> data) {
+        public static sha sha1([NotNull] IBufferProtocol data) {
             return new sha(data);
+        }
+
+        public static sha sha1([NotNull] string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         [Documentation("sha1([data]) -> object (object used to calculate hash)")]
@@ -58,7 +51,7 @@ namespace IronPython.Modules {
         public class sha : HashBase<SHA1> {
             public sha() : base("sha1", BLOCK_SIZE, DIGEST_SIZE) { }
 
-            internal sha(IList<byte> initialBytes) : this() {
+            internal sha(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 

--- a/Src/IronPython.Modules/hashlib/_sha1.cs
+++ b/Src/IronPython.Modules/hashlib/_sha1.cs
@@ -41,7 +41,7 @@ namespace IronPython.Modules {
             }
 
             protected override void CreateHasher() {
-                _hasher = new SHA1Managed();
+                _hasher = new Mono.Security.Cryptography.SHA1CryptoServiceProvider();
             }
 
             [Documentation("copy() -> object (copy of this object)")]

--- a/Src/IronPython.Modules/hashlib/_sha1.cs
+++ b/Src/IronPython.Modules/hashlib/_sha1.cs
@@ -17,21 +17,6 @@ namespace IronPython.Modules {
         private const int DIGEST_SIZE = 20;
         private const int BLOCK_SIZE = 64;
 
-        public static int digest_size {
-            [Documentation("Size of the resulting digest in bytes (constant)")]
-            get { return DIGEST_SIZE; }
-        }
-
-        public static int digestsize {
-            [Documentation("Size of the resulting digest in bytes (constant)")]
-            get { return digest_size; }
-        }
-
-        public static int blocksize {
-            [Documentation("Block size")]
-            get { return BLOCK_SIZE; }
-        }
-
         [Documentation("sha1([data]) -> object (object used to calculate hash)")]
         public static sha sha1([NotNull] IBufferProtocol data) {
             return new sha(data);

--- a/Src/IronPython.Modules/hashlib/_sha256.cs
+++ b/Src/IronPython.Modules/hashlib/_sha256.cs
@@ -47,7 +47,7 @@ namespace IronPython.Modules {
             }
 
             protected override void CreateHasher() {
-                _hasher = SHA256.Create();
+                _hasher = new Mono.Security.Cryptography.SHA256Managed();
             }
         }
 
@@ -73,7 +73,7 @@ namespace IronPython.Modules {
             }
 
             protected override void CreateHasher() {
-                _hasher = SHA224.Create();
+                _hasher = new SHA224Managed();
             }
 
             [Documentation("copy() -> object (copy of this object)")]

--- a/Src/IronPython.Modules/hashlib/_sha256.cs
+++ b/Src/IronPython.Modules/hashlib/_sha256.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Security.Cryptography;
+
+using IronPython.Runtime;
+using IronPython.Runtime.Operations;
 
 using Microsoft.Scripting.Runtime;
 
 using Mono.Security.Cryptography;
-
-using IronPython.Runtime;
-using IronPython.Runtime.Operations;
 
 [assembly: PythonModule("_sha256", typeof(IronPython.Modules.PythonSha256))]
 namespace IronPython.Modules {
@@ -20,16 +19,12 @@ namespace IronPython.Modules {
 
         public const string __doc__ = "SHA256 hash algorithm";
 
-        public static Sha256Object sha256(string data) {
-            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
-        }
-
-        public static Sha256Object sha256(ArrayModule.array data) {
-            return new Sha256Object(data.ToByteArray());
-        }
-
-        public static Sha256Object sha256([BytesLike]IList<byte> data) {
+        public static Sha256Object sha256([NotNull] IBufferProtocol data) {
             return new Sha256Object(data);
+        }
+
+        public static Sha256Object sha256([NotNull] string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         public static Sha256Object sha256() {
@@ -40,7 +35,7 @@ namespace IronPython.Modules {
         public sealed class Sha256Object : HashBase<SHA256> {
             internal Sha256Object() : base("sha256", BLOCK_SIZE, 32) { }
 
-            internal Sha256Object(IList<byte> initialBytes) : this() {
+            internal Sha256Object(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
@@ -56,16 +51,12 @@ namespace IronPython.Modules {
             }
         }
 
-        public static Sha256Object sha224(string data) {
-            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
-        }
-
-        public static Sha224Object sha224(ArrayModule.array data) {
-            return new Sha224Object(data.ToByteArray());
-        }
-
-        public static Sha224Object sha224([BytesLike]IList<byte> data) {
+        public static Sha224Object sha224([NotNull] IBufferProtocol data) {
             return new Sha224Object(data);
+        }
+
+        public static Sha256Object sha224([NotNull] string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         public static Sha224Object sha224() {
@@ -77,7 +68,7 @@ namespace IronPython.Modules {
             internal Sha224Object() : base("sha224", BLOCK_SIZE, 28) {
             }
 
-            internal Sha224Object(IList<byte> initialBytes) : this() {
+            internal Sha224Object(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 

--- a/Src/IronPython.Modules/hashlib/_sha256.cs
+++ b/Src/IronPython.Modules/hashlib/_sha256.cs
@@ -19,29 +19,29 @@ namespace IronPython.Modules {
 
         public const string __doc__ = "SHA256 hash algorithm";
 
-        public static Sha256Object sha256([NotNull] IBufferProtocol data) {
-            return new Sha256Object(data);
+        public static SHA256Type sha256([NotNull] IBufferProtocol data) {
+            return new SHA256Type(data);
         }
 
-        public static Sha256Object sha256([NotNull] string data) {
+        public static SHA256Type sha256([NotNull] string data) {
             throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
-        public static Sha256Object sha256() {
-            return new Sha256Object();
+        public static SHA256Type sha256() {
+            return new SHA256Type();
         }
 
-        [PythonHidden]
-        public sealed class Sha256Object : HashBase<SHA256> {
-            internal Sha256Object() : base("sha256", BLOCK_SIZE, 32) { }
+        [PythonType("sha256")]
+        public sealed class SHA256Type : HashBase<SHA256> {
+            internal SHA256Type() : base("sha256", BLOCK_SIZE, 32) { }
 
-            internal Sha256Object(IBufferProtocol initialBytes) : this() {
+            internal SHA256Type(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
             [Documentation("copy() -> object (copy of this object)")]
             public override HashBase<SHA256> copy() {
-                Sha256Object res = new Sha256Object();
+                SHA256Type res = new SHA256Type();
                 res._hasher = CloneHasher();
                 return res;
             }
@@ -51,24 +51,24 @@ namespace IronPython.Modules {
             }
         }
 
-        public static Sha224Object sha224([NotNull] IBufferProtocol data) {
-            return new Sha224Object(data);
+        public static SHA224Type sha224([NotNull] IBufferProtocol data) {
+            return new SHA224Type(data);
         }
 
-        public static Sha256Object sha224([NotNull] string data) {
+        public static SHA256Type sha224([NotNull] string data) {
             throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
-        public static Sha224Object sha224() {
-            return new Sha224Object();
+        public static SHA224Type sha224() {
+            return new SHA224Type();
         }
 
-        [PythonHidden]
-        public sealed class Sha224Object : HashBase<SHA224> {
-            internal Sha224Object() : base("sha224", BLOCK_SIZE, 28) {
+        [PythonType("sha224")]
+        public sealed class SHA224Type : HashBase<SHA224> {
+            internal SHA224Type() : base("sha224", BLOCK_SIZE, 28) {
             }
 
-            internal Sha224Object(IBufferProtocol initialBytes) : this() {
+            internal SHA224Type(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
@@ -78,7 +78,7 @@ namespace IronPython.Modules {
 
             [Documentation("copy() -> object (copy of this object)")]
             public override HashBase<SHA224> copy() {
-                Sha224Object res = new Sha224Object();
+                SHA224Type res = new SHA224Type();
                 res._hasher = CloneHasher();
                 return res;
             }

--- a/Src/IronPython.Modules/hashlib/_sha512.cs
+++ b/Src/IronPython.Modules/hashlib/_sha512.cs
@@ -52,7 +52,7 @@ namespace IronPython.Modules {
             }
 
             protected override void CreateHasher() {
-                _hasher = SHA384.Create();
+                _hasher = new Mono.Security.Cryptography.SHA384Managed();
             }
 
             [Documentation("copy() -> object (copy of this md5 object)")]
@@ -72,7 +72,7 @@ namespace IronPython.Modules {
             }
 
             protected override void CreateHasher() {
-                _hasher = SHA512.Create();
+                _hasher = new Mono.Security.Cryptography.SHA512Managed();
             }
 
             [Documentation("copy() -> object (copy of this md5 object)")]

--- a/Src/IronPython.Modules/hashlib/_sha512.cs
+++ b/Src/IronPython.Modules/hashlib/_sha512.cs
@@ -19,35 +19,23 @@ namespace IronPython.Modules {
 
         public const string __doc__ = "SHA512 hash algorithm";
 
-        public static Sha512Object sha512([NotNull] IBufferProtocol data) {
-            return new Sha512Object(data);
+        public static SHA384Type sha384([NotNull] IBufferProtocol data) {
+            return new SHA384Type(data);
         }
 
-        public static Sha512Object sha512([NotNull] string data) {
+        public static SHA384Type sha384([NotNull] string data) {
             throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
-        public static Sha512Object sha512() {
-            return new Sha512Object();
+        public static SHA384Type sha384() {
+            return new SHA384Type();
         }
 
-        public static Sha384Object sha384([NotNull] IBufferProtocol data) {
-            return new Sha384Object(data);
-        }
+        [PythonType("sha384")]
+        public sealed class SHA384Type : HashBase<SHA384> {
+            internal SHA384Type() : base("sha384", BLOCK_SIZE, 48) { }
 
-        public static Sha384Object sha384([NotNull] string data) {
-            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
-        }
-
-        public static Sha384Object sha384() {
-            return new Sha384Object();
-        }
-
-        [PythonHidden]
-        public sealed class Sha384Object : HashBase<SHA384> {
-            internal Sha384Object() : base("sha384", BLOCK_SIZE, 48) { }
-
-            internal Sha384Object(IBufferProtocol initialBytes) : this() {
+            internal SHA384Type(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
@@ -57,17 +45,29 @@ namespace IronPython.Modules {
 
             [Documentation("copy() -> object (copy of this md5 object)")]
             public override HashBase<SHA384> copy() {
-                Sha384Object res = new Sha384Object();
+                SHA384Type res = new SHA384Type();
                 res._hasher = CloneHasher();
                 return res;
             }
         }
 
-        [PythonHidden]
-        public sealed class Sha512Object : HashBase<SHA512> {
-            internal Sha512Object() : base("sha512", BLOCK_SIZE, 64) { }
+        public static SHA512Type sha512([NotNull] IBufferProtocol data) {
+            return new SHA512Type(data);
+        }
 
-            internal Sha512Object(IBufferProtocol initialBytes) : this() {
+        public static SHA512Type sha512([NotNull] string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
+        }
+
+        public static SHA512Type sha512() {
+            return new SHA512Type();
+        }
+
+        [PythonType("sha512")]
+        public sealed class SHA512Type : HashBase<SHA512> {
+            internal SHA512Type() : base("sha512", BLOCK_SIZE, 64) { }
+
+            internal SHA512Type(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
@@ -77,7 +77,7 @@ namespace IronPython.Modules {
 
             [Documentation("copy() -> object (copy of this md5 object)")]
             public override HashBase<SHA512> copy() {
-                Sha512Object res = new Sha512Object();
+                SHA512Type res = new SHA512Type();
                 res._hasher = CloneHasher();
                 return res;
             }

--- a/Src/IronPython.Modules/hashlib/_sha512.cs
+++ b/Src/IronPython.Modules/hashlib/_sha512.cs
@@ -4,13 +4,12 @@
 
 #if FEATURE_FULL_CRYPTO // SHA384, SHA512
 
-using System.Collections.Generic;
 using System.Security.Cryptography;
-
-using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
+
+using Microsoft.Scripting.Runtime;
 
 [assembly: PythonModule("_sha512", typeof(IronPython.Modules.PythonSha512))]
 namespace IronPython.Modules {
@@ -20,32 +19,24 @@ namespace IronPython.Modules {
 
         public const string __doc__ = "SHA512 hash algorithm";
 
-        public static Sha512Object sha512(string data) {
-            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
-        }
-
-        public static Sha512Object sha512(ArrayModule.array data) {
-            return new Sha512Object(data.ToByteArray());
-        }
-
-        public static Sha512Object sha512([BytesLike]IList<byte> data) {
+        public static Sha512Object sha512([NotNull] IBufferProtocol data) {
             return new Sha512Object(data);
+        }
+
+        public static Sha512Object sha512([NotNull] string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         public static Sha512Object sha512() {
             return new Sha512Object();
         }
 
-        public static Sha384Object sha384(string data) {
-            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
-        }
-
-        public static Sha384Object sha384(ArrayModule.array data) {
-            return new Sha384Object(data.ToByteArray());
-        }
-
-        public static Sha384Object sha384([BytesLike]IList<byte> data) {
+        public static Sha384Object sha384([NotNull] IBufferProtocol data) {
             return new Sha384Object(data);
+        }
+
+        public static Sha384Object sha384([NotNull] string data) {
+            throw PythonOps.TypeError("Unicode-objects must be encoded before hashing");
         }
 
         public static Sha384Object sha384() {
@@ -56,7 +47,7 @@ namespace IronPython.Modules {
         public sealed class Sha384Object : HashBase<SHA384> {
             internal Sha384Object() : base("sha384", BLOCK_SIZE, 48) { }
 
-            internal Sha384Object(IList<byte> initialBytes) : this() {
+            internal Sha384Object(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 
@@ -76,7 +67,7 @@ namespace IronPython.Modules {
         public sealed class Sha512Object : HashBase<SHA512> {
             internal Sha512Object() : base("sha512", BLOCK_SIZE, 64) { }
 
-            internal Sha512Object(IList<byte> initialBytes) : this() {
+            internal Sha512Object(IBufferProtocol initialBytes) : this() {
                 update(initialBytes);
             }
 

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -506,9 +506,6 @@ Reason=Only valid for Unix
 [CPython.test_gzip]
 Ignore=true
 
-[CPython.test_hashlib]
-Ignore=true
-
 [CPython.test_heapq]
 Ignore=true
 Reason=TypeError: __next__() takes exactly 1 argument (1 given)
@@ -720,10 +717,6 @@ Reason=Blocking
 
 [CPython.test_peepholer]
 Ignore=true
-
-[CPython.test_pep247]
-RunCondition=NOT $(IS_NETCOREAPP)
-Reason=test_sha is failing - https://github.com/IronLanguages/ironpython3/issues/813
 
 [CPython.test_pep277]
 Ignore=true

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -506,6 +506,9 @@ Reason=Only valid for Unix
 [CPython.test_gzip]
 Ignore=true
 
+[CPython.test_hashlib]
+Timeout=300000 # 5 minute timeout - slow on Mono
+
 [CPython.test_heapq]
 Ignore=true
 Reason=TypeError: __next__() takes exactly 1 argument (1 given)
@@ -892,7 +895,6 @@ Ignore=true
 
 [CPython.test_smtplib]
 RunCondition=NOT $(IS_POSIX) # TODO: debug
-Timeout=600000 # 10 minute timeout
 
 [CPython.test_socket]
 Ignore=true


### PR DESCRIPTION
.NET Core does not use managed implementations for its hashing algorithms. Because of this the `copy` methods were failing. This brings in managed implementations for the algorithms from Mono (https://github.com/mono/mono/tree/mono-4.0.5.1/mcs/class/corlib/System.Security.Cryptography)