### PR TITLE
Remove IsolationLevel on test_dictcomp and test_setcomp

### DIFF
--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -24,9 +24,6 @@ Reason=disabled in IronLanguages/main, needs lots of work
 [IronPython.test_delegate]
 RetryCount=2
 
-[IronPython.test_dictcomp]
-IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
-
 [IronPython.test_doc]
 RunCondition=NOT $(IS_OSX) # TODO: figure out
 IsolationLevel=PROCESS # required to have quit/exit
@@ -91,9 +88,6 @@ RetryCount=2
 [IronPython.test_regressions_compiled]
 IsolationLevel=PROCESS
 Arguments=-X:CompilationThreshold 0 "$(TEST_FILE)" # ensure CompilationThreshold is 0 otherwise tests are meaningless!
-
-[IronPython.test_setcomp]
-IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 
 [IronPython.test_stdconsole]
 Timeout=600000 # 10 minute timeout


### PR DESCRIPTION
Part of https://github.com/IronLanguages/ironpython3/issues/489. I believe the issue was fixed with https://github.com/IronLanguages/ironpython3/pull/1083.