### PR TITLE
Fix assertion for IsCContiguous test on IPythonBuffer

### DIFF
--- a/Src/IronPython/Runtime/BufferProtocol.cs
+++ b/Src/IronPython/Runtime/BufferProtocol.cs
@@ -246,7 +246,7 @@ namespace IronPython.Runtime {
             => new BufferBytesEnumerator(buffer);
 
         public static bool IsCContiguous(this IPythonBuffer buffer) {
-            Debug.Assert(buffer.Offset == 0);
+            Debug.Assert(buffer.Strides != null || buffer.Offset == 0);
             return buffer.Strides == null;
         }
 


### PR DESCRIPTION
The assertion was too restrictive.