### PR TITLE
Prevent using str type arg in int.from_bytes

### DIFF
--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -164,6 +164,8 @@ namespace IronPython.Runtime {
                 return (Bytes)o;
             } else if (TryInvokeBytesOperator(context, o, out Bytes? res)) {
                 return res;
+            } else if (o is string || o is ExtensibleString) {
+                throw PythonOps.TypeError("cannot convert unicode object to bytes");
             } else {
                 return new Bytes(ByteOps.GetBytes(o, useHint: true, context).ToArray());
             }

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -528,7 +528,7 @@ namespace IronPython.Runtime.Operations {
             return Bytes.Make(res.ToArray());
         }
 
-        public static BigInteger from_bytes([BytesLike]IList<byte> bytes, string byteorder, bool signed=false) {
+        public static BigInteger from_bytes([NotNull, BytesLike]IList<byte> bytes, string byteorder, bool signed=false) {
             // TODO: signed should be a keyword only argument
             // TODO: return int when possible?
 


### PR DESCRIPTION
Resolves #955, that is, the debug mode tests pass and the error message for `int.from_bytes("abc", 'big')` is aligned with CPython.

It does not resolve the underlying issue, for which I have created a separate issue report (#957).