### PR TITLE
Update test_arguments to match DLR

### DIFF
--- a/Tests/interop/net/method/test_arguments.py
+++ b/Tests/interop/net/method/test_arguments.py
@@ -24,7 +24,7 @@ class ArgumentsTest(IronPythonTestCase):
 
     def test_0_1_args(self):
 
-        # public void M100() { Flag.Reset(); Flag.Set(10); }
+        # public void M100() { Flag.Set(10); }
         f = self.o.M100
         f()
         self.assertRaisesMessage(TypeError, 'M100() takes no arguments (1 given)', lambda: f(1))
@@ -36,7 +36,7 @@ class ArgumentsTest(IronPythonTestCase):
         self.assertRaisesMessage(TypeError, 'M100() takes no arguments (1 given)', lambda: f(**{'x':10}))
         f(*(), **{})
 
-        # public void M200(int arg) { Flag.Reset(); Flag.Set(arg); }
+        # public void M200(int arg) { Flag.Set(arg); }
         f = self.o.M200
         self.assertRaisesMessage(TypeError, "M200() takes exactly 1 argument (0 given)", lambda: f())
         f(1)
@@ -57,7 +57,7 @@ class ArgumentsTest(IronPythonTestCase):
         self.assertRaisesMessage(TypeError, "M200() takes exactly 1 argument (2 given)", lambda: f(arg = 1, other = 2))
         self.assertRaisesMessage(TypeError, "M200() takes exactly 1 argument (2 given)", lambda: f(arg = 1, **{'arg' : 2})) # msg
 
-        # public void M201([DefaultParameterValue(20)] int arg) { Flag.Reset(); Flag.Set(arg); }
+        # public void M201([DefaultParameterValue(20)] int arg) { Flag.Set(arg); }
         f = self.o.M201
         f()
         f(1)
@@ -81,7 +81,7 @@ class ArgumentsTest(IronPythonTestCase):
         self.assertRaisesMessage(TypeError, "M201() takes at most 1 argument (2 given)", lambda: f(arg1 = 1, other = 2))
         self.assertRaisesMessage(TypeError, "M201() got an unexpected keyword argument 'arg1'", lambda: f(**{ "arg1" : 1}))
 
-        # public void M202(params int[] arg) { Flag.Reset(); Flag.Set(arg.Length); }
+        # public void M202(params int[] arg) { Flag.Set(arg.Length); }
         f = self.o.M202
         f()
         f(1)
@@ -95,7 +95,7 @@ class ArgumentsTest(IronPythonTestCase):
         self.assertRaisesMessage(TypeError, "M202() got an unexpected keyword argument 'arg'", lambda: f(**{'arg': 3}))# msg
         self.assertRaisesMessage(TypeError, "M202() got an unexpected keyword argument 'other'", lambda: f(**{'other': 4}))
 
-        # public void M203([ParamDictionaryAttribute] IAttributesCollection arg) { Flag.Set(arg.Count); }
+        # public void M203([ParamDictionaryAttribute] IDictionary<object, object> arg) { Flag.Set(arg.Count); }
         f = self.o.M203
         f()
         self.assertRaisesMessage(TypeError, "M203() takes no arguments (1 given)", lambda: f(1))
@@ -189,18 +189,19 @@ class ArgumentsTest(IronPythonTestCase):
         # mixed
         # positional/keyword
         f(1, y = 2)
-        self.assertRaisesMessage(TypeError, "M300() got multiple values for keyword argument 'x'", lambda: f(2, x = 1))    # msg
+        self.assertRaisesMessage(TypeError, "Argument for M300() given by name ('x') and position (1)", lambda: f(2, x = 1))
         self.assertRaisesMessage(TypeError, "M300() takes exactly 2 arguments (3 given)", lambda: f(1, y = 1, x = 2)) # msg
+        self.assertRaisesMessage(TypeError, "M300() takes exactly 2 arguments (3 given)", lambda: f(1, 2, y = 1)) # msg
 
         # positional / **
         f(1, **{'y': 2})
-        self.assertRaisesMessage(TypeError, "M300() got multiple values for keyword argument 'x'", lambda: f(2, ** {'x':1}))
-        self.assertRaisesMessage(TypeError, "M300() takes exactly 2 arguments (3 given)", lambda: f(1, ** {'y':1, 'x':2}))
+        self.assertRaisesMessage(TypeError, "Argument for M300() given by name ('x') and position (1)", lambda: f(2, ** {'x':1}))
+        self.assertRaisesMessage(TypeError, "M300() takes exactly 2 arguments (3 given)", lambda: f(1, ** {'y':1, 'x':2}))  # msg
 
         # keyword / *
         f(y = 2, *(1,))
         self.assertRaisesMessage(TypeError, "M300() takes exactly 2 arguments (3 given)", lambda: f(y = 2, *(1,2)))
-        self.assertRaisesMessage(TypeError, "M300() takes exactly 2 arguments (3 given)", lambda: f(y = 2, x = 1, *(3,)))
+        self.assertRaisesMessage(TypeError, "M300() takes exactly 2 arguments (3 given)", lambda: f(y = 2, x = 1, *(3,)))  # msg
 
         # keyword / **
         f(y = 2, **{'x' : 1})
@@ -224,12 +225,12 @@ class ArgumentsTest(IronPythonTestCase):
 
         f(**{'x' : 1})
         self.assertRaisesMessage(TypeError, "M350() got an unexpected keyword argument 'y'", lambda: f(**{'x' : 1, 'y' : 2}))
-        self.assertRaisesMessage(TypeError, "M350() got multiple values for keyword argument 'x'", lambda: f(2, 3, 4, x = 1))
+        self.assertRaisesMessage(TypeError, "Argument for M350() given by name ('x') and position (1)", lambda: f(2, 3, 4, x = 1))
 
         # TODO: mixed
         f(x = 1)  # check the value
 
-        #public void M351(int x, [ParamDictionary] IAttributesCollection arg) { Flag<object>.Set(arg); }
+        #public void M351(int x, [ParamDictionary] IDictionary<object, object> arg) { Flag<object>.Set(arg); }
         f = self.o.M351
         self.assertRaisesMessage(TypeError, "M351() takes exactly 1 argument (0 given)", lambda: f())
         f(1); self.assertEqual(Flag[object].Value1, {})
@@ -239,7 +240,7 @@ class ArgumentsTest(IronPythonTestCase):
         f(x=1); self.assertEqual(Flag[object].Value1, {})
         f(**{'x' : 1}); self.assertEqual(Flag[object].Value1, {})
 
-        #public void M352([ParamDictionary] IAttributesCollection arg, params int[] x) { Flag<object>.Set(arg); }
+        #public void M352([ParamDictionary] IDictionary<object, object> arg, params int[] x) { Flag<object>.Set(arg); }
 
         f=self.o.M352
         f(); self.assertEqual(Flag[object].Value1, {})
@@ -253,7 +254,7 @@ class ArgumentsTest(IronPythonTestCase):
 
     def test_default_values_2(self):
         from Merlin.Testing import Flag
-        # public void M310(int x, [DefaultParameterValue(30)]int y) { Flag.Reset(); Flag.Set(x + y); }
+        # public void M310(int x, [DefaultParameterValue(30)]int y) { Flag.Set(x + y); }
         f = self.o.M310
         self.assertRaisesMessage(TypeError, "M310() takes at least 1 argument (0 given)", f)
         f(1); Flag.Check(31)
@@ -268,7 +269,7 @@ class ArgumentsTest(IronPythonTestCase):
 
         f(1, **{'y':2}); Flag.Check(3)
 
-        # public void M320([DefaultParameterValue(40)] int y, int x) { Flag.Reset(); Flag.Set(x + y); }
+        # public void M320([DefaultParameterValue(40)] int y, int x) { Flag.Set(x + y); }
         f = self.o.M320
         self.assertRaisesMessage(TypeError, "M320() takes at least 1 argument (0 given)", f)
         f(1); Flag.Check(41)  # !!!
@@ -280,10 +281,10 @@ class ArgumentsTest(IronPythonTestCase):
         f(*(1,)); Flag.Check(41)
         f(*(1, 2)); Flag.Check(3)
 
-        self.assertRaisesMessage(TypeError, "M320() got multiple values for keyword argument 'y'", lambda : f(5, y = 6)) # !!!
+        self.assertRaisesMessage(TypeError, "Argument for M320() given by name ('y') and position (1)", lambda : f(5, y = 6)) # !!!
         f(6, x = 7); Flag.Check(13)
 
-        # public void M330([DefaultParameterValue(50)] int x, [DefaultParameterValue(60)] int y) { Flag.Reset(); Flag.Set(x + y); }
+        # public void M330([DefaultParameterValue(50)] int x, [DefaultParameterValue(60)] int y) { Flag.Set(x + y); }
         f = self.o.M330
         f(); Flag.Check(110)
         f(1); Flag.Check(61)
@@ -298,23 +299,25 @@ class ArgumentsTest(IronPythonTestCase):
 
     def test_3_args(self):
         from Merlin.Testing import Flag
-        # public void M500(int x, int y, int z) { Flag.Reset(); Flag.Set(x * 100 + y * 10 + z); }
+        # public void M500(int x, int y, int z) { Flag.Set(x * 100 + y * 10 + z); }
         f = self.o.M500
         f(1, 2, 3); Flag.Check(123)
         f(y = 1, z = 2, x = 3); Flag.Check(312)
         f(3, *(2, 1)); Flag.Check(321)
         f(1, z = 2, **{'y':3}); Flag.Check(132)
         f(z = 1, **{'x':2, 'y':3}); Flag.Check(231)
-        f(1, z = 2, *(3,)); #Flag.Check(132)
+        f(1, z = 2, *(3,)); Flag.Check(132)
+        self.assertRaisesMessage(TypeError, "Argument for M500() given by name ('y') and position (2)", lambda: f(1, 2, y = 2)) # msg
 
-        # public void M510(int x, int y, [DefaultParameterValue(70)] int z) { Flag.Reset(); Flag.Set(x * 100 + y * 10 + z); }
+        # public void M510(int x, int y, [DefaultParameterValue(70)] int z) { Flag.Set(x * 100 + y * 10 + z); }
         f = self.o.M510
         f(1, 2); Flag.Check(120 + 70)
         f(2, y = 1); Flag.Check(210 + 70)
 
         f(1, 2, 3); Flag.Check(123)
+        self.assertRaisesMessage(TypeError, "Argument for M510() given by name ('y') and position (2)", lambda: f(1, 2, y = 2))
 
-        # public void M520(int x, [DefaultParameterValue(80)]int y, int z) { Flag.Reset(); Flag.Set(x * 100 + y * 10 + z); }
+        # public void M520(int x, [DefaultParameterValue(80)]int y, int z) { Flag.Set(x * 100 + y * 10 + z); }
         f = self.o.M520
         f(1, 2); Flag.Check(102 + 800)
         f(2, z = 1); Flag.Check(201 + 800)
@@ -324,16 +327,17 @@ class ArgumentsTest(IronPythonTestCase):
         f(1, z = 2, y = 3); Flag.Check(132)
         f(1, 2, 3); Flag.Check(123)
 
-        # public void M530([DefaultParameterValue(90)]int x, int y, int z) { Flag.Reset(); Flag.Set(x * 100 + y * 10 + z); }
+        # public void M530([DefaultParameterValue(90)]int x, int y, int z) { Flag.Set(x * 100 + y * 10 + z); }
         f = self.o.M530
         f(1, 2); Flag.Check(12 + 9000)
         f(3, z = 4); Flag.Check(34 + 9000)
         f(*(5,), **{'z':6}); Flag.Check(56 + 9000)
-        self.assertRaisesMessage(TypeError, "M530() got multiple values for keyword argument 'y'", lambda: f(2, y = 2)) # msg
+        self.assertRaisesMessage(TypeError, "Argument for M530() given by name ('y') and position (1)", lambda: f(2, y = 2)) # !!!
+        self.assertRaisesMessage(TypeError, "Argument for M530() given by name ('y') and position (2)", lambda: f(1, 2, y = 2))
 
         f(1, 2, 3); Flag.Check(123)
 
-        # public void M550(int x, int y, params int[] z) { Flag.Reset(); Flag.Set(x * 100 + y * 10 + z.Length); }
+        # public void M550(int x, int y, params int[] z) { Flag.Set(x * 100 + y * 10 + z.Length); }
         f = self.o.M550
         f(1, 2); Flag.Check(120)
         f(1, 2, 3); Flag.Check(121)
@@ -344,15 +348,19 @@ class ArgumentsTest(IronPythonTestCase):
 
         # bug 311155
         ##def  f(x, y, *z): print x, y, z
-        #f(1, y = 2); Flag.Check(120)
-        #f(x = 2, y = 3); Flag.Check(230)
-        #f(1, y = 2, *()); Flag.Check(120)
+        f(1, y = 2); Flag.Check(120)
+        f(x = 2, y = 3); Flag.Check(230)
+        f(1, y = 2, *()); Flag.Check(120)
 
-        #f(1, y = 2, *(3, )); Flag.Check(121)
-        #f(y = 2, x = 3; *(3, 4)); Flag.Check(322)
-        #f(1, *(2, 3), **{'y': 4}); Flag.Check(142)
-        #f(*(4, 5, 6), **{'y':7}); Flag.Check(472)
-        #f(*(1, 2, 0, 1), **{'y':3, 'x':4}); Flag.Check(434)
+        self.assertRaisesMessage(TypeError, "Argument for M550() given by name ('y') and position (2)", lambda: f(1, y = 2, *(3, )))
+        self.assertRaisesMessage(TypeError, "Argument for M550() given by name ('y') and position (2)", lambda: f(y = 2, x = 3, *(3, 4)))
+        self.assertRaisesMessage(TypeError, "Argument for M550() given by name ('y') and position (2)", lambda: f(1, *(2, 3), **{'y': 4}))
+        self.assertRaisesMessage(TypeError, "Argument for M550() given by name ('y') and position (2)", lambda: f(*(4, 5, 6), **{'y':7}))
+        self.assertRaises(TypeError, r"^Argument for M550\(\) given by name \('[xy]'\) and position \([12]\)$", lambda: f(*(1, 2, 0, 1), **{'y':3, 'x':4}))
+        #f(1, 2, 3, z=4, y=5, x=6) # FIXME: M550() takes at least 2 arguments (6 given) => e.g. Argument for M550() given by name ('x') and position (1)
+        #f(1, 2, **{'z':3, 'y':4}) # FIXME: M550() takes at least 2 arguments (4 given) => e.g. Argument for M550() given by name ('y') and position (2)
+        #f(*(1, 2, 0, 1), **{'z':3, 'y':4}) # FIXME: M550() takes at least 2 arguments (6 given) => e.g. Argument for M550() given by name ('x') and position (1)
+        #f(*(1, 2, 0, 1), **{'z':3, 'x':4}) # FIXME: M550() takes at least 2 arguments (6 given) => e.g. Argument for M550() given by name ('x') and position (1)
 
     def test_many_args(self):
         from Merlin.Testing import Flag
@@ -373,7 +381,8 @@ class ArgumentsTest(IronPythonTestCase):
         f(1, 2, 3, arg9 = 9, arg10 = 10, *(4, 5, 6, 7, 8)); # Flag[str].Check(expect)  # bug 311195
         f(1, 2, 3, arg10 = 10, *(4, 5, 6, 7, 8), ** {'arg9': 9}); # Flag[str].Check(expect) # bug 311195
 
-        self.assertRaisesMessage(TypeError, "M650() got multiple values for keyword argument 'arg5'", lambda: f(2, 3, arg5 = 5, arg10 = 10, *(4, 6, 7, 9), **{'arg8': 8, 'arg1': 1})) # msg (should be 6 given)
+        # msg below, should it be pos 4? (positon of the splatee) but 5 matches CPython
+        self.assertRaisesMessage(TypeError, "Argument for M650() given by name ('arg5') and position (5)", lambda: f(2, arg5 = 5, arg10 = 10, *(3, 4, 6, 7, 9), **{'arg8': 8, 'arg1': 1}))
 
         #public void M700(int arg1, string arg2, bool arg3, object arg4, EnumInt16 arg5, SimpleClass arg6, SimpleStruct arg7) { }
 
@@ -415,7 +424,7 @@ class ArgumentsTest(IronPythonTestCase):
         #public void M120(out int arg) { arg = 2; }
         f = obj.M120
         self.assertEqual(f(), 2)
-        #self.assertRaises(TypeError, lambda: f(1))  # bug 311218
+        self.assertRaises(TypeError, lambda: f(1))  # bug 311218
 
         x = self.box_int(); self.assertEqual(f(x), None); self.assertEqual(x.Value, 2)
         x = self.box_int(7); f(arg = x); self.assertEqual(x.Value, 2)
@@ -427,7 +436,7 @@ class ArgumentsTest(IronPythonTestCase):
         from Merlin.Testing.Call import ByRefParameters
         obj = ByRefParameters()
 
-        #public void M200(int arg1, ref int arg2) { Flag.Reset(); Flag.Value1 = arg1 * 10 + arg2; arg2 = 10; }
+        #public void M200(int arg1, ref int arg2) { Flag.Set(arg1 * 10 + arg2); arg2 = 10; }
         f = obj.M200
         self.assertEqual(f(1, 2), 10); Flag.Check(12)
         self.assertEqual(f(3, arg2 = 4), 10); Flag.Check(34)
@@ -440,12 +449,12 @@ class ArgumentsTest(IronPythonTestCase):
         x = self.box_int(7); f(3, *(x,)); self.assertEqual(x.Value, 10); Flag.Check(37)
         x = self.box_int(8); f(**{'arg1': 4, 'arg2' : x}); self.assertEqual(x.Value, 10); Flag.Check(48)
 
-        #public void M201(ref int arg1, int arg2) { Flag.Reset(); Flag.Value1 = arg1 * 10 + arg2; arg1 = 20; }
+        #public void M201(ref int arg1, int arg2) { Flag.Set(arg1 * 10 + arg2); arg1 = 20; }
         f = obj.M201
         self.assertEqual(f(1, 2), 20)
         x = self.box_int(2); f(x, *(2,)); self.assertEqual(x.Value, 20); Flag.Check(22)
 
-        #public void M202(ref int arg1, ref int arg2) { Flag.Reset(); Flag.Value1 = arg1 * 10 + arg2; arg1 = 30; arg2 = 40; }
+        #public void M202(ref int arg1, ref int arg2) { Flag.Set(arg1 * 10 + arg2); arg1 = 30; arg2 = 40; }
         f = obj.M202
         self.assertEqual(f(1, 2), (30, 40))
         self.assertEqual(f(arg2 = 1, arg1 = 2), (30, 40)); Flag.Check(21)
@@ -453,8 +462,8 @@ class ArgumentsTest(IronPythonTestCase):
         self.assertRaisesMessage(TypeError, "expected int, got StrongBox[int]", lambda: f(self.box_int(3), 4))  # bug 311239
         x = self.box_int(3)
         y = self.box_int(4)
-        #f(arg2 = y, *(x,)); Flag.Check(34) # bug 311169
-        self.assertRaisesMessage(TypeError, "M202() got multiple values for keyword argument 'arg1'", lambda: f(arg1 = x, *(y,))) # msg
+        f(arg2 = y, *(x,)); Flag.Check(34) # bug 311169
+        self.assertRaisesMessage(TypeError, "Argument for M202() given by name ('arg1') and position (1)", lambda: f(arg1 = x, *(y,)))
 
         # just curious
         x = y = self.box_int(5)
@@ -465,26 +474,26 @@ class ArgumentsTest(IronPythonTestCase):
         from Merlin.Testing.Call import ByRefParameters
         obj = ByRefParameters()
 
-        #public void M203(int arg1, out int arg2) { Flag.Reset(); Flag.Value1 = arg1 * 10; arg2 = 50; }
+        #public void M203(int arg1, out int arg2) { Flag.Set(arg1 * 10); arg2 = 50; }
         f = obj.M203
         self.assertEqual(f(1), 50)
         self.assertEqual(f(*(2,)), 50)
-        #self.assertRaises(TypeError, lambda: f(1, 2))  # bug 311218
+        self.assertRaises(TypeError, lambda: f(1, 2))  # bug 311218
 
         x = self.box_int(4)
         f(1, x); self.assertEqual(x.Value, 50)
 
-        #public void M204(out int arg1, int arg2) { Flag.Reset(); Flag.Value1 = arg2; arg1 = 60; }
+        #public void M204(out int arg1, int arg2) { Flag.Set(arg2); arg1 = 60; }
         # TODO
 
         #public void M205(out int arg1, out int arg2) { arg1 = 70; arg2 = 80; }
         f = obj.M205
         self.assertEqual(f(), (70, 80))
-        self.assertRaisesMessage(TypeError, "M205() takes at most 2 arguments (1 given)", lambda: f(1))
-        #self.assertRaisesMessage(TypeError, "M205() ??)", lambda: f(1, 2))
+        self.assertRaisesMessage(TypeError, "M205() takes at most 2 arguments (1 given)", lambda: f(1)) # FIXME: msg
+        self.assertRaisesMessage(TypeError, "expected StrongBox[int], got int", lambda: f(1, 2))
 
-        self.assertRaisesMessage(TypeError, "M205() takes at most 2 arguments (1 given)", lambda: f(arg2 = self.box_int(2)))
-        self.assertRaisesMessage(TypeError, "M205() takes at most 2 arguments (1 given)", lambda: f(arg1 = self.box_int(2)))
+        self.assertRaisesMessage(TypeError, "M205() takes at most 2 arguments (1 given)", lambda: f(arg2 = self.box_int(2))) # FIXME: msg
+        self.assertRaisesMessage(TypeError, "M205() takes at most 2 arguments (1 given)", lambda: f(arg1 = self.box_int(2))) # FIXME: msg
 
         for l in [
             lambda: f(*(x, y)),
@@ -500,7 +509,7 @@ class ArgumentsTest(IronPythonTestCase):
             self.assertEqual(y.Value, 80)
 
 
-        #public void M206(ref int arg1, out int arg2) { Flag.Reset(); Flag.Value1 = arg1 * 10; arg1 = 10; arg2 = 20; }
+        #public void M206(ref int arg1, out int arg2) { Flag.Set(arg1 * 10); arg1 = 10; arg2 = 20; }
         f = obj.M206
         self.assertEqual(f(1), (10, 20))
         self.assertEqual(f(arg1 = 2), (10, 20))
@@ -510,12 +519,12 @@ class ArgumentsTest(IronPythonTestCase):
         x, y = self.box_int(4), self.box_int(5)
         f(x, y); self.assertEqual(x.Value, 10); self.assertEqual(y.Value, 20);
 
-        #public void M207(out int arg1, ref int arg2) { Flag.Reset(); Flag.Value1 = arg2; arg1 = 30; arg2 = 40; }
+        #public void M207(out int arg1, ref int arg2) { Flag.Set(arg2); arg1 = 30; arg2 = 40; }
 
         f = obj.M207
         self.assertEqual(f(1), (30, 40))
         self.assertEqual(f(arg2 = 2), (30, 40)); Flag.Check(2)
-        #self.assertRaises(TypeError, lambda: f(1, 2))
+        self.assertRaises(TypeError, lambda: f(1, 2))
         self.assertRaises(TypeError, lambda: f(arg2 = 1, arg1 = 2))
 
         for l in [


### PR DESCRIPTION
Matches IronLanguages/dlr#247.

Tests marked with `# msg` may need a review. I think the messages are correct, but a different message (from a different angle) would also be acceptable.

Labels `!!!` or `FIXME` indicate unexpected or erroneous behaviour.

`TODO` means more tests needed.