### PR TITLE
Handle generic parameter types as return types of builtins in DocBuilder

### DIFF
--- a/Src/IronPython/Runtime/Types/DocBuilder.cs
+++ b/Src/IronPython/Runtime/Types/DocBuilder.cs
@@ -305,7 +305,7 @@ namespace IronPython.Runtime.Types {
                 paramDoc.Add(
                     new ParameterDoc(
                         pi.Name ?? "",  // manufactured methods, such as string[].ctor(int) can have no parameter names.
-                        pi.ParameterType.IsGenericParameter ? pi.ParameterType.Name : GetPythonTypeName(pi.ParameterType),
+                        GetPythonTypeName(pi.ParameterType),
                         paramDocString,
                         flags
                     )
@@ -398,6 +398,10 @@ namespace IronPython.Runtime.Types {
         }
 
         private static string GetPythonTypeName(Type type) {
+            if (type.IsGenericParameter) {
+                return type.Name;
+            }
+
             if (type.IsByRef) {
                 type = type.GetElementType();
             }

--- a/Src/IronPython/Runtime/Types/DocBuilder.cs
+++ b/Src/IronPython/Runtime/Types/DocBuilder.cs
@@ -398,12 +398,12 @@ namespace IronPython.Runtime.Types {
         }
 
         private static string GetPythonTypeName(Type type) {
-            if (type.IsGenericParameter) {
-                return type.Name;
-            }
-
             if (type.IsByRef) {
                 type = type.GetElementType();
+            }
+
+            if (type.IsGenericParameter) {
+                return type.Name;
             }
 
             return DynamicHelpers.GetPythonTypeFromType(type).Name;

--- a/Src/IronPython/Runtime/Types/DynamicHelpers.cs
+++ b/Src/IronPython/Runtime/Types/DynamicHelpers.cs
@@ -17,7 +17,7 @@ namespace IronPython.Runtime.Types {
 
             PerfTrack.NoteEvent(PerfTrack.Categories.DictInvoke, "TypeLookup " + type.FullName);
 
-            return PythonType.GetPythonType(type) ?? throw Operations.PythonOps.TypeError("Type {0} cannot be represented as a Python type", type);
+            return PythonType.GetPythonType(type);
         }
 
         public static PythonType GetPythonType(object? o) {

--- a/Src/IronPython/Runtime/Types/DynamicHelpers.cs
+++ b/Src/IronPython/Runtime/Types/DynamicHelpers.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
+
 using Microsoft.Scripting;
 using Microsoft.Scripting.Generation;
 using Microsoft.Scripting.Utils;
@@ -14,17 +17,17 @@ namespace IronPython.Runtime.Types {
 
             PerfTrack.NoteEvent(PerfTrack.Categories.DictInvoke, "TypeLookup " + type.FullName);
 
-            return PythonType.GetPythonType(type);
+            return PythonType.GetPythonType(type) ?? throw Operations.PythonOps.TypeError("Type {0} cannot be represented as a Python type", type);
         }
 
-        public static PythonType GetPythonType(object o) {
+        public static PythonType GetPythonType(object? o) {
             if (o is IPythonObject dt) return dt.PythonType;
 
             return GetPythonTypeFromType(CompilerHelpers.GetType(o));
         }
 
-        public static ReflectedEvent.BoundEvent MakeBoundEvent(ReflectedEvent eventObj, object instance, Type type) {
-            return new ReflectedEvent.BoundEvent(eventObj, instance, DynamicHelpers.GetPythonTypeFromType(type));
+        public static ReflectedEvent.BoundEvent MakeBoundEvent(ReflectedEvent eventObj, object? instance, Type type) {
+            return new ReflectedEvent.BoundEvent(eventObj, instance, GetPythonTypeFromType(type));
         }
     }
 }

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -127,9 +127,6 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// </summary>
         /// <param name="underlyingSystemType"></param>
         internal PythonType(Type underlyingSystemType) {
-            if (underlyingSystemType.IsGenericParameter)
-                throw new ArgumentException($"Generic parameter type {underlyingSystemType} cannot be represented by a Python type", nameof(underlyingSystemType));
-
             _underlyingSystemType = underlyingSystemType;
 
             InitializeSystemType();
@@ -182,10 +179,6 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// </summary>
         internal PythonType(PythonType[] baseTypes, Type underlyingType, string name, Func<string, Exception, Exception> exceptionMaker)
             : this(baseTypes, name) {
-
-            if (underlyingType.IsGenericParameter)
-                throw new ArgumentException($"Generic parameter type {underlyingType} cannot be represented by a Python type", nameof(underlyingType));
-
             _underlyingSystemType = underlyingType;
             _makeException = exceptionMaker;
         }
@@ -776,10 +769,10 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        internal static PythonType GetPythonType(Type type) {
-            if (type.IsGenericParameter) return null;
-
-            if (!_pythonTypes.TryGetValue(type, out object res)) {
+        internal static PythonType/*!*/ GetPythonType(Type type) {
+            object res;
+            
+            if (!_pythonTypes.TryGetValue(type, out res)) {
                 lock (_pythonTypes) {
                     if (!_pythonTypes.TryGetValue(type, out res)) {
                         res = new PythonType(type);

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -127,6 +127,9 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// </summary>
         /// <param name="underlyingSystemType"></param>
         internal PythonType(Type underlyingSystemType) {
+            if (underlyingSystemType.IsGenericParameter)
+                throw new ArgumentException($"Generic parameter type {underlyingSystemType} cannot be represented by a Python type", nameof(underlyingSystemType));
+
             _underlyingSystemType = underlyingSystemType;
 
             InitializeSystemType();
@@ -179,6 +182,10 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// </summary>
         internal PythonType(PythonType[] baseTypes, Type underlyingType, string name, Func<string, Exception, Exception> exceptionMaker)
             : this(baseTypes, name) {
+
+            if (underlyingType.IsGenericParameter)
+                throw new ArgumentException($"Generic parameter type {underlyingType} cannot be represented by a Python type", nameof(underlyingType));
+
             _underlyingSystemType = underlyingType;
             _makeException = exceptionMaker;
         }
@@ -769,10 +776,10 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        internal static PythonType/*!*/ GetPythonType(Type type) {
-            object res;
-            
-            if (!_pythonTypes.TryGetValue(type, out res)) {
+        internal static PythonType GetPythonType(Type type) {
+            if (type.IsGenericParameter) return null;
+
+            if (!_pythonTypes.TryGetValue(type, out object res)) {
                 lock (_pythonTypes) {
                     if (!_pythonTypes.TryGetValue(type, out res)) {
                         res = new PythonType(type);

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -764,7 +764,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// <summary>
         /// Gets the dynamic type that corresponds with the provided static type. 
         /// 
-        /// Returns null if no type is available.  TODO: In the future this will
+        /// TODO: In the future this will
         /// always return a PythonType created by the DLR.
         /// </summary>
         /// <param name="type"></param>
@@ -777,7 +777,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                     if (!_pythonTypes.TryGetValue(type, out res)) {
                         res = new PythonType(type);
 
-                        _pythonTypes.Add(type, res);
+                       _pythonTypes.Add(type, res);
                     }
                 }
             }
@@ -2325,7 +2325,17 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             lock (_bases) {
                 _bases = bases;
             }
-            
+
+            if (_underlyingSystemType.IsGenericParameter) {
+                // add all interfaces into the MRO
+                foreach (Type t in interfaces) {
+                    Debug.Assert(t.IsInterface);
+
+                    mro.Add(DynamicHelpers.GetPythonTypeFromType(t));
+                }
+                return; // end of story for generic parameter types
+            }
+
             foreach (Type iface in interfaces) {
 #if NET46
                 // causes failures on Mono: https://github.com/mono/mono/issues/14712


### PR DESCRIPTION
Fixes:
```
>>> import System
>>> help(System.Reflection.CustomAttributeExtensions.GetCustomAttribute)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\_sitebuiltins.py", line 103, in __call__
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1843, in __call__
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1876, in help
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1630, in doc
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1623, in render_doc
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 373, in document
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 1364, in docroutine
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\pydoc.py", line 90, in getdoc
  File "C:\Code\ironlang\ironpython3\Src\StdLib\Lib\inspect.py", line 477, in getdoc
SystemError: Method must be called on a Type for which Type.IsGenericParameter is false.
```

The documentation on `PythonType.GetPythonType(Type type)` says it may return `null` if no type is available. So this is what it does now. However, this code path (chiefly though `DynamicHelpers.GetPythonTypeFromType`) is used in a lot of places that do not check for null. From nullability annotation point of view, it would be good to keep the return type of `GetPythonTypeFromType` non-nullable, but how to handle errors? `ArgumentException`?