### PR TITLE
Flush std files on shutdown

### DIFF
--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1295,6 +1295,19 @@ namespace IronPython.Runtime {
                 }
 #endif
             }
+
+            Flush(SharedContext, SystemStandardOut);
+            Flush(SharedContext, SystemStandardError);
+
+            static void Flush(CodeContext context, object obj) {
+                if (obj is PythonIOModule._IOBase pf) {
+                    if (!pf.closed)
+                        pf.flush(context);
+                } else if (PythonOps.TryGetBoundAttr(context, obj, "closed", out object closed)) {
+                    if (!PythonOps.IsTrue(closed))
+                        PythonTypeOps.TryInvokeUnaryOperator(context, obj, "flush", out _);
+                }
+            }
         }
 
         // TODO: ExceptionFormatter service

--- a/Src/StdLib/Lib/base64.py
+++ b/Src/StdLib/Lib/base64.py
@@ -586,7 +586,6 @@ def main():
             func(f, sys.stdout.buffer)
     else:
         func(sys.stdin.buffer, sys.stdout.buffer)
-    sys.stdout.buffer.flush() # ironpython: workaround for https://github.com/IronLanguages/ironpython3/issues/791
 
 def test():
     s0 = b"Aladdin:open sesame"


### PR DESCRIPTION
Calling flush on the standard file stream is the same approach CPython uses. Resolves https://github.com/IronLanguages/ironpython3/issues/791. Also related to https://github.com/IronLanguages/ironpython3/issues/938.

@jameslan