### PR TITLE
Eliminate data copy when calling str() on a bytes-like object

### DIFF
--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -15,6 +15,7 @@ using System.Text;
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 
+using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
 
@@ -1076,6 +1077,11 @@ namespace IronPython.Runtime {
             lock (this) {
                 return "bytearray(" + _bytes.BytesRepr() + ")";
             }
+        }
+
+        public virtual string __str__(CodeContext context) {
+            PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytearray instance");
+            return Repr();
         }
 
         public virtual string __repr__(CodeContext context) => Repr();

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1080,7 +1080,9 @@ namespace IronPython.Runtime {
         }
 
         public virtual string __str__(CodeContext context) {
-            PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytearray instance");
+            if (context.LanguageContext.PythonOptions.BytesWarning) {
+                PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytearray instance");
+            }
             return Repr();
         }
 

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -856,7 +856,9 @@ namespace IronPython.Runtime {
         }
 
         public virtual string __str__(CodeContext context) {
-            PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytes instance");
+            if (context.LanguageContext.PythonOptions.BytesWarning) {
+                PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytes instance");
+            }
             return _bytes.BytesRepr();
         }
 

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -16,6 +16,7 @@ using System.Text;
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 
+using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
 using NotNullWhenAttribute = System.Diagnostics.CodeAnalysis.NotNullWhenAttribute;
@@ -852,6 +853,11 @@ namespace IronPython.Runtime {
                 ),
                 GetType() == typeof(Bytes) ? null : ObjectOps.ReduceProtocol0(context, this)[2]
             );
+        }
+
+        public virtual string __str__(CodeContext context) {
+            PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytes instance");
+            return _bytes.BytesRepr();
         }
 
         public virtual string __repr__(CodeContext context) {

--- a/Tests/test_str.py
+++ b/Tests/test_str.py
@@ -55,36 +55,13 @@ class StrTest(IronPythonTestCase):
         if is_cli:
             self.assertEqual('ä', str('ä'.Chars[0])) # StringOps.__new__(..., char)
 
-        with warnings.catch_warnings(record=True) as ws:
-            warnings.simplefilter("always")
+        self.assertRegex(str(memoryview(b'abc')), r"^<memory at .+>$")
+        self.assertEqual(str(memoryview(b'abc'), 'ascii'), 'abc')
+        self.assertRaises(TypeError, str, memoryview(b'abc')[::2], 'ascii')
 
-            with self.assertWarnsRegex(BytesWarning, r"^str\(\) on a bytes instance$"):
-                self.assertEqual(str(b'abc'), "b'abc'")
-            self.assertEqual(str(b'abc', 'ascii'), 'abc')
-
-            with self.assertWarnsRegex(BytesWarning, r"^str\(\) on a bytearray instance$"):
-                self.assertEqual(str(bytearray(b'abc')), "bytearray(b'abc')")
-            self.assertEqual(str(bytearray(b'abc'), 'ascii'), 'abc')
-
-            self.assertRegex(str(memoryview(b'abc')), r"^<memory at .+>$")
-            self.assertEqual(str(memoryview(b'abc'), 'ascii'), 'abc')
-            self.assertRaises(TypeError, str, memoryview(b'abc')[::2], 'ascii')
-
-            import array
-            self.assertEqual(str(array.array('B', b'abc')), "array('B', [97, 98, 99])")
-            self.assertEqual(str(array.array('B', b'abc'), 'ascii'), 'abc')
-
-            class B(bytes):
-                def __str__(self):
-                    return "This is B"
-
-            self.assertEqual(str(B(b'abc')), "This is B") # no warning
-
-            class B2(bytes): pass
-            with self.assertWarnsRegex(BytesWarning, r"^str\(\) on a bytes instance$"):
-                self.assertEqual(str(B2(b'abc')), "b'abc'")
-
-        self.assertEqual(len(ws), 0) # no unchecked warnings
+        import array
+        self.assertEqual(str(array.array('B', b'abc')), "array('B', [97, 98, 99])")
+        self.assertEqual(str(array.array('B', b'abc'), 'ascii'), 'abc')
 
     def test_add_mul(self):
         self.assertRaises(TypeError, lambda: "a" + 3)


### PR DESCRIPTION
This also aligns error types and warnings with CPython's.