### PR TITLE
Fix binding freevars in comprehension scope

### DIFF
--- a/Src/IronPython/Compiler/Ast/Comprehension.cs
+++ b/Src/IronPython/Compiler/Ast/Comprehension.cs
@@ -239,7 +239,8 @@ namespace IronPython.Compiler.Ast {
 
         internal override bool TryBindOuter(ScopeStatement from, PythonReference reference, out PythonVariable variable) {
             ContainsNestedFreeVariables = true;
-            if (TryGetVariable(reference.Name, out variable) && variable.Kind != VariableKind.Nonlocal) {
+            if (TryGetVariable(reference.Name, out variable)) {
+                Debug.Assert(variable.Kind != VariableKind.Nonlocal, "there should be no nonlocals in a comprehension");
                 variable.AccessedInNestedScope = true;
 
                 if (variable.Kind == VariableKind.Local || variable.Kind == VariableKind.Parameter) {

--- a/Src/IronPython/Compiler/Ast/Comprehension.cs
+++ b/Src/IronPython/Compiler/Ast/Comprehension.cs
@@ -237,6 +237,27 @@ namespace IronPython.Compiler.Ast {
             return MSAst.Expression.Call(null, typeof(PythonOps).GetMethod(nameof(PythonOps.GetClosureTupleFromContext)), _comprehension.Parent.LocalContext);
         }
 
+        internal override bool TryBindOuter(ScopeStatement from, PythonReference reference, out PythonVariable variable) {
+            ContainsNestedFreeVariables = true;
+            if (TryGetVariable(reference.Name, out variable) && variable.Kind != VariableKind.Nonlocal) {
+                variable.AccessedInNestedScope = true;
+
+                if (variable.Kind == VariableKind.Local || variable.Kind == VariableKind.Parameter) {
+                    from.AddFreeVariable(variable, true);
+
+                    for (ScopeStatement scope = from.Parent; scope != this; scope = scope.Parent) {
+                        scope.AddFreeVariable(variable, false);
+                    }
+
+                    AddCellVariable(variable);
+                } else {
+                    from.AddReferencedGlobal(reference.Name);
+                }
+                return true;
+            }
+            return false;
+        }
+
         internal override PythonVariable BindReference(PythonNameBinder binder, PythonReference reference) {
             if (TryGetVariable(reference.Name, out PythonVariable variable)) {
                 if (variable.Kind == VariableKind.Global) {

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -570,9 +570,6 @@ Ignore=true
 IsolationLevel=ENGINE
 MaxRecursion=100
 
-[CPython.test_listcomps]
-Ignore=true
-
 [CPython.test_locale]
 Ignore=true
 
@@ -830,9 +827,6 @@ Ignore=true
 [CPython.test_set]
 RunCondition=NOT $(IS_MONO) # weakref failures; https://github.com/IronLanguages/ironpython3/issues/544
 IsolationLevel=PROCESS # Also weakref failures; https://github.com/IronLanguages/ironpython3/issues/489
-
-[CPython.test_setcomps]
-Ignore=true
 
 [CPython.test_shelve]
 NotParallelSafe=true


### PR DESCRIPTION
`[lambda: i for i in [1,2]]` should bind the `i` correctly now.