### PR TITLE
Bypass _scproxy import on macOS

### DIFF
--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -507,10 +507,6 @@ Ignore=true
 Ignore=true
 Reason=TypeError: __next__() takes exactly 1 argument (1 given)
 
-[CPython.test_http_cookiejar]
-RunCondition=NOT $(IS_DEBUG) AND NOT $(IS_OSX)
-Reason=Raises an assertion error in Debug / ImportError: No module named _scproxy (on macOS)
-
 [CPython.test_httplib]
 Ignore=true
 Reason=Blocking

--- a/Src/StdLib/Lib/urllib/request.py
+++ b/Src/StdLib/Lib/urllib/request.py
@@ -2429,7 +2429,7 @@ def _proxy_bypass_macosx_sysconf(host, proxy_settings):
     return False
 
 
-if sys.platform == 'darwin':
+if sys.platform == 'darwin' and sys.implementation.name != "ironpython": # https://github.com/IronLanguages/ironpython3/issues/1050
     from _scproxy import _get_proxy_settings, _get_proxies
 
     def proxy_bypass_macosx_sysconf(host):


### PR DESCRIPTION
Workaround for https://github.com/IronLanguages/ironpython3/issues/1050