### PR TITLE
Use IBufferProtocol in compressors and decompressors

### DIFF
--- a/Src/IronPython.Modules/bz2/BZ2Compressor.cs
+++ b/Src/IronPython.Modules/bz2/BZ2Compressor.cs
@@ -40,22 +40,25 @@ must be a number between 1 and 9.
                 this.bz2Output = new BZip2OutputStream(this.output, true);
             }
 
-            [Documentation(@"compress(data) -> string
+            [Documentation(@"compress(data) -> bytes
 
 Provide more data to the compressor object. It will return chunks of
-compressed data whenever possible. When you've finished providing data
+compressed data whenever possible, or b'' otherwise.
+
+When you've finished providing data
 to compress, call the flush() method to finish the compression process,
 and return what is left in the internal buffers.
 ")]
-            public Bytes compress([BytesLike]IList<byte> data) {
-                byte[] bytes = data.ToArrayNoCopy();
+            public Bytes compress([NotNull] IBufferProtocol data) {
+                using var buffer = data.GetBuffer();
+                byte[] bytes = buffer.AsUnsafeArray() ?? buffer.ToArray();
 
                 this.bz2Output.Write(bytes, 0, bytes.Length);
 
                 return Bytes.Make(this.GetLatestData());
             }
 
-            [Documentation(@"flush() -> string
+            [Documentation(@"flush() -> bytes
 
 Finish the compression process and return what is left in internal buffers.
 You must not use the compressor object after calling this method.

--- a/Src/IronPython.Modules/bz2/BZ2Decompressor.cs
+++ b/Src/IronPython.Modules/bz2/BZ2Decompressor.cs
@@ -46,7 +46,7 @@ decompress() function instead.
                 }
             }
 
-            [Documentation(@"decompress(data) -> string
+            [Documentation(@"decompress(data) -> bytes
 
 Provide more data to the decompressor object. It will return chunks
 of decompressed data whenever possible. If you try to decompress data
@@ -54,11 +54,12 @@ after the end of stream is found, EOFError will be raised. If any data
 was found after the end of stream, it'll be ignored and saved in
 unused_data attribute.
 ")]
-            public Bytes decompress([BytesLike]IList<byte> data) {
+            public Bytes decompress([NotNull] IBufferProtocol data) {
                 if (_finished)
                     throw PythonOps.EofError("End of stream was already found");
 
-                var bytes = data.ToArrayNoCopy();
+                using var buffer = data.GetBuffer();
+                byte[] bytes = buffer.AsUnsafeArray() ?? buffer.ToArray();
 
                 if (!InitializeMemoryStream(bytes))
                     AddData(bytes);

--- a/Src/IronPython.Modules/bz2/BZ2Module.cs
+++ b/Src/IronPython.Modules/bz2/BZ2Module.cs
@@ -15,22 +15,5 @@ using IronPython.Runtime;
 namespace IronPython.Modules.Bz2 {
     public static partial class Bz2Module {
         internal const int DEFAULT_COMPRESSLEVEL = 9;
-
-        /// <summary>
-        /// Try to convert IList(Of byte) to byte[] without copying, if possible.
-        /// </summary>
-        /// <param name="bytes"></param>
-        /// <returns></returns>
-        private static byte[] ToArrayNoCopy(this IList<byte> bytes) {
-            if (bytes is byte[] bytesA) {
-                return bytesA;
-            }
-
-            if (bytes is Bytes bytesP) {
-                return bytesP.UnsafeByteArray;
-            }
-
-            return bytes.ToArray();
-        }
     }
 }

--- a/Src/IronPython.Modules/zlib/Compress.cs
+++ b/Src/IronPython.Modules/zlib/Compress.cs
@@ -44,14 +44,15 @@ namespace IronPython.Zlib
             }
         }
 
-        [Documentation(@"compress(data) -- Return a string containing data compressed.
+        [Documentation(@"compress(data) -- Return a bytes object containing compressed data.
 
 After calling this function, some of the input data may still
 be stored in internal buffers for later processing.
 Call the flush() method to clear these buffers.")]
-        public Bytes compress([BytesLike]IList<byte> data)
+        public Bytes compress([NotNull] IBufferProtocol data)
         {
-            byte[] input = data.ToArray();
+            using var buffer = data.GetBuffer();
+            byte[] input = buffer.AsUnsafeArray() ?? buffer.ToArray();
             byte[] output = new byte[ZlibModule.DEFAULTALLOC];
 
             long start_total_out = zst.total_out;
@@ -83,7 +84,7 @@ Call the flush() method to clear these buffers.")]
             return GetBytes(output, 0, (int)(zst.total_out - start_total_out));
         }
 
-        [Documentation(@"flush( [mode] ) -- Return a string containing any remaining compressed data.
+        [Documentation(@"flush( [mode] ) -- Return a bytes object containing any remaining compressed data.
 
 mode can be one of the constants Z_SYNC_FLUSH, Z_FULL_FLUSH, Z_FINISH; the
 default value used when mode is not specified is Z_FINISH.

--- a/Src/IronPython.Modules/zlib/Decompress.cs
+++ b/Src/IronPython.Modules/zlib/Decompress.cs
@@ -50,7 +50,7 @@ namespace IronPython.Zlib
         public Bytes unused_data { get; private set; }
         public Bytes unconsumed_tail { get; private set; }
 
-        [Documentation(@"decompress(data, max_length) -- Return a string containing the decompressed
+        [Documentation(@"decompress(data, max_length) -- Return a bytes object containing the decompressed
 version of the data.
 
 After calling this function, some of the input data may still be stored in
@@ -59,11 +59,12 @@ Call the flush() method to clear these buffers.
 If the max_length parameter is specified then the return value will be
 no longer than max_length.  Unconsumed input data will be stored in
 the unconsumed_tail attribute.")]
-        public Bytes decompress([BytesLike]IList<byte> value, int max_length=0)
+        public Bytes decompress([NotNull] IBufferProtocol data, int max_length=0)
         {
             if(max_length < 0) throw new ArgumentException("max_length must be greater than zero");
 
-            byte[] input = value.ToArray();
+            using var buffer = data.GetBuffer();
+            byte[] input = buffer.AsUnsafeArray() ?? buffer.ToArray();
             byte[] output = new byte[max_length > 0 && ZlibModule.DEFAULTALLOC > max_length ? max_length : ZlibModule.DEFAULTALLOC];
 
             long start_total_out = zst.total_out;
@@ -109,7 +110,7 @@ the unconsumed_tail attribute.")]
 
         public bool eof { get; set; }
 
-        [Documentation(@"flush( [length] ) -- Return a string containing any remaining
+        [Documentation(@"flush( [length] ) -- Return a bytes object  containing any remaining
 decompressed data. length, if given, is the initial size of the
 output buffer.
 


### PR DESCRIPTION
`BZ2Compress.cs` and `BZ2Decompress.cs` are small could be merged into `BZ2Module.cs` (which is practically empty), but I suppose are kept separate to keep the same structure as of `zlib`.