### PR TITLE
Make int.from_bytes recognize __bytes__ in all cases

### DIFF
--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -165,6 +165,8 @@ namespace IronPython.Runtime {
                 return (Bytes)o;
             } else if (TryInvokeBytesOperator(context, o, out Bytes? res)) {
                 return res;
+            } else if (o is IBufferProtocol bp) {
+                return new Bytes(bp);
             } else if (o is string || o is ExtensibleString) {
                 throw PythonOps.TypeError("cannot convert unicode object to bytes");
             } else {

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -528,27 +528,15 @@ namespace IronPython.Runtime.Operations {
             return Bytes.Make(res.ToArray());
         }
 
-        public static BigInteger from_bytes([NotNull] byte[] bytes, [NotNull] string byteorder, bool signed=false) {
-            // TODO: signed should be a keyword only argument
-            // TODO: return int when possible?
-
-            bool isLittle = byteorder == "little";
-            if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
-
-            return FromBytes(bytes, isLittle, signed);
-        }
-
         public static BigInteger from_bytes(CodeContext context, object bytes, [NotNull] string byteorder, bool signed = false) {
             // TODO: signed should be a keyword only argument
             // TODO: return int when possible?
+            // TODO: if called on a subclass of Extensible<BigInteger>, return that subclass
 
             bool isLittle = byteorder == "little";
             if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
 
-            return FromBytes(Bytes.FromObject(context, bytes).UnsafeByteArray, isLittle, signed);
-        }
-
-        private static BigInteger FromBytes(byte[] bytesArr, bool isLittle, bool signed) {
+            byte[] bytesArr = Bytes.FromObject(context, bytes).UnsafeByteArray;
             if (bytesArr.Length == 0) return 0;
 
 #if NETCOREAPP

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -213,6 +213,7 @@ class BytesTest(IronPythonTestCase):
         self.assertEqual(bytes(BytesBytesSubclass(b"JUST BYTES")), b"BYTES FROM BYTES")
         self.assertIs(type(bytes(BytesBytesSubclass(b"JUST BYTES"))), BytesBytesSubclass)
         self.assertEqual(int.from_bytes(bytes(BytesBytesSubclass(b"JUST BYTES")), 'big'), int.from_bytes(b"BYTES FROM BYTES", 'big'))
+        self.assertEqual(int.from_bytes(BytesBytesSubclass(b"JUST BYTES"), 'big'), int.from_bytes(b"BYTES FROM BYTES", 'big'))
 
         class ListSubclass(bytes):
             def __bytes__(self):

--- a/Tests/test_memoryview.py
+++ b/Tests/test_memoryview.py
@@ -247,6 +247,11 @@ class MemoryViewTests(unittest.TestCase):
             with self.assertRaisesRegex(TypeError, "^memoryview: cannot cast between two non-byte formats$"):
                 mv.cast('H')
 
+    def test_conv(self):
+        self.assertEqual(int.from_bytes(memoryview(b'abcd'), 'big'), 0x61626364)
+        self.assertEqual(int.from_bytes(memoryview(b'abcd')[::2], 'big'), 0x6163)
+        self.assertEqual(int.from_bytes(memoryview(b'abcd')[::-2], 'big'), 0x6462)
+
 class CastTests(unittest.TestCase):
     def test_get_int_alignment(self):
         a = array.array('b', range(8))


### PR DESCRIPTION
Fixes:
```python
class BytesBytesSubclass(bytes):
    def __bytes__(self):
        return BytesBytesSubclass(b"xyz")

assert int.from_bytes(BytesBytesSubclass(b"abc"), 'big') == int.from_bytes(b"xyz", 'big')
```
Also:
```python
assert int.from_bytes(memoryview(b"abc")[::2], 'big') == int.from_bytes(b"ac", 'big')
```
