### PR TITLE
Update tests to expect no binding by keyword to *args/**kwargs

### DIFF
--- a/Tests/test_dlrkwarg.py
+++ b/Tests/test_dlrkwarg.py
@@ -74,13 +74,10 @@ class DlrKwargTest(IronPythonTestCase):
         self.assertRaisesMessage(TypeError, "FuncWithIRoDictGenSOKwargs() takes no arguments (1 given)",
             Variadics.FuncWithIRoDictGenSOKwargs, {})
 
-        # TODO: this should not work, 'kwargs' should be a key in 'kwargs' dict passed to the builtin function
+    def test_keyword_arg(self):
         clrdict = System.Collections.Generic.Dictionary[System.String, System.Object]()
-        self.assertEqual(Variadics.FuncWithIRoDictGenSOKwargs(kwargs=clrdict), 0)
-
-        # TODO: This should work
-        #self.assertEqual(Variadics.FuncWithIRoDictGenSOKwargs(kwargs={}), 'kwargs')
-        #self.assertEqual(Variadics.FuncWithIRoDictGenSOKwargs(kwargs=clrdict), 'kwargs')
+        self.assertEqual(Variadics.FuncWithIRoDictGenSOKwargs(kwargs=clrdict), 1) # no binding by keyword
+        self.assertEqual(Variadics.FuncWithIRoDictGenSOKwargs(kwargs={}), 1)
 
     def test_attribcol(self):
         self.assertRaisesMessage(SystemError, "Unsupported param dictionary type: System.ComponentModel.AttributeCollection",

--- a/Tests/test_function.py
+++ b/Tests/test_function.py
@@ -347,6 +347,20 @@ class FunctionTest(IronPythonTestCase):
             self.assertTrue(SplatTest2.FuncWithIDictGenOOKwargs(**mymapping({mystr("bla"): "bla"})))
             self.assertTrue(SplatTest2.FuncWithIDictGenSOKwargs(**mymapping({mystr("bla"): "bla"})))
 
+    def test_kwargs4(self):
+        """verify args/kwargs are not bindable by name or position"""
+
+        def foo(*args, **kwargs):
+            return args, kwargs
+
+        self.assertEqual(foo(), ((), {}))
+        self.assertEqual(foo(args=()), ((), {'args': ()}))
+        self.assertEqual(foo(kwargs={}), ((), {'kwargs': {}}))
+        self.assertEqual(foo(args=(), kwargs={}), ((), {'args': (), 'kwargs': {}}))
+        self.assertEqual(foo(()), (((),), {}))
+        self.assertEqual(foo({}), (({},), {}))
+        self.assertEqual(foo((), {}), (((), {}), {}))
+
     @skipUnlessIronPython()
     def test_params_method_no_params(self):
         """call a params method w/ no params"""


### PR DESCRIPTION
Matches IronLanguages/dlr#250.