### PR TITLE
Class variable

### DIFF
--- a/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -626,18 +626,6 @@ namespace IronPython.Compiler.Ast {
 
             CreateFunctionVariables(locals, init);
 
-            // If the __class__ variable is used in a class method then we need to initialize it.
-            // This must be done before parameter initialization (in case one of the parameters is called __class__).
-            ClassDefinition parent = FindParentOfType<ClassDefinition>();
-            if (parent != null && TryGetVariable("__class__", out PythonVariable pVar)) {
-                init.Add(
-                    AssignValue(
-                        GetVariableExpression(pVar),
-                        Ast.Call(AstMethods.LookupName, parent.Parent.LocalContext, Ast.Constant(parent.Name))
-                    )
-                );
-            }
-
             // Initialize parameters - unpack tuples.
             // Since tuples unpack into locals, this must be done after locals have been created.
             InitializeParameters(init, needsWrapperMethod, parameters);

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -204,6 +204,7 @@ namespace IronPython.Compiler.Ast {
         // ClassDefinition
         public override bool Walk(ClassDefinition node) {
             node.PythonVariable = DefineName(node.Name);
+            node.CreateClassVariable();
 
             // Base references are in the outer context
             foreach (Expression b in node.Bases) b.Walk(this);
@@ -216,7 +217,7 @@ namespace IronPython.Compiler.Ast {
                     dec.Walk(this);
                 }
             }
-            
+
             PushScope(node);
 
             node.ModuleNameVariable = _globalScope.EnsureGlobalVariable("__name__");

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -1938,28 +1938,8 @@ namespace IronPython.Compiler {
                     NextToken();
                     string name = (string)t.Value;
                     ParserSink?.StartName(GetSourceSpan(), name);
-                    var fixedName = FixName(name);
-                    if (ShouldReplaceClassKeyword(fixedName)) {
-                        // if `__class__` variable is used in a class method, replace with `name_of_the_class`.
-                        ret = new NameExpression(CurrentClass.Name);
-                    } else {
-                        ret = new NameExpression(fixedName);
-                    }
+                    ret = new NameExpression(FixName(name));
                     ret.SetLoc(_globalParent, GetStart(), GetEnd());
-
-                    bool ShouldReplaceClassKeyword(string fixedName) {
-                        if (CurrentClass == null || CurrentFunction == null) {
-                            return false;
-                        }
-                        if (PeekToken(TokenKind.Assign)) {
-                            // avoid replacing statement like `__class__ = getproperty(...)`.
-                            return false;
-                        }
-                        if (fixedName != "__class__") {
-                            return false;
-                        }
-                        return true;
-                    }
                     return ret;
                 case TokenKind.Constant:        // literal
                     NextToken();


### PR DESCRIPTION
This is another take on #723 (an alternative to #734). As such it partially undoes #721 (parser changes). 

It is still a hack, because `__class__` variables are now manages as global variables named `$__class__NN`, not an ideal situation, but it is meant as a proof-of-concept for how a `__class__` variable should behave. In particular, it seems that a `__class__` variable behaves as a regular class scope variable that just happen to be initialized to the class type. For instance, it is possible to set `__class__` to any value, even if it is not a type (e.g. it is possible to set it to a number), while setting the **attribute** `__class__` is guarded against invalid values.

Alternative implementations to global variables:
1. use an ordinary local variable as `__class__`, placed in the class scope and lifted to be a closure cell; this is my favourite, but I was unable to get it work (2ac9d8ce)
2. use a closure from the parent scope to place `__class__`; it works OK but only for non-top-level classes and still pollutes the namespace, this time the local one
3. use a separate closure from the parent closure, which is managed by the class scope itself; since 2. works, this should be possible as well, but I was unable to get it to work (with the same error as with 1., so maybe I am overlooking something) (2d954769)
4. use a separate dedicated storage that is out of sight, perhaps as part of the context

@slozier @isaiah @in-code-i-trust 