### PR TITLE
Support rewriting of comprehension scopes

### DIFF
--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -250,6 +250,7 @@ namespace IronPython.Compiler.Ast {
 
         public override bool Walk(ListComprehension node) {
             node.Parent = _currentScope;
+            node.Scope.Parent = _currentScope;
             PushScope(node.Scope);
             return base.Walk(node);
         }

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -250,7 +250,6 @@ namespace IronPython.Compiler.Ast {
 
         public override bool Walk(ListComprehension node) {
             node.Parent = _currentScope;
-            node.Scope.Parent = _currentScope;
             PushScope(node.Scope);
             return base.Walk(node);
         }

--- a/Src/IronPythonTest/EngineTest.cs
+++ b/Src/IronPythonTest/EngineTest.cs
@@ -619,6 +619,26 @@ class K(object):
         }
 
         [Test]
+        public static void ScenarioComprehensionScope() {
+            var engine = Python.CreateEngine();
+            var scope = engine.CreateScope();
+            var source = engine.CreateScriptSourceFromString("assert [lambda: i for i in [1,2]][0]() == 2");
+            var compiledCode = source.Compile();
+            compiledCode.Execute(scope);
+        }
+
+        [Test]
+        public static void ScenarioComprehensionScopeGlobal() {
+            var engine = Python.CreateEngine();
+            var source = engine.CreateScriptSourceFromString("assert [lambda: i for i in global_list][0]() == res");
+            var compiledCode = source.Compile();
+            var scope = engine.CreateScope();
+            scope.SetVariable("global_list", new[] { 1, 2 });
+            scope.SetVariable("res", 2);
+            compiledCode.Execute(scope);
+        }
+
+        [Test]
         public static void ScenarioInterfaceExtensions() {
             var engine = Python.CreateEngine();
             engine.Runtime.LoadAssembly(typeof(Fooable).Assembly);

--- a/Src/StdLib/Lib/sre_compile.py
+++ b/Src/StdLib/Lib/sre_compile.py
@@ -64,7 +64,7 @@ _equivalences = (
 )
 
 # Maps the lowercase code to lowercase codes which have the same uppercase.
-_ignorecase_fixes = {i: tuple([j for j in t if i != j]) # https://github.com/IronLanguages/ironpython3/issues/817
+_ignorecase_fixes = {i: tuple(j for j in t if i != j)
                      for t in _equivalences for i in t}
 
 def _compile(code, pattern, flags):


### PR DESCRIPTION
Resolves #817.

Redesigning the inheritance hierarchy would have been a more elegant solution, but that perhaps for another time.

Credit for the tests to the work/discussion done under #1073.

@slozier @isaiah 