### PR TITLE
Use IBufferProtocol in zlib

### DIFF
--- a/Src/IronPython.Modules/binascii.cs
+++ b/Src/IronPython.Modules/binascii.cs
@@ -374,7 +374,7 @@ both encoded.  When quotetabs is set, space and tabs are encoded.")]
 
         #region crc32
 
-        [Documentation("crc32(data[, crc]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of string.")]
+        [Documentation("crc32(data[, crc]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of data.")]
         public static object crc32([NotNull]IBufferProtocol data, uint crc = 0) {
             // TODO: [PythonIndex(overflow=mask)] uint crc = 0
             using var buffer = data.GetBuffer();

--- a/Src/IronPython.Modules/binascii.cs
+++ b/Src/IronPython.Modules/binascii.cs
@@ -374,20 +374,19 @@ both encoded.  When quotetabs is set, space and tabs are encoded.")]
 
         #region crc32
 
-        [Documentation("crc32(string[, value]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of string.")]
-        public static object crc32([NotNull]IBufferProtocol data, uint crc = 0)
-            => crc32_impl(data.ToBytes(), crc);
-
-        private static object crc32_impl(IList<byte> bytes, uint crc) {
-            var res = crc32(bytes, 0, bytes.Count, crc);
+        [Documentation("crc32(data[, crc]) -> string\n\nComputes a CRC (Cyclic Redundancy Check) checksum of string.")]
+        public static object crc32([NotNull]IBufferProtocol data, uint crc = 0) {
+            // TODO: [PythonIndex(overflow=mask)] uint crc = 0
+            using var buffer = data.GetBuffer();
+            var res = crc32(buffer.AsReadOnlySpan(), crc);
             if (res <= int.MaxValue) return (int)res;
             return (BigInteger)res;
         }
 
-        internal static uint crc32(IList<byte> buffer, int offset, int count, uint baseValue) {
+        private static uint crc32(ReadOnlySpan<byte> buffer, uint baseValue) {
             uint remainder = (baseValue ^ 0xffffffff);
-            for (int i = offset; i < offset + count; i++) {
-                remainder ^= buffer[i];
+            foreach (byte val in buffer) {
+                remainder ^= val;
                 for (int j = 0; j < 8; j++) {
                     if ((remainder & 0x01) != 0) {
                         remainder = (remainder >> 1) ^ 0xEDB88320;

--- a/Src/IronPython.Modules/zlib/ZlibModule.cs
+++ b/Src/IronPython.Modules/zlib/ZlibModule.cs
@@ -27,11 +27,11 @@ namespace IronPython.Zlib
         public const string __doc__ = @"The functions in this module allow compression and decompression using the
 zlib library, which is based on GNU zip.
 
-adler32(string[, start]) -- Compute an Adler-32 checksum.
-compress(string[, level]) -- Compress string, with compression level in 1-9.
+adler32(data[, value]) -- Compute an Adler-32 checksum.
+compress(data[, level]) -- Compress data, with compression level 1-9.
 compressobj([level]) -- Return a compressor object.
-crc32(string[, start]) -- Compute a CRC-32 checksum.
-decompress(string,[wbits],[bufsize]) -- Decompresses a compressed string.
+crc32(data[, value]) -- Compute a CRC-32 checksum.
+decompress(data,[wbits],[bufsize]) -- Decompresses compressed data.
 decompressobj([wbits]) -- Return a decompressor object.
 
 'wbits' is window buffer size.
@@ -69,7 +69,7 @@ objects support decompress() and flush().";
 
         internal const int DEFAULTALLOC = 16 * 1024;
 
-        [Documentation(@"adler32(data[, value]) -- Compute an Adler-32 checksum of string.
+        [Documentation(@"adler32(data[, value]) -- Compute an Adler-32 checksum of data.
 
 An optional starting value can be specified.  The returned checksum is
 a signed integer.")]
@@ -79,7 +79,7 @@ a signed integer.")]
             return (int)Adler32.GetAdler32Checksum(value, buffer.AsUnsafeArray() ?? buffer.ToArray(), 0, buffer.NumBytes());
         }
 
-        [Documentation(@"crc32(data[, value]) -- Compute a CRC-32 checksum of string.
+        [Documentation(@"crc32(data[, value]) -- Compute a CRC-32 checksum of data.
 
 An optional starting value can be specified.  The returned checksum is
 a signed integer.")]
@@ -87,7 +87,7 @@ a signed integer.")]
             // TODO: [PythonIndex(overflow=mask)] uint value = 0
             => IronPython.Modules.PythonBinaryAscii.crc32(data, value);
 
-        [Documentation(@"compress(data[, level]) -- Returned compressed string.
+        [Documentation(@"compress(data[, level]) -- Returns a bytes object containing compressed data.
 
 Optional arg level is the compression level, in 1-9.")]
         public static Bytes compress([NotNull] IBufferProtocol data,
@@ -152,7 +152,7 @@ Optional arg level is the compression level, in 1-9.")]
             return new Compress(level, method, wbits, memlevel, strategy);
         }
 
-        [Documentation(@"decompress(data[, wbits[, bufsize]]) -- Return decompressed string.
+        [Documentation(@"decompress(data[, wbits[, bufsize]]) -- Returns a bytes object containing the uncompressed data.
 
 Optional arg wbits is the window buffer size.  Optional arg bufsize is
 the initial output buffer size.")]

--- a/Src/IronPython.Modules/zlib/ZlibModule.cs
+++ b/Src/IronPython.Modules/zlib/ZlibModule.cs
@@ -69,34 +69,32 @@ objects support decompress() and flush().";
 
         internal const int DEFAULTALLOC = 16 * 1024;
 
-        [Documentation(@"adler32(string[, start]) -- Compute an Adler-32 checksum of string.
+        [Documentation(@"adler32(data[, value]) -- Compute an Adler-32 checksum of string.
 
 An optional starting value can be specified.  The returned checksum is
 a signed integer.")]
-        public static int adler32([BytesLike]IList<byte> data, long baseValue=1L)
+        public static int adler32([NotNull] IBufferProtocol data, long value=1L)
         {
-            return (int)Adler32.GetAdler32Checksum(baseValue, data.ToArray(), 0, data.Count);
+            using var buffer = data.GetBuffer();
+            return (int)Adler32.GetAdler32Checksum(value, buffer.AsUnsafeArray() ?? buffer.ToArray(), 0, buffer.NumBytes());
         }
 
-        [Documentation(@"crc32(string[, start]) -- Compute a CRC-32 checksum of string.
+        [Documentation(@"crc32(data[, value]) -- Compute a CRC-32 checksum of string.
 
 An optional starting value can be specified.  The returned checksum is
 a signed integer.")]
-        public static BigInteger crc32([BytesLike]IList<byte> data, long baseValue=0L)
-        {
-            if(baseValue < int.MinValue || baseValue > uint.MaxValue)
-                throw new ArgumentOutOfRangeException(nameof(baseValue));
+        public static object crc32([NotNull] IBufferProtocol data, uint value = 0)
+            // TODO: [PythonIndex(overflow=mask)] uint value = 0
+            => IronPython.Modules.PythonBinaryAscii.crc32(data, value);
 
-            return IronPython.Modules.PythonBinaryAscii.crc32(data, 0, data.Count, (uint)baseValue);
-        }
-
-        [Documentation(@"compress(string[, level]) -- Returned compressed string.
+        [Documentation(@"compress(data[, level]) -- Returned compressed string.
 
 Optional arg level is the compression level, in 1-9.")]
-        public static Bytes compress([BytesLike]IList<byte> data,
+        public static Bytes compress([NotNull] IBufferProtocol data,
             int level=Z_DEFAULT_COMPRESSION)
         {
-            byte[] input = data.ToArray();
+            using var buffer = data.GetBuffer();
+            byte[] input = buffer.AsUnsafeArray() ?? buffer.ToArray();
             byte[] output = new byte[input.Length + input.Length / 1000 + 12 + 1];
 
             ZStream zst = new ZStream();
@@ -154,15 +152,16 @@ Optional arg level is the compression level, in 1-9.")]
             return new Compress(level, method, wbits, memlevel, strategy);
         }
 
-        [Documentation(@"decompress(string[, wbits[, bufsize]]) -- Return decompressed string.
+        [Documentation(@"decompress(data[, wbits[, bufsize]]) -- Return decompressed string.
 
 Optional arg wbits is the window buffer size.  Optional arg bufsize is
 the initial output buffer size.")]
-        public static Bytes decompress([BytesLike]IList<byte> data,
+        public static Bytes decompress([NotNull] IBufferProtocol data,
             int wbits=MAX_WBITS,
             int bufsize=DEFAULTALLOC)
         {
-            var bytes = Decompress(data.ToArray(), wbits, bufsize);
+            using var buffer = data.GetBuffer();
+            var bytes = Decompress(buffer.AsUnsafeArray() ?? buffer.ToArray(), wbits, bufsize);
             return Bytes.Make(bytes);
         }
 


### PR DESCRIPTION
Here is an example where `PythonIndexAttribute` would be quite useful, and on a different type than `int`. The `crc` parameter for `binascii.crc32`, (and `value` parameter for `zlib.crc32`) honours `__index__` and accepts any integer value, but for any value not fitting in `UInt32`, the value is masked, i.e. the 32 least significant bits are taken and interpreted as unsigned. I suspect something similar for `zlib.adler32`, though I haven't tesed it. In general, I suspect honouring `__index__` is quite widespread and the error handling differences can be clamping, masking, `OverflowError`, `ValueError`.

----
`zlib.crc32` seems to do the same as `binascii.crc32` so I assume it is OK for it to return `object` as well?

----
It can be risky to convert `IBufferProtocol` to `IList` in a general case by calling the `Bytes` constructor. This constructor is one of the very few places that accept any possible buffer protocol, but in most cases Python API requires a bytes-like object (i.e. C-contiguous). I have noticed that the (old) `binascii.crc32` was doing it, but I haven't checked the whole `binascii`. But since it is a negative noncompliance, I am not too worried about it.