### PR TITLE
Support custom decoding error handler

### DIFF
--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1797,14 +1797,10 @@ namespace IronPython.Runtime.Operations {
                 case "xmlcharrefreplace":
                 case "strict": e = setFallback(e, new ExceptionFallback(e is UTF8Encoding)); break;
                 case "replace": e = setFallback(e, ReplacementFallback); break;
-                case "ignore": e = setFallback(e, new PythonDecoderFallback(encoding, buffer, start)); break;
+                case "ignore": e = setFallback(e, new DecoderReplacementFallback(string.Empty)); break;
                 case "surrogateescape": e =  new PythonSurrogateEscapeEncoding(e, encoding); break;
                 case "surrogatepass": e =  new PythonSurrogatePassEncoding(e, encoding); break;
-                default:
-                    e = setFallback(e, new PythonDecoderFallback(encoding,
-                        buffer, start,
-                        () => LightExceptions.CheckAndThrow(PythonOps.LookupEncodingError(context, errors))));
-                    break;
+                default: e = new PythonErrorHandlerEncoding(context, e, encoding, errors); break;
             }
 
             string decoded = string.Empty;
@@ -1823,8 +1819,8 @@ namespace IronPython.Runtime.Operations {
                 }
             } catch (DecoderFallbackException ex) {
                 // augmenting the caught exception instead of creating UnicodeDecodeError to preserve the stack trace
-                ex.Data["encoding"] = encoding;
-                ex.Data["object"] = Bytes.Make(span.Slice(start, length).ToArray());
+                if (!ex.Data.Contains("encoding")) ex.Data["encoding"] = encoding;
+                if (!ex.Data.Contains("object")) ex.Data["object"] = Bytes.Make(span.Slice(start, length).ToArray()); ;
                 throw;
             }
 
@@ -2219,6 +2215,8 @@ namespace IronPython.Runtime.Operations {
                     ReprEncode(s, index, count, isUniEscape: true);
             }
 
+            public override string EncodingName => _raw ? "rawunicodeescape" : "unicodeescape";
+
             public override int GetByteCount(string s)
                 => EscapeEncode(s, 0, s.Length).Length;
 
@@ -2302,127 +2300,6 @@ namespace IronPython.Runtime.Operations {
         #endregion
 
         #region  Unicode Encode/Decode Fallback Support
-
-        /// When encoding or decoding strings if an error occurs CPython supports several different
-        /// behaviors, in addition it supports user-extensible behaviors as well.  For the default
-        /// behavior we're ok - both of us support throwing and replacing.  For custom behaviors
-        /// we define a single fallback for decoding and encoding that calls the python function to do
-        /// the replacement.
-        ///
-        /// When we do the replacement we call the provided handler w/ a UnicodeEncodeError or UnicodeDecodeError
-        /// object which contains:
-        ///         encoding    (string, the encoding the user requested)
-        ///         object      (the original string or bytes being encoded/decoded)
-        ///         start       (the start of the invalid sequence)
-        ///         end         (the exclusive end of the invalid sequence)
-        ///         reason      (the error message, e.g. 'unexpected byte code', not sure of others)
-        ///
-        /// The decoder returns a tuple of (str, int) where str is the replacement string
-        /// and int is an index where encoding/decoding should continue.
-        /// TODO: returned int is currently ignored, assumed to be equal to end (i.e. the index is not adjusted).
-
-        private class PythonDecoderFallbackBuffer : DecoderFallbackBuffer {
-            private readonly object? _function;
-            private readonly string _encoding;
-            private readonly IPythonBuffer _data;
-            private readonly int _offset;
-            private Bytes? _byteData;
-            private string? _buffer;
-            private int _bufferIndex;
-
-            public PythonDecoderFallbackBuffer(string encoding, IPythonBuffer data, int offset, object? callable) {
-                _encoding = encoding;
-                _data = data;
-                _offset = offset;
-                _function = callable;
-            }
-
-            public override int Remaining {
-                get {
-                    if (_buffer == null) return 0;
-                    return _buffer.Length - _bufferIndex;
-                }
-            }
-
-            public override char GetNextChar() {
-                if (_buffer == null || _bufferIndex >= _buffer.Length) return Char.MinValue;
-
-                return _buffer[_bufferIndex++];
-            }
-
-            public override bool MovePrevious() {
-                if (_bufferIndex > 0) {
-                    _bufferIndex--;
-                    return true;
-                }
-                return false;
-            }
-
-            public override void Reset() {
-                _buffer = null;
-                _bufferIndex = 0;
-                base.Reset();
-            }
-
-            public override bool Fallback(byte[] bytesUnknown, int index) {
-                if (_function != null) {
-                    // create the exception object to hand to the user-function...
-                    _byteData ??= Bytes.Make(_data.AsReadOnlySpan().Slice(_offset).ToArray());
-                    var exObj = PythonExceptions.CreatePythonThrowable(PythonExceptions.UnicodeDecodeError, _encoding, _byteData, index, index + bytesUnknown.Length, "unexpected code byte");
-
-                    // call the user function...
-                    object? res = PythonCalls.Call(_function, exObj);
-
-                    string replacement = CheckReplacementTuple(res, "decoding", index + bytesUnknown.Length);
-
-                    // finally process the user's request.
-                    _buffer = replacement;
-                    _bufferIndex = 0;
-                    return true;
-                }
-
-                return false;
-            }
-
-        }
-
-        private class PythonDecoderFallback : DecoderFallback {
-            private readonly string encoding;
-            private readonly IPythonBuffer data;
-            private readonly int offset;
-            private readonly Func<object>? lookup;
-            private object? function;
-
-            public PythonDecoderFallback(string encoding, IPythonBuffer data, int offset, Func<object>? lookup = null) {
-                this.encoding = encoding;
-                this.data = data;
-                this.offset = offset;
-                this.lookup = lookup;
-            }
-
-            public override DecoderFallbackBuffer CreateFallbackBuffer() {
-                if (function == null && lookup != null) {
-                    function = lookup.Invoke();
-                }
-                return new PythonDecoderFallbackBuffer(encoding, data, offset, function);
-            }
-
-            public override int MaxCharCount {
-                get { throw new NotImplementedException(); }
-            }
-        }
-
-        private static string CheckReplacementTuple(object? res, string encodeOrDecode, int cursorPos) {
-            // verify the result is sane...
-            if (res is PythonTuple tres && tres.__len__() == 2
-                    && Converter.TryConvertToString(tres[0], out string? replacement)
-                    && Converter.TryConvertToInt32(tres[1], out int newPos)) {
-                if (newPos != cursorPos) throw new NotImplementedException($"Moving {encodeOrDecode} cursor not implemented yet");
-                return replacement;
-            }
-
-            throw PythonOps.TypeError("{1} error handler must return tuple containing (str, int), got {0}", PythonOps.GetPythonTypeName(res), encodeOrDecode);
-        }
 
         private class BackslashEncoderReplaceFallback : EncoderFallback {
             private class BackslashReplaceFallbackBuffer : EncoderFallbackBuffer {

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -231,7 +231,7 @@ Ignore=true
 [CPython.test_code]
 Ignore=true
 
-[CPython.test_codeccallbacks]
+[CPython.test_codeccallbacks] # IronPython.test_codeccallbacks_stdlib
 Ignore=true
 
 [CPython.test_codecencodings_cn]

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -921,6 +921,7 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(codecs.utf_8_decode(b"a\xFF\xFEz", 'test_dec_sur'), ("a\uDDEE\uDDEEz", 4))
         self.assertEqual(codecs.ascii_decode(b"a\xFF\xFEz", 'test_dec_sur'), ("a\uDDEE\uDDEEz", 4))
         self.assertEqual(codecs.charmap_decode(b"a\xFF\xFEz", 'test_dec_sur', {ord('a'): 'a', ord('z'): 'z'}), ("a\uDDEE\uDDEEz", 4))
+        self.assertEqual(b"a\x81\x82z".decode('iso-2022-jp', 'test_dec_sur'), "a\uDDEE\uDDEEz")
 
         # test encoding error handler that produces replacement bytes
         def test_encoding_error_byteshandler(uee): return (b"*" * (uee.end - uee.start), uee.end)

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -588,7 +588,7 @@ class CodecTest(IronPythonTestCase):
             ('abc€xyzabc₭₮xyzabc₯₰₱', 38),
             ('abc€xyzabc₭₮xyzabc₯₰₱x', 39),
             ('abc€xyzabc₭₮xyzabc₯₰₱xy', 40),
-            ('abc€xyzabc₭₮xyzabc₯₰₱xyz', 41)            
+            ('abc€xyzabc₭₮xyzabc₯₰₱xyz', 41)
         ]
 
         for i in range(len(b) + 1):
@@ -921,7 +921,8 @@ class CodecTest(IronPythonTestCase):
         self.assertEqual(codecs.utf_8_decode(b"a\xFF\xFEz", 'test_dec_sur'), ("a\uDDEE\uDDEEz", 4))
         self.assertEqual(codecs.ascii_decode(b"a\xFF\xFEz", 'test_dec_sur'), ("a\uDDEE\uDDEEz", 4))
         self.assertEqual(codecs.charmap_decode(b"a\xFF\xFEz", 'test_dec_sur', {ord('a'): 'a', ord('z'): 'z'}), ("a\uDDEE\uDDEEz", 4))
-        self.assertEqual(b"a\x81\x82z".decode('iso-2022-jp', 'test_dec_sur'), "a\uDDEE\uDDEEz")
+        if not is_mono: # 'iso-2022-jp' is not working well on Mono
+            self.assertEqual(b"a\x81\x82z".decode('iso-2022-jp', 'test_dec_sur'), "a\uDDEE\uDDEEz")
 
         # test encoding error handler that produces replacement bytes
         def test_encoding_error_byteshandler(uee): return (b"*" * (uee.end - uee.start), uee.end)

--- a/Tests/test_codeccallbacks_stdlib.py
+++ b/Tests/test_codeccallbacks_stdlib.py
@@ -1,0 +1,55 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+##
+## Run selected tests from test_codeccallbacks from StdLib
+##
+
+import unittest
+import sys
+
+from iptest import run_test
+
+import test.test_codeccallbacks
+
+def load_tests(loader, standard_tests, pattern):
+    if sys.implementation.name == 'ironpython':
+        suite = unittest.TestSuite()
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_backslashescape')) # UTF-16 vs. UTF-32
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badandgoodbackslashreplaceexceptions')) # UTF-16 vs. UTF-32
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badandgoodreplaceexceptions')) # UTF-16 vs. UTF-32
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badandgoodstrictexceptions'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badandgoodsurrogateescapeexceptions'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badandgoodsurrogatepassexceptions'))
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badandgoodxmlcharrefreplaceexceptions')) # UTF-16 vs. UTF-32
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badhandlerresults')) # TypeError not raised by decode
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badlookupcall'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_badregistercall'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_bug828737'))
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_callbacks')) # Moving cursor not implemented
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_charmapencode'))
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_decodehelper')) # Moving cursor not implemented
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_decodeunicodeinternal'))
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_decoding_callbacks')) # Moving cursor not implemented
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_encodehelper')) # Moving cursor not implemented
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_fake_error_class'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_longstrings'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_lookup'))
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_mutatingdecodehandler')) # Moving cursor not implemented
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_translatehelper'))
+        #!suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_unencodablereplacement')) # UnicodeEncodeError not raised by encode
+        #!suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_unicodedecodeerror')) # TypeError not raised by UnicodeDecodeError
+        #!suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_unicodeencodeerror')) # TypeError not raised by UnicodeEncodeError
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_unicodetranslateerror'))  # UTF-16 vs. UTF-32
+        #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_uninamereplace')) # bug?
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_unknownhandler'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_xmlcharnamereplace'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_xmlcharrefreplace'))
+        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_xmlcharrefvalues'))
+        return suite
+
+    else:
+        return loader.loadTestsFromModule(test.test_codeccallbacks, pattern)
+
+run_test(__name__)

--- a/Tests/test_codeccallbacks_stdlib.py
+++ b/Tests/test_codeccallbacks_stdlib.py
@@ -9,7 +9,7 @@
 import unittest
 import sys
 
-from iptest import run_test
+from iptest import run_test, is_mono
 
 import test.test_codeccallbacks
 
@@ -34,7 +34,8 @@ def load_tests(loader, standard_tests, pattern):
         #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_decoding_callbacks')) # Moving cursor not implemented
         #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_encodehelper')) # Moving cursor not implemented
         suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_fake_error_class'))
-        suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_longstrings'))
+        if not is_mono: # https://github.com/mono/mono/issues/20445
+            suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_longstrings'))
         suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_lookup'))
         #suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_mutatingdecodehandler')) # Moving cursor not implemented
         suite.addTest(test.test_codeccallbacks.CodecCallbackTest('test_translatehelper'))

--- a/Tests/test_codecs.py
+++ b/Tests/test_codecs.py
@@ -120,7 +120,7 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual(codecs.latin_1_decode(mem), ("abc", 3))
         self.assertEqual(codecs.latin_1_decode(rom), ("abc", 3))
 
-    def test_interop_ascii_encode_exeption(self):
+    def test_interop_ascii_encode_exception(self):
         def check_error1(encoding, name):
             # exception on a single character
             with self.assertRaises(UnicodeEncodeError) as uee:
@@ -151,7 +151,7 @@ class CodecsTest(unittest.TestCase):
         if not is_cli: # TODO: Replace PythonAsciiEncoding with ASCIIEncoding
             check_error2('ascii', 'ascii')
 
-    def test_interop_utf8_encode_exeption(self):
+    def test_interop_utf8_encode_exception(self):
         def check_error(encoding, name):
             # exception on a lone surrogate
             with self.assertRaises(UnicodeEncodeError) as uee:
@@ -172,7 +172,7 @@ class CodecsTest(unittest.TestCase):
         else:
             check_error('utf-8-sig', 'utf-8')
 
-    def test_interop_utf16_encode_exeption(self):
+    def test_interop_utf16_encode_exception(self):
         def check_error(encoding, name):
             # exception on a lone surrogate
             with self.assertRaises(UnicodeEncodeError) as uee:
@@ -188,7 +188,7 @@ class CodecsTest(unittest.TestCase):
 
         check_error('utf-16', 'utf-16') # TODO: should be 'utf-16LE' (CPython: 'utf-16-le')
 
-    def test_interop_ascii_decode_exeption(self):
+    def test_interop_ascii_decode_exception(self):
         def check_error(encoding, name):
             with self.assertRaises(UnicodeDecodeError) as ude:
                 b"abc\xffxyz".decode(encoding)
@@ -203,7 +203,7 @@ class CodecsTest(unittest.TestCase):
 
         check_error('ascii', 'ascii')
 
-    def test_interop_utf8_decode_exeption(self):
+    def test_interop_utf8_decode_exception(self):
         def check_error(encoding, name):
             with self.assertRaises(UnicodeDecodeError) as ude:
                 # broken input (� is 0xff): "abć�ẋyz"
@@ -221,7 +221,7 @@ class CodecsTest(unittest.TestCase):
 
         check_error('utf-8', 'utf-8')
 
-    def test_interop_utf8bom_decode_exeption(self):
+    def test_interop_utf8bom_decode_exception(self):
         def check_error(encoding, name):
             with self.assertRaises(UnicodeDecodeError) as ude:
                 # broken input (� is 0xff): BOM + "abć�ẋyz"
@@ -238,7 +238,7 @@ class CodecsTest(unittest.TestCase):
 
         check_error('utf-8', 'utf-8')
 
-    def test_interop_utf8sigbom_decode_exeption(self):
+    def test_interop_utf8sigbom_decode_exception(self):
         def check_error(encoding, name):
             with self.assertRaises(UnicodeDecodeError) as ude:
                 # broken input (� is 0xff): BOM_UTF8 + "abć�ẋyz"


### PR DESCRIPTION
This is the decoding counterpart of #914 and #941. Apart from consolidating the code and preparing for incremental decoding support (in file i/o), a direct functional benefit is that custom decoding error handlers are now allowed to provide surrogate code points.

It also eliminates almost all data copy steps when using `PythonEncoding`, the only one remaining I am aware of is when using `(raw-)unicode-escape` encoding with a custom error handler. I consider this an infrequent scenario, besides, the input will usually not be very large. Also, in such usage there are more inefficiencies at play (e.g. the input data is processed thrice rather than once). Because of this and since this encoding is notorious for difficulties of fitting into the .NET encoding framework, I am inclined to leave it as is rather than writing much code for a performance-improving workaround that hardly anybody will use.