### PR TITLE
Enable test_memory

### DIFF
--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -40,7 +40,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         private PythonTypeAttributes _attrs;                // attributes of the type
         private int _flags;                                 // CPython-like flags on the type
         private int _version = GetNextVersion();            // version of the type
-        private List<WeakReference> _subtypes;              // all of the subtypes of the PythonType
+        private List<WeakReference<PythonType>> _subtypes;  // all of the subtypes of the PythonType
         private PythonContext _pythonContext;               // the context the type was created from, or null for system types.
         private bool? _objectNew, _objectInit;              // true if the type doesn't override __new__ / __init__ from object.
         internal Dictionary<CachedGetKey, FastGetBase> _cachedGets; // cached gets on user defined type instances
@@ -79,7 +79,6 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         private static int MasterVersion = 1;
         private static readonly CommonDictionaryStorage _pythonTypes = new CommonDictionaryStorage();
         internal static readonly PythonType _pythonTypeType = DynamicHelpers.GetPythonTypeFromType(typeof(PythonType));
-        private static readonly WeakReference[] _emptyWeakRef = new WeakReference[0];
         private static object _subtypesLock = new object();
         internal static readonly Func<string, Exception, Exception> DefaultMakeException = (message, innerException) => new Exception(message, innerException);
         internal static readonly Func<string, Exception> DefaultMakeExceptionNoInnerException = (message) => new Exception(message);
@@ -658,17 +657,15 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 
         public PythonList __subclasses__(CodeContext/*!*/ context) {
             PythonList ret = new PythonList();
-            IList<WeakReference> subtypes = SubTypes;
+            var subtypes = SubTypes;
 
             if (subtypes != null) {
                 PythonContext pc = context.LanguageContext;
 
-                foreach (WeakReference wr in subtypes) {
-                    if (wr.IsAlive) {
-                        PythonType pt = (PythonType)wr.Target;
-
+                foreach (var wr in subtypes) {
+                    if (wr.TryGetTarget(out PythonType pt)) {
                         if (pt.PythonContext == null || pt.PythonContext == pc) {
-                            ret.AddNoLock(wr.Target);
+                            ret.AddNoLock(pt);
                         }
                     }
                 }
@@ -1267,8 +1264,8 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         private void ClearObjectNewInSubclasses(PythonType pt) {
             lock (_subtypesLock) {
                 if (pt._subtypes != null) {
-                    foreach (WeakReference wr in pt._subtypes) {
-                        if (wr.Target is PythonType type) {
+                    foreach (var wr in pt._subtypes) {
+                        if (wr.TryGetTarget(out PythonType type)) {
                             type._objectNew = null;
 
                             ClearObjectNewInSubclasses(type);
@@ -1281,8 +1278,8 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         private void ClearObjectInitInSubclasses(PythonType pt) {
             lock (_subtypesLock) {
                 if (pt._subtypes != null) {
-                    foreach (WeakReference wr in pt._subtypes) {
-                        if (wr.Target is PythonType type) {
+                    foreach (var wr in pt._subtypes) {
+                        if (wr.TryGetTarget(out PythonType type)) {
                             type._objectInit = null;
 
                             ClearObjectInitInSubclasses(type);
@@ -2452,9 +2449,9 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         #region Private implementation details
 
         private void UpdateVersion() {
-            foreach (WeakReference wr in SubTypes) {
-                if (wr.IsAlive) {
-                    ((PythonType)wr.Target).UpdateVersion();
+            foreach (var wr in SubTypes) {
+                if (wr.TryGetTarget(out PythonType pt)) {
+                    pt.UpdateVersion();
                 }
             }
 
@@ -2484,31 +2481,32 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                     null);
             }
         }
-      
+
         /// <summary>
         /// Internal helper function to add a subtype
         /// </summary>
         private void AddSubType(PythonType subtype) {
             if (_subtypes == null) {
-                Interlocked.CompareExchange<List<WeakReference>>(ref _subtypes, new List<WeakReference>(), null);
+                Interlocked.CompareExchange(ref _subtypes, new List<WeakReference<PythonType>>(), null);
             }
 
             lock (_subtypesLock) {
-                _subtypes.Add(new WeakReference(subtype));
+                _subtypes.Add(new WeakReference<PythonType>(subtype));
             }
         }
 
         private void RemoveSubType(PythonType subtype) {
-            int i = 0;
-            if (_subtypes != null) {
-                lock (_subtypesLock) {
-                    while (i < _subtypes.Count) {
-                        if (!_subtypes[i].IsAlive || _subtypes[i].Target == subtype) {
-                            _subtypes.RemoveAt(i);
-                            continue;
-                        }
-                        i++;
+            if (_subtypes is null) return;
+
+            lock (_subtypesLock) {
+                int i = 0;
+                while (i < _subtypes.Count) {
+                    var wr = _subtypes[i];
+                    if (!wr.TryGetTarget(out PythonType target) || target == subtype) {
+                        _subtypes.RemoveAt(i);
+                        continue;
                     }
+                    i++;
                 }
             }
         }
@@ -2517,9 +2515,9 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// Gets a list of weak references to all the subtypes of this class.  May return null
         /// if there are no subtypes of the class.
         /// </summary>
-        private IList<WeakReference> SubTypes {
+        private IList<WeakReference<PythonType>> SubTypes {
             get {
-                if (_subtypes == null) return _emptyWeakRef;
+                if (_subtypes == null) return Array.Empty<WeakReference<PythonType>>();
 
                 lock (_subtypesLock) {
                     return _subtypes.ToArray();

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -2491,6 +2491,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             }
 
             lock (_subtypesLock) {
+                _subtypes.RemoveAll(x => !x.TryGetTarget(out _)); // remove dead entries
                 _subtypes.Add(new WeakReference<PythonType>(subtype));
             }
         }

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -62,12 +62,6 @@ Reason=New test needs to be written for new csharp version
 Ignore=true
 Reason=Assertion error
 
-[IronPython.test_memory]
-#RunCondition=NOT $(IS_POSIX)
-#Reason=Memory allocation on Mono may not match MS.NET
-Ignore=true
-Reason=Fails intermittently - https://github.com/IronLanguages/ironpython3/issues/508
-
 [IronPython.test_number]
 Timeout=300000 # 5 minute timeout - slow on macOS
 

--- a/Tests/test_memory.py
+++ b/Tests/test_memory.py
@@ -82,9 +82,9 @@ class MemoryTest(unittest.TestCase):
         from Microsoft.Scripting.Generation import Snippets
 
         self.skipMemoryCheck = Snippets.Shared.SaveSnippets or clr.GetCurrentRuntime().Configuration.DebugMode
-        self.expectedMem = 24000
 
         # account for adaptive compilation
+        self.expectedMem = 24000
         if is_cli64:
             self.expectedMem = int(self.expectedMem*1.25)
 


### PR DESCRIPTION
The issue is that the `PythonType._subtypes` list (which is used for the `__subclasses__` method) is growing every time a new subclass is created and not getting cleaned up as types get GCd. This is not actually a regression with ipy2, if you swap the class definitions with new-style classes then it also fails there.

I'm not super happy with the perf impact of this solution but I'm not sure what else to do (other than adding a finalizer to PythonType). @BCSharp any other ideas?

Resolves https://github.com/IronLanguages/ironpython3/issues/508

