### PR TITLE
Use UTF-8 as default with ScriptEngine

### DIFF
--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -892,7 +892,13 @@ namespace IronPython.Runtime {
 
             if (sourceEncoding == null) {
                 // not autodetected and not declared, hence use default
-                sourceEncoding = defaultEncoding;
+                if (ReferenceEquals(defaultEncoding, StringUtils.DefaultEncoding)) {
+                    // Override DLR default encoding with Python default
+                    sourceEncoding = DefaultEncoding;
+                } else {
+                    // user-provided encoding
+                    sourceEncoding = defaultEncoding;
+                }
             } else {
                 sourceEncoding = (Encoding)sourceEncoding.Clone();
                 sourceEncoding.DecoderFallback = DecoderFallback.ExceptionFallback;

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -892,13 +892,7 @@ namespace IronPython.Runtime {
 
             if (sourceEncoding == null) {
                 // not autodetected and not declared, hence use default
-                if (ReferenceEquals(defaultEncoding, StringUtils.DefaultEncoding)) {
-                    // Override DLR default encoding with Python default
-                    sourceEncoding = DefaultEncoding;
-                } else {
-                    // user-provided encoding
-                    sourceEncoding = defaultEncoding;
-                }
+                sourceEncoding = defaultEncoding;
             } else {
                 sourceEncoding = (Encoding)sourceEncoding.Clone();
                 sourceEncoding.DecoderFallback = DecoderFallback.ExceptionFallback;

--- a/Tests/encoded_files/cp20472.py
+++ b/Tests/encoded_files/cp20472.py
@@ -1,2 +1,3 @@
 pi = 3.14 #This module is completely broken because of:  Ïæ¸
           #AKA encoding 1251
+s = "Ïæ¸"

--- a/WhatsNewInPython30.md
+++ b/WhatsNewInPython30.md
@@ -36,7 +36,7 @@ Text Vs. Data Instead Of Unicode Vs. 8-bit
 - [ ] Filenames are passed to and returned from APIs as (Unicode) strings. This can present platform-specific problems because on some platforms filenames are arbitrary byte strings. (On the other hand, on Windows filenames are natively stored as Unicode.) As a work-around, most APIs (e.g. `open()` and many functions in the `os` module) that take filenames accept bytes objects as well as strings, and a few APIs have a way to ask for a `bytes` return value. Thus, `os.listdir()` returns a list of `bytes` instances if the argument is a `bytes` instance, and `os.getcwdb()` returns the current working directory as a `bytes` instance. Note that when `os.listdir()` returns a list of strings, filenames that cannot be decoded properly are omitted rather than raising `UnicodeError`.
 - [ ] Some system APIs like `os.environ` and `sys.argv` can also present problems when the bytes made available by the system is not interpretable using the default encoding. Setting the `LANG` variable and rerunning the program is probably the best approach.
 - [x] [PEP 3138][]: The `repr()` of a string no longer escapes non-ASCII characters. It still escapes control characters and code points with non-printable status in the Unicode standard, however.
-- [ ] [PEP 3120][]: The default source encoding is now UTF-8.
+- [x] [PEP 3120][]: The default source encoding is now UTF-8.
 - [x] [PEP 3131][]: Non-ASCII letters are now allowed in identifiers. (However, the standard library remains ASCII-only with the exception of contributor names in comments.)
 - [x] The `StringIO` and `cStringIO` modules are gone. Instead, import the `io` module and use `io.StringIO` or `io.BytesIO` for text and data respectively.
 


### PR DESCRIPTION
This is the last bit of the work to use UTF-8 as default source encoding that I am aware of.

The test for encoding used by `ScriptEngine` was already in place (disabled) but it wasn't testing the right thing. I went to the [CodePlex archive](https://archive.codeplex.com/?p=ironpython) to look up the original report 20472 (_Issue with non-unicode script file encoding_) and fixed the test to test for that.

One caveat: if the user uses `CreateScriptSourceFromFile(file, System.Text.Encoding.Default)`, UTF-8 will be used rather than `Encoding.Default` which on .NET Framework is the active Windows code page. Perhaps this is OK, since the IronPython 3 default **is** UTF-8. If this is not right, the solution might be to modify `Microsoft.Scripting.Utils.StringUtils.DefaultEncoding` to use a clone of ` System.Text.Encoding.Default`.

For now, if somebody really needs to use the active Windows code page, they may either specify it explicitly or clone the default themselves, e.g.:
```C#
CreateScriptSourceFromFile(file, Encoding.GetEncoding(1252)); // or whatever codepage is active
CreateScriptSourceFromFile(file, Encoding.Default.Clone());
```