### PR TITLE
Disable parallel execution for test_nt

### DIFF
--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -688,6 +688,7 @@ Ignore=true
 
 [CPython.test_ntpath]
 RunCondition=$(IS_WINDOWS) # TODO: failing on posix
+IsolationLevel=PROCESS # Manipulates environment variables
 
 [CPython.test_numeric_tower]
 Ignore=true

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -193,6 +193,7 @@ IsolationLevel=PROCESS # changes the locale which can cause other tests to fail
 
 [IronPython.modules.system_related.test_nt]
 RunCondition=NOT $(IS_POSIX)
+NotParallelSafe=true # Uses fixed file, directory, and environment variable names
 
 [IronPython.modules.system_related.test_sys_getframe]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489


### PR DESCRIPTION
`IronPython.modules.system_related.test_nt` uses fixed file, directory, and environment variable names.