### PR TITLE
Fix __doc__ string processing

### DIFF
--- a/Src/IronPython/Runtime/Types/DocBuilder.cs
+++ b/Src/IronPython/Runtime/Types/DocBuilder.cs
@@ -733,11 +733,12 @@ namespace IronPython.Runtime.Types {
                             switch (xr.Name) {
                                 case "see":
                                     if (xr.MoveToFirstAttribute() && xr.ReadAttributeValue()) {
+                                        int prefixlen = xr.Value.IndexOf(':') + 1;
                                         int arity = xr.Value.IndexOf(ReflectionUtils.GenericArityDelimiter);
                                         if (arity != -1)
-                                            text.Append(xr.Value, 2, arity - 2);
+                                            text.Append(xr.Value, prefixlen, arity - prefixlen);
                                         else
-                                            text.Append(xr.Value, 2, xr.Value.Length - 2);
+                                            text.Append(xr.Value, prefixlen, xr.Value.Length - prefixlen);
                                     }
                                     break;
                                 case "paramref":


### PR DESCRIPTION
Fixes:
```
>>> import System
>>> help(System.Math.Exp)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\_sitebuiltins.py", line 103, in __call__
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1843, in __call__
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1876, in help
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1630, in doc
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1623, in render_doc
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 373, in document
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1364, in docroutine
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 90, in getdoc
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\inspect.py", line 477, in getdoc
ValueError: Value must be positive.
Parameter name: count
```