### PR TITLE
Add command line argument to disable importlib bootstrapping

### DIFF
--- a/Src/IronPython/Hosting/PythonOptionsParser.cs
+++ b/Src/IronPython/Hosting/PythonOptionsParser.cs
@@ -190,6 +190,12 @@ namespace IronPython.Hosting {
                     ConsoleOptions.BasicConsole = true;
                     break;
 
+#if DEBUG
+                case "-X:NoImportLib":
+                    LanguageSetup.Options["NoImportLib"] = ScriptingRuntimeHelpers.True;
+                    break;
+#endif
+
                 default:
                     if(arg.StartsWith("-W")) {
                         if (_warningFilters == null) {
@@ -261,6 +267,9 @@ namespace IronPython.Hosting {
                 { "-X:EnableProfiler",      "Enables profiling support in the compiler" },
                 { "-X:LightweightScopes",   "Generate optimized scopes that can be garbage collected" },
                 { "-X:BasicConsole",        "Use only the basic console features" },
+#if DEBUG
+                { "-X:NoImportLib",         "Don't bootstrap importlib" },
+#endif
             };
 
             // Ensure the combined options come out sorted

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -294,6 +294,7 @@ namespace IronPython.Runtime {
             _mainThreadFunctionStack = PythonOps.GetFunctionStack();
 
             // bootstrap importlib
+            if (PythonOptions.NoImportLib) return;
             try {
                 var sourceUnit = CreateSourceUnit(new BootstrapStreamContentProvider(), null, DefaultEncoding, SourceCodeKind.File);
 

--- a/Src/IronPython/Runtime/PythonOptions.cs
+++ b/Src/IronPython/Runtime/PythonOptions.cs
@@ -120,6 +120,8 @@ namespace IronPython.Runtime {
 
         public bool Quiet { get; }
 
+        internal bool NoImportLib { get; } // TODO: get rid of me when we no longer bootstrap importlib
+
         public PythonOptions() 
             : this(null) {
         }
@@ -149,6 +151,9 @@ namespace IronPython.Runtime {
             Tracing = GetOption(options, "Tracing", false);
             NoDebug = GetOption(options, "NoDebug", (Regex)null);
             Quiet = GetOption(options, "Quiet", false);
+#if DEBUG
+            NoImportLib = GetOption(options, "NoImportLib", false);
+#endif
         }
 
         private static IDictionary<string, object> EnsureSearchPaths(IDictionary<string, object> options) {


### PR DESCRIPTION
I often find myself disabling the importlib bootstrapping when debugging, this adds an options to do it without having to amend the code.