### PR TITLE
Complete support of commandline options -b and -bb

### DIFF
--- a/Src/IronPython.Modules/_warnings.cs
+++ b/Src/IronPython.Modules/_warnings.cs
@@ -33,7 +33,13 @@ namespace IronPython.Modules {
             defaultFilters.AddNoLock(PythonTuple.MakeTuple("ignore", null, PythonExceptions.DeprecationWarning, null, 0));
             defaultFilters.AddNoLock(PythonTuple.MakeTuple("ignore", null, PythonExceptions.PendingDeprecationWarning, null, 0));
             defaultFilters.AddNoLock(PythonTuple.MakeTuple("ignore", null, PythonExceptions.ImportWarning, null, 0));
-            defaultFilters.AddNoLock(PythonTuple.MakeTuple("ignore", null, PythonExceptions.BytesWarning, null, 0));
+
+            string bytesWarningAction = context.PythonOptions.BytesWarning switch {
+                Severity.Ignore => "ignore",
+                Severity.Warning => "default",
+                _ => "error"
+            };
+            defaultFilters.AddNoLock(PythonTuple.MakeTuple(bytesWarningAction, null, PythonExceptions.BytesWarning, null, 0));
 
             context.GetOrCreateModuleState(_keyFields, () => {
                 dict.Add(_keyDefaultAction, "default");

--- a/Src/IronPython/Hosting/PythonOptionsParser.cs
+++ b/Src/IronPython/Hosting/PythonOptionsParser.cs
@@ -26,11 +26,14 @@ namespace IronPython.Hosting {
 
             switch (arg) {
                 case "-B": break; // dont_write_bytecode always true in IronPython
-                case "-U": break; // unicode always true in IronPython
                 case "-d": break; // debug output from parser, always False in IronPython
 
-                case "-b": // Not shown in help on CPython
-                    LanguageSetup.Options["BytesWarning"] = ScriptingRuntimeHelpers.True;
+                case "-b":
+                    LanguageSetup.Options["BytesWarning"] = LanguageSetup.Options.ContainsKey("BytesWarning") ? Severity.Error : Severity.Warning;
+                    break;
+
+                case "-bb":
+                    LanguageSetup.Options["BytesWarning"] = Severity.Error;
                     break;
 
                 case "-c":
@@ -232,6 +235,7 @@ namespace IronPython.Hosting {
 #if !IRONPYTHON_WINDOW
                 { "-v",                     "Verbose (trace import statements) (also PYTHONVERBOSE=x)" },
 #endif
+                { "-b",                     "issue warnings about str(bytes_instance), str(bytearray_instance) and comparing bytes/bytearray with str. (-bb: issue errors)"},
                 { "-m module",              "run library module as a script"},
                 { "-x",                     "Skip first line of the source" },
                 { "-u",                     "Unbuffered stdout & stderr" },

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1080,7 +1080,7 @@ namespace IronPython.Runtime {
         }
 
         public virtual string __str__(CodeContext context) {
-            if (context.LanguageContext.PythonOptions.BytesWarning) {
+            if (context.LanguageContext.PythonOptions.BytesWarning != Microsoft.Scripting.Severity.Ignore) {
                 PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytearray instance");
             }
             return Repr();

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -858,7 +858,7 @@ namespace IronPython.Runtime {
         }
 
         public virtual string __str__(CodeContext context) {
-            if (context.LanguageContext.PythonOptions.BytesWarning) {
+            if (context.LanguageContext.PythonOptions.BytesWarning != Microsoft.Scripting.Severity.Ignore) {
                 PythonOps.Warn(context, PythonExceptions.BytesWarning, "str() on a bytes instance");
             }
             return _bytes.BytesRepr();

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -722,7 +722,13 @@ namespace IronPython.Runtime {
             }
             flags.verbose = PythonOptions.Verbose ? 1 : 0;
             flags.unicode = 1;
-            flags.bytes_warning = PythonOptions.BytesWarning ? 1 : 0;
+            flags.bytes_warning = PythonOptions.BytesWarning switch {
+                Severity.Ignore => 0,
+                Severity.Warning => 1,
+                Severity.Error => 2,
+                Severity.FatalError => 3,
+                _ => (int)PythonOptions.BytesWarning
+            };
             flags.quiet = PythonOptions.Quiet ? 1 : 0;
         }
 

--- a/Src/IronPython/Runtime/PythonOptions.cs
+++ b/Src/IronPython/Runtime/PythonOptions.cs
@@ -33,7 +33,7 @@ namespace IronPython.Runtime {
         /// </summary>
         public ReadOnlyCollection<string>/*!*/ WarningFilters { get; }
 
-        public bool BytesWarning { get; }
+        public Severity BytesWarning { get; }
 
         /// <summary>
         /// Enables debugging support.  When enabled a .NET debugger can be attached
@@ -130,7 +130,7 @@ namespace IronPython.Runtime {
             Arguments = GetStringCollectionOption(options, "Arguments") ?? EmptyStringCollection;
             WarningFilters = GetStringCollectionOption(options, "WarningFilters", ';', ',') ?? EmptyStringCollection;
 
-            BytesWarning = GetOption(options, "BytesWarning", false);
+            BytesWarning = GetOption(options, "BytesWarning", Severity.Ignore);
             Debug = GetOption(options, "Debug", false);
             Inspect = GetOption(options, "Inspect", false);
             NoUserSite = GetOption(options, "NoUserSite", false);


### PR DESCRIPTION
So in the end I did not implement support for `-bbb`, `-bbbb` and the like. They are nowhere documented and I wonder if anybody is using this in the wild. Anyway, since `PythonOptions.BytesWarning` is an int-backed enum now, it should be fairly easy to add such support in the future, if the need arises.