### PR TITLE
Add rich comparison operators to number types

### DIFF
--- a/Src/IronPython.Modules/_datetime.cs
+++ b/Src/IronPython.Modules/_datetime.cs
@@ -1417,7 +1417,7 @@ namespace IronPython.Modules {
             #region Rich Comparison Members
 
             /// <summary>
-            /// Helper function for doing the comparisons.  time has no __cmp__ method
+            /// Helper function for doing the comparisons.
             /// </summary>
             private int CompareTo(object other) {
                 time other2 = other as time;

--- a/Src/IronPython/Modules/_locale.cs
+++ b/Src/IronPython/Modules/_locale.cs
@@ -91,12 +91,23 @@ If locale is None then the current setting is returned.
             return GetLocaleInfo(context).Collate.CompareInfo.Compare(string1, string2, CompareOptions.None);
         }
 
-        [Documentation(@"returns a System.Globalization.SortKey that can be compared using the built-in cmp.
+        private sealed class SortKeyWrapper : IComparable<SortKeyWrapper>, IComparable {
+            public SortKey SortKey { get; }
+
+            public SortKeyWrapper(SortKey sortKey) {
+                SortKey = sortKey;
+            }
+
+            public int CompareTo(SortKeyWrapper other) => SortKey.Compare(SortKey, other.SortKey);
+
+            public int CompareTo(object other) => (other is SortKeyWrapper wrapper) ? CompareTo(wrapper) : throw new ArgumentException($"The parameter must be a {nameof(SortKeyWrapper)}.", nameof(other));
+        }
+
+        [Documentation(@"returns a wrapped System.Globalization.SortKey that can be compared using the built-in cmp.
 
 Note: Return value differs from CPython - it is not a string.")]
-        public static object strxfrm(CodeContext/*!*/ context, string @string) {
-            return GetLocaleInfo(context).Collate.CompareInfo.GetSortKey(@string);
-        }
+        public static object strxfrm(CodeContext/*!*/ context, string @string)
+            => new SortKeyWrapper(GetLocaleInfo(context).Collate.CompareInfo.GetSortKey(@string));
 
         private enum LocaleCategories {
             All = 0,

--- a/Src/IronPython/Runtime/Binding/PythonBinder.cs
+++ b/Src/IronPython/Runtime/Binding/PythonBinder.cs
@@ -380,11 +380,11 @@ namespace IronPython.Runtime.Binding {
         #endregion
 
         internal IList<Type> GetExtensionTypesInternal(Type t) {
-            List<Type> res = new List<Type>(base.GetExtensionTypes(t));
+            var res = new List<Type>(base.GetExtensionTypes(t));
 
             AddExtensionTypes(t, res);
 
-            return res.ToArray();
+            return res;
         }
 
         public override bool IncludeExtensionMember(MemberInfo member) {

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1056,6 +1056,9 @@ namespace IronPython.Runtime {
             throw PythonOps.TypeError("Type {0} doesn't support the buffer API", PythonTypeOps.GetName(value));
         }
 
+        public IEnumerator<int> __iter__()
+            => IListOfByteOps.BytesEnumerator(this);
+
         public PythonTuple __reduce__(CodeContext context) {
             return PythonTuple.MakeTuple(
                 DynamicHelpers.GetPythonType(this),
@@ -1436,10 +1439,6 @@ namespace IronPython.Runtime {
         }
 
         #endregion
-
-        public IEnumerator __iter__() {
-            return PythonOps.BytesEnumerator(this).Key;
-        }
 
         #region IEnumerable<byte> Members
 

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -846,6 +846,9 @@ namespace IronPython.Runtime {
             throw PythonOps.TypeError("Type {0} doesn't support the buffer API", PythonTypeOps.GetName(value));
         }
 
+        public IEnumerator<int> __iter__()
+            => IListOfByteOps.BytesEnumerator(this);
+
         public PythonTuple __reduce__(CodeContext context) {
             return PythonTuple.MakeTuple(
                 DynamicHelpers.GetPythonType(this),

--- a/Src/IronPython/Runtime/Operations/DecimalOps.cs
+++ b/Src/IronPython/Runtime/Operations/DecimalOps.cs
@@ -16,7 +16,7 @@ using Microsoft.Scripting.Runtime;
 namespace IronPython.Runtime.Operations {
     public static class DecimalOps {
 
-        public static int __cmp__(CodeContext context, decimal x, decimal other) {
+        internal static int __cmp__(CodeContext context, decimal x, decimal other) {
             return x.CompareTo(other);
         }
 

--- a/Src/IronPython/Runtime/Operations/DecimalOps.cs
+++ b/Src/IronPython/Runtime/Operations/DecimalOps.cs
@@ -29,29 +29,30 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static bool LessThan(decimal x, decimal y) {
-            return x < y;
-        }
+        public static bool LessThan(decimal x, decimal y) => x < y;
         [SpecialName]
-        public static bool LessThanOrEqual(decimal x, decimal y) {
-            return x <= y;
-        }
+        public static bool LessThanOrEqual(decimal x, decimal y) => x <= y;
         [SpecialName]
-        public static bool GreaterThan(decimal x, decimal y) {
-            return x > y;
-        }
+        public static bool GreaterThan(decimal x, decimal y) => x > y;
         [SpecialName]
-        public static bool GreaterThanOrEqual(decimal x, decimal y) {
-            return x >= y;
-        }
+        public static bool GreaterThanOrEqual(decimal x, decimal y) => x >= y;
         [SpecialName]
-        public static bool Equals(decimal x, decimal y) {
-            return x == y;
-        }
+        public static bool Equals(decimal x, decimal y) => x == y;
         [SpecialName]
-        public static bool NotEquals(decimal x, decimal y) {
-            return x != y;
-        }
+        public static bool NotEquals(decimal x, decimal y) => x != y;
+
+        [SpecialName]
+        public static bool LessThan(decimal x, BigInteger y) => __cmp__(x, y) < 0;
+        [SpecialName]
+        public static bool LessThanOrEqual(decimal x, BigInteger y) => __cmp__(x, y) <= 0;
+        [SpecialName]
+        public static bool GreaterThan(decimal x, BigInteger y) => __cmp__(x, y) > 0;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(decimal x, BigInteger y) => __cmp__(x, y) >= 0;
+        [SpecialName]
+        public static bool Equals(decimal x, BigInteger y) => __cmp__(x, y) == 0;
+        [SpecialName]
+        public static bool NotEquals(decimal x, BigInteger y) => __cmp__(x, y) != 0;
 
         internal static int __cmp__(BigInteger x, decimal y) {
             return -__cmp__(y, x);

--- a/Src/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/Src/IronPython/Runtime/Operations/InstanceOps.cs
@@ -182,16 +182,6 @@ namespace IronPython.Runtime.Operations {
 
         #region Iteration
 
-        // 3.0-only
-        public static object IterMethodForString(string self) {
-            return StringOps.StringEnumerator(self);
-        }
-
-        // 3.0-only
-        public static object IterMethodForBytes(Bytes self) {
-            return IListOfByteOps.BytesEnumerator(self);
-        }
-
         public static object IterMethodForEnumerator(IEnumerator self) {
             return self;
         }

--- a/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
@@ -183,6 +183,18 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(SByte x, SByte y) {
             return x == y ? 0 : x > y ? 1 : -1;
         }
+        [SpecialName]
+        public static bool LessThan(SByte x, SByte y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(SByte x, SByte y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(SByte x, SByte y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(SByte x, SByte y) => x >= y;
+        [SpecialName]
+        public static bool Equals(SByte x, SByte y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(SByte x, SByte y) => x != y;
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]
@@ -498,6 +510,30 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(SByte x, Byte y) {
             return Int16Ops.Compare((Int16)x, (Int16)y);
         }
+        [SpecialName]
+        public static bool LessThan(Byte x, Byte y) => x < y;
+        [SpecialName]
+        public static bool LessThan(Byte x, SByte y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(Byte x, Byte y) => x <= y;
+        [SpecialName]
+        public static bool LessThanOrEqual(Byte x, SByte y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(Byte x, Byte y) => x > y;
+        [SpecialName]
+        public static bool GreaterThan(Byte x, SByte y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(Byte x, Byte y) => x >= y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(Byte x, SByte y) => x >= y;
+        [SpecialName]
+        public static bool Equals(Byte x, Byte y) => x == y;
+        [SpecialName]
+        public static bool Equals(Byte x, SByte y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(Byte x, Byte y) => x != y;
+        [SpecialName]
+        public static bool NotEquals(Byte x, SByte y) => x != y;
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]
@@ -727,6 +763,18 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(Int16 x, Int16 y) {
             return x == y ? 0 : x > y ? 1 : -1;
         }
+        [SpecialName]
+        public static bool LessThan(Int16 x, Int16 y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(Int16 x, Int16 y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(Int16 x, Int16 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(Int16 x, Int16 y) => x >= y;
+        [SpecialName]
+        public static bool Equals(Int16 x, Int16 y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(Int16 x, Int16 y) => x != y;
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]
@@ -1045,6 +1093,30 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(Int16 x, UInt16 y) {
             return Int32Ops.Compare((Int32)x, (Int32)y);
         }
+        [SpecialName]
+        public static bool LessThan(UInt16 x, UInt16 y) => x < y;
+        [SpecialName]
+        public static bool LessThan(UInt16 x, Int16 y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(UInt16 x, UInt16 y) => x <= y;
+        [SpecialName]
+        public static bool LessThanOrEqual(UInt16 x, Int16 y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(UInt16 x, UInt16 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThan(UInt16 x, Int16 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(UInt16 x, UInt16 y) => x >= y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(UInt16 x, Int16 y) => x >= y;
+        [SpecialName]
+        public static bool Equals(UInt16 x, UInt16 y) => x == y;
+        [SpecialName]
+        public static bool Equals(UInt16 x, Int16 y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(UInt16 x, UInt16 y) => x != y;
+        [SpecialName]
+        public static bool NotEquals(UInt16 x, Int16 y) => x != y;
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]
@@ -1219,6 +1291,18 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(Int32 x, Int32 y) {
             return x == y ? 0 : x > y ? 1 : -1;
         }
+        [SpecialName]
+        public static bool LessThan(Int32 x, Int32 y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(Int32 x, Int32 y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(Int32 x, Int32 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(Int32 x, Int32 y) => x >= y;
+        [SpecialName]
+        public static bool Equals(Int32 x, Int32 y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(Int32 x, Int32 y) => x != y;
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]
@@ -1532,6 +1616,30 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(Int32 x, UInt32 y) {
             return Int64Ops.Compare((Int64)x, (Int64)y);
         }
+        [SpecialName]
+        public static bool LessThan(UInt32 x, UInt32 y) => x < y;
+        [SpecialName]
+        public static bool LessThan(UInt32 x, Int32 y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(UInt32 x, UInt32 y) => x <= y;
+        [SpecialName]
+        public static bool LessThanOrEqual(UInt32 x, Int32 y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(UInt32 x, UInt32 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThan(UInt32 x, Int32 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(UInt32 x, UInt32 y) => x >= y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(UInt32 x, Int32 y) => x >= y;
+        [SpecialName]
+        public static bool Equals(UInt32 x, UInt32 y) => x == y;
+        [SpecialName]
+        public static bool Equals(UInt32 x, Int32 y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(UInt32 x, UInt32 y) => x != y;
+        [SpecialName]
+        public static bool NotEquals(UInt32 x, Int32 y) => x != y;
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]
@@ -1768,6 +1876,18 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(Int64 x, Int64 y) {
             return x == y ? 0 : x > y ? 1 : -1;
         }
+        [SpecialName]
+        public static bool LessThan(Int64 x, Int64 y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(Int64 x, Int64 y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(Int64 x, Int64 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(Int64 x, Int64 y) => x >= y;
+        [SpecialName]
+        public static bool Equals(Int64 x, Int64 y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(Int64 x, Int64 y) => x != y;
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]
@@ -2081,6 +2201,30 @@ namespace IronPython.Runtime.Operations {
         public static int Compare(Int64 x, UInt64 y) {
             return BigIntegerOps.Compare((BigInteger)x, (BigInteger)y);
         }
+        [SpecialName]
+        public static bool LessThan(UInt64 x, UInt64 y) => x < y;
+        [SpecialName]
+        public static bool LessThan(UInt64 x, Int64 y) => BigIntegerOps.LessThan((BigInteger)x, (BigInteger)y);
+        [SpecialName]
+        public static bool LessThanOrEqual(UInt64 x, UInt64 y) => x <= y;
+        [SpecialName]
+        public static bool LessThanOrEqual(UInt64 x, Int64 y) => BigIntegerOps.LessThanOrEqual((BigInteger)x, (BigInteger)y);
+        [SpecialName]
+        public static bool GreaterThan(UInt64 x, UInt64 y) => x > y;
+        [SpecialName]
+        public static bool GreaterThan(UInt64 x, Int64 y) => BigIntegerOps.GreaterThan((BigInteger)x, (BigInteger)y);
+        [SpecialName]
+        public static bool GreaterThanOrEqual(UInt64 x, UInt64 y) => x >= y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(UInt64 x, Int64 y) => BigIntegerOps.GreaterThanOrEqual((BigInteger)x, (BigInteger)y);
+        [SpecialName]
+        public static bool Equals(UInt64 x, UInt64 y) => x == y;
+        [SpecialName]
+        public static bool Equals(UInt64 x, Int64 y) => BigIntegerOps.Equals((BigInteger)x, (BigInteger)y);
+        [SpecialName]
+        public static bool NotEquals(UInt64 x, UInt64 y) => x != y;
+        [SpecialName]
+        public static bool NotEquals(UInt64 x, Int64 y) => BigIntegerOps.NotEquals((BigInteger)x, (BigInteger)y);
 
         // Conversion operators
         [SpecialName, ExplicitConversionMethod]

--- a/Src/IronPython/Runtime/Operations/LongOps.cs
+++ b/Src/IronPython/Runtime/Operations/LongOps.cs
@@ -510,6 +510,19 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
+        public static bool LessThan(BigInteger x, BigInteger y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(BigInteger x, BigInteger y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(BigInteger x, BigInteger y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(BigInteger x, BigInteger y) => x >= y;
+        [SpecialName]
+        public static bool Equals(BigInteger x, BigInteger y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(BigInteger x, BigInteger y) => x != y;
+
+        [SpecialName]
         public static int Compare(BigInteger x, int y) {
             int ix;
             if (x.AsInt32(out ix)) {                
@@ -520,6 +533,19 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
+        public static bool LessThan(BigInteger x, int y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(BigInteger x, int y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(BigInteger x, int y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(BigInteger x, int y) => x >= y;
+        [SpecialName]
+        public static bool Equals(BigInteger x, int y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(BigInteger x, int y) => x != y;
+
+        [SpecialName]
         public static int Compare(BigInteger x, uint y) {
             uint ix;
             if (x.AsUInt32(out ix)) {
@@ -528,6 +554,19 @@ namespace IronPython.Runtime.Operations {
 
             return BigInteger.Compare(x, y);
         }
+
+        [SpecialName]
+        public static bool LessThan(BigInteger x, uint y) => x < y;
+        [SpecialName]
+        public static bool LessThanOrEqual(BigInteger x, uint y) => x <= y;
+        [SpecialName]
+        public static bool GreaterThan(BigInteger x, uint y) => x > y;
+        [SpecialName]
+        public static bool GreaterThanOrEqual(BigInteger x, uint y) => x >= y;
+        [SpecialName]
+        public static bool Equals(BigInteger x, uint y) => x == y;
+        [SpecialName]
+        public static bool NotEquals(BigInteger x, uint y) => x != y;
 
         [SpecialName]
         public static int Compare(BigInteger x, double y) {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -623,6 +623,14 @@ namespace IronPython.Runtime.Operations {
             return 1;
         }
 
+        internal static object EqualHelper(CodeContext/*!*/ context, object self, object other) {
+            return InternalCompare(context, PythonOperationKind.Equal, self, other);
+        }
+
+        internal static object NotEqualHelper(CodeContext/*!*/ context, object self, object other) {
+            return InternalCompare(context, PythonOperationKind.NotEqual, self, other);
+        }
+
         public static object GreaterThanHelper(CodeContext/*!*/ context, object? self, object? other) {
             return InternalCompare(context, PythonOperationKind.GreaterThan, self, other);
         }

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -592,23 +592,14 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static bool CompareTypesEqual(CodeContext/*!*/ context, object? x, object? y) {
-            if (x == null && y == null) return true;
-            if (x == null) return false;
-            if (y == null) return false;
-
-            if (DynamicHelpers.GetPythonType(x) == DynamicHelpers.GetPythonType(y)) {
-                // avoid going to the ID dispenser if we have the same types...
-                return x == y;
-            }
-
-            return PythonOps.CompareTypesWorker(context, false, x, y) == 0;
+            return ReferenceEquals(x, y);
         }
 
         public static bool CompareTypesNotEqual(CodeContext/*!*/ context, object? x, object? y) {
-            return PythonOps.CompareTypesWorker(context, false, x, y) != 0;
+            return !CompareTypesEqual(context, x, y);
         }
 
-        private static int CompareTypesWorker(CodeContext/*!*/ context, bool shouldWarn, object? x, object? y) {
+        public static int CompareTypes(CodeContext/*!*/ context, object? x, object? y) {
             if (x == null && y == null) return 0;
             if (x == null) return -1;
             if (y == null) return 1;
@@ -630,10 +621,6 @@ namespace IronPython.Runtime.Operations {
             if (diff < 0) return -1;
             if (diff == 0) return 0;
             return 1;
-        }
-
-        public static int CompareTypes(CodeContext/*!*/ context, object? x, object? y) {
-            return CompareTypesWorker(context, true, x, y);
         }
 
         public static object GreaterThanHelper(CodeContext/*!*/ context, object? self, object? other) {

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -348,6 +348,9 @@ namespace IronPython.Runtime.Operations {
             return text;
         }
 
+        public static IEnumerator<string> __iter__([NotNull] string s)
+            => StringEnumerator(s);
+
         public static int __len__([NotNull]string s) {
             return s.Length;
         }

--- a/Src/IronPython/Runtime/PythonFunction.cs
+++ b/Src/IronPython/Runtime/PythonFunction.cs
@@ -538,11 +538,28 @@ namespace IronPython.Runtime {
 
         public const object __hash__ = null;
 
-        [Python3Warning("cell comparisons not supported in 3.x")]
-        public int __cmp__(object other) {
-            if (!(other is ClosureCell cc)) throw PythonOps.TypeError("cell.__cmp__(x,y) expected cell, got {0}", PythonTypeOps.GetName(other));
+        [return: MaybeNotImplemented]
+        public object __eq__(CodeContext context, object other)
+            => other is ClosureCell cell ? PythonOps.EqualHelper(context, Value, cell.Value) : NotImplementedType.Value;
 
-            return PythonOps.Compare(Value, cc.Value);
-        }
+        [return: MaybeNotImplemented]
+        public object __ne__(CodeContext context, object other)
+            => other is ClosureCell cell ? PythonOps.NotEqualHelper(context, Value, cell.Value) : NotImplementedType.Value;
+
+        [return: MaybeNotImplemented]
+        public object __lt__(CodeContext context, object other)
+            => other is ClosureCell cell ? PythonOps.LessThanHelper(context, Value, cell.Value) : NotImplementedType.Value;
+
+        [return: MaybeNotImplemented]
+        public object __le__(CodeContext context, object other)
+            => other is ClosureCell cell ? PythonOps.LessThanOrEqualHelper(context, Value, cell.Value) : NotImplementedType.Value;
+
+        [return: MaybeNotImplemented]
+        public object __ge__(CodeContext context, object other)
+            => other is ClosureCell cell ? PythonOps.GreaterThanOrEqualHelper(context, Value, cell.Value) : NotImplementedType.Value;
+
+        [return: MaybeNotImplemented]
+        public object __gt__(CodeContext context, object other)
+            => other is ClosureCell cell ? PythonOps.GreaterThanHelper(context, Value, cell.Value) : NotImplementedType.Value;
     }
 }

--- a/Src/IronPython/Runtime/Types/BuiltinFunction.cs
+++ b/Src/IronPython/Runtime/Types/BuiltinFunction.cs
@@ -37,10 +37,10 @@ namespace IronPython.Runtime.Types {
     /// TODO: Back BuiltinFunction's by MethodGroup's.
     /// </summary>    
     [PythonType("builtin_function_or_method"), DontMapGetMemberNamesToDir]
-    public partial class BuiltinFunction : PythonTypeSlot, ICodeFormattable, IDynamicMetaObjectProvider, IDelegateConvertible, IFastInvokable  {
+    public partial class BuiltinFunction : PythonTypeSlot, ICodeFormattable, IDynamicMetaObjectProvider, IDelegateConvertible, IFastInvokable {
         internal readonly BuiltinFunctionData/*!*/ _data;            // information describing the BuiltinFunction
         internal readonly object _instance;                          // the bound instance or null if unbound
-        private static readonly object _noInstance = new object();  
+        private static readonly object _noInstance = new object();
 
         #region Static factories
 
@@ -128,7 +128,7 @@ namespace IronPython.Runtime.Types {
 
         internal object Call(CodeContext context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object[], object>>> storage, object instance, object[] args) {
             storage = GetInitializedStorage(context, storage);
-            
+
             object callable;
             if (!GetDescriptor().TryGetValue(context, instance, DynamicHelpers.GetPythonTypeFromType(DeclaringType), out callable)) {
                 callable = this;
@@ -144,7 +144,7 @@ namespace IronPython.Runtime.Types {
             if (!GetDescriptor().TryGetValue(context, instance, DynamicHelpers.GetPythonTypeFromType(DeclaringType), out callable)) {
                 callable = this;
             }
-            
+
             return storage.Data.Target(storage.Data, context, callable);
         }
 
@@ -183,7 +183,7 @@ namespace IronPython.Runtime.Types {
 
             return storage.Data.Target(storage.Data, context, this, args, keywordArgs);
         }
-        
+
         /// <summary>
         /// Returns a BuiltinFunction bound to the provided type arguments.  Returns null if the binding
         /// cannot be performed.
@@ -253,7 +253,7 @@ namespace IronPython.Runtime.Types {
         public IList<MethodBase> Targets {
             [PythonHidden]
             get {
-                return _data.Targets;                
+                return _data.Targets;
             }
         }
 
@@ -300,7 +300,7 @@ namespace IronPython.Runtime.Types {
                 AstUtils.Constant(_data, typeof(object))
             );
         }
-        
+
         #endregion
 
         #region PythonTypeSlot Overrides
@@ -428,7 +428,7 @@ namespace IronPython.Runtime.Types {
 
             if (target.Overload != null && BindingWarnings.ShouldWarn(PythonContext.GetPythonContext(call), target.Overload, out info)) {
                 res = info.AddWarning(codeContext, res);
-            }            
+            }
 
             // finally add the restrictions for the built-in function and return the result.
             res = new DynamicMetaObject(
@@ -559,38 +559,22 @@ namespace IronPython.Runtime.Types {
         }
 
         #endregion
-                        
+
         #region Public Python APIs
 
-        public int __cmp__(CodeContext/*!*/ context, [NotNull]BuiltinFunction/*!*/  other) {
-            if (other == this) {
-                return 0;
-            }
+        private bool Equals(BuiltinFunction other) {
+            if (this == other) return true;
 
             if (!IsUnbound && !other.IsUnbound) {
-                int result = PythonOps.Compare(__self__, other.__self__);
-                if (result != 0) {
-                    return result;
-                }
-
-                if (_data == other._data) {
-                    return 0;
-                }
+                return _instance == other._instance && _data == other._data;
             }
 
-            int res = String.CompareOrdinal(__name__, other.__name__);
-            if (res != 0) {
-                return res;
-            }
-
-            res = String.CompareOrdinal(Get__module__(context), other.Get__module__(context));
-            if (res != 0) {
-                return res;
-            }
-            
-            long lres = IdDispenser.GetId(this) - IdDispenser.GetId(other);
-            return lres > 0 ? 1 : -1;
+            return false;
         }
+
+        public bool __eq__([NotNull] BuiltinFunction/*!*/ other) => Equals(other);
+
+        public bool __ne__([NotNull] BuiltinFunction/*!*/ other) => !Equals(other);
 
         [return: MaybeNotImplemented]
         public NotImplementedType __gt__(CodeContext context, object other) => NotImplementedType.Value;
@@ -713,11 +697,11 @@ namespace IronPython.Runtime.Types {
             }
         }
 
-        public object __call__(CodeContext/*!*/ context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object[], IDictionary<object, object>, object>>> storage, [ParamDictionary]IDictionary<object, object> dictArgs, params object[] args) {
+        public object __call__(CodeContext/*!*/ context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object[], IDictionary<object, object>, object>>> storage, [ParamDictionary] IDictionary<object, object> dictArgs, params object[] args) {
             return Call(context, storage, null, args, dictArgs);
         }
 
-        
+
         internal virtual bool IsOnlyGeneric {
             get {
                 return false;
@@ -852,7 +836,6 @@ namespace IronPython.Runtime.Types {
         }
     }
 
-    
     /// <summary>
     /// A custom built-in function which supports indexing 
     /// </summary>
@@ -926,4 +909,3 @@ namespace IronPython.Runtime.Types {
 
     }
 }
-

--- a/Src/IronPython/Runtime/Types/DocBuilder.cs
+++ b/Src/IronPython/Runtime/Types/DocBuilder.cs
@@ -28,7 +28,6 @@ namespace IronPython.Runtime.Types {
                 case "__abs__": return "x.__abs__() <==> abs(x)";
                 case "__add__": return "x.__add__(y) <==> x+y";
                 case "__call__": return "x.__call__(...) <==> x(...)";
-                case "__cmp__": return "x.__cmp__(y) <==> cmp(x,y)";
                 case "__delitem__": return "x.__delitem__(y) <==> del x[y]";
                 case "__eq__": return "x.__eq__(y) <==> x==y";
                 case "__floordiv__": return "x.__floordiv__(y) <==> x//y";

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -2252,7 +2252,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (_underlyingSystemType.BaseType != null) {
                 Type baseType;
                 if (_underlyingSystemType == typeof(bool)) {
-                    // bool inherits from int in python
+                    // bool inherits from int in Python
                     baseType = typeof(int);
                 } else if (_underlyingSystemType.BaseType == typeof(ValueType)) {
                     // hide ValueType, it doesn't exist in Python
@@ -2266,6 +2266,13 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 }
 
                 _bases = new PythonType[] { GetPythonType(baseType) };
+
+                if (_underlyingSystemType == typeof(bool)) {
+                    // exclude ValueType from the mro
+                    Debug.Assert(baseType == typeof(int));
+                    mro.Add(DynamicHelpers.GetPythonTypeFromType(baseType));
+                    baseType = typeof(object);
+                }
 
                 Type curType = baseType;
                 while (curType != null) {

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -995,16 +995,6 @@ namespace IronPython.Runtime.Types {
         /// Provides a resolution for __iter__
         /// </summary>
         private static MemberGroup/*!*/ IterResolver(MemberBinder/*!*/ binder, Type/*!*/ type) {
-            if (type == typeof(string)) {
-                // __iter__ is only exposed in 3.0
-                return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForString));
-            }
-
-            if (typeof(Bytes).IsAssignableFrom(type)) {
-                // __iter__ is only exposed in 3.0
-                return GetInstanceOpsMethod(type, nameof(InstanceOps.IterMethodForBytes));
-            }
-
             foreach (Type t in binder.GetContributingTypes(type)) {
                 MemberInfo[] news = t.GetMember("__iter__");
                 if (news.Length > 0) {

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -384,13 +384,14 @@ namespace IronPython.Runtime.Types {
 
                         if (opInfo != null) {
                             foreach (Type curType in binder.GetContributingTypes(type)) {
-                                if (curType == typeof(double)) {
+                                if ((type.IsPrimitive || type == typeof(decimal)) && curType.IsInterface && (opInfo.Operator & PythonOperationKind.Comparison) != 0) continue;
+
+                                if (curType.IsPrimitive || curType == typeof(decimal)) {
                                     if ((opInfo.Operator & PythonOperationKind.Comparison) != 0) {
                                         // we override these with our own comparisons in DoubleOps
                                         continue;
                                     }
-                                } else
-                                if (curType == typeof(BigInteger)) {
+                                } else if (curType == typeof(BigInteger)) {
                                     if (opInfo.Operator == PythonOperationKind.Mod ||
                                         opInfo.Operator == PythonOperationKind.RightShift ||
                                         opInfo.Operator == PythonOperationKind.LeftShift ||
@@ -399,7 +400,6 @@ namespace IronPython.Runtime.Types {
                                         // we override these with our own modulus/power PythonOperationKind which are different from BigInteger.
                                         continue;
                                     }
-
                                 } else if (curType == typeof(Complex) && opInfo.Operator == PythonOperationKind.TrueDivide) {
                                     // we override this with our own division PythonOperationKind which is different from .NET Complex.
                                     continue;
@@ -1706,28 +1706,8 @@ namespace IronPython.Runtime.Types {
         /// <summary>
         /// Filters out methods which are present on standard .NET types but shouldn't be there in Python
         /// </summary>
-        internal static bool IncludeOperatorMethod(Type/*!*/ t, PythonOperationKind op) {
-            if (t == typeof(string) && op == PythonOperationKind.Compare) {
-                // string doesn't define __cmp__, just __lt__ and friends
-                return false;
-            } 
-
-            // numeric types in python don't define equality, just __cmp__
-            if (t == typeof(bool) ||
-                (Converter.IsNumeric(t) && t != typeof(Complex) && t != typeof(double) && t != typeof(float)) &&
-                t != typeof(Decimal)) {
-                switch (op) {
-                    case PythonOperationKind.Equal:
-                    case PythonOperationKind.NotEqual:
-                    case PythonOperationKind.GreaterThan:
-                    case PythonOperationKind.LessThan:
-                    case PythonOperationKind.GreaterThanOrEqual:
-                    case PythonOperationKind.LessThanOrEqual:
-                        return false;
-                }
-            }
-            return true;
-        }
+        internal static bool IncludeOperatorMethod(Type/*!*/ t, PythonOperationKind op)
+            => op != PythonOperationKind.Compare;
 
         /// <summary>
         /// When private binding is enabled we can have a collision between the private Event
@@ -1913,6 +1893,7 @@ namespace IronPython.Runtime.Types {
                 }
                 mts.Add(mt);
             }
+            if (mts.Count == 0) return MemberGroup.EmptyGroup;
             return new MemberGroup(mts.ToArray());
         }
 

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -384,11 +384,12 @@ namespace IronPython.Runtime.Types {
 
                         if (opInfo != null) {
                             foreach (Type curType in binder.GetContributingTypes(type)) {
+                                // we override these with our own comparisons, don't use the interface methods (e.g. IEquatable<Int16>.Equals)
                                 if ((type.IsPrimitive || type == typeof(decimal)) && curType.IsInterface && (opInfo.Operator & PythonOperationKind.Comparison) != 0) continue;
 
                                 if (curType.IsPrimitive || curType == typeof(decimal)) {
                                     if ((opInfo.Operator & PythonOperationKind.Comparison) != 0) {
-                                        // we override these with our own comparisons in DoubleOps
+                                        // we override these with our own comparisons
                                         continue;
                                     }
                                 } else if (curType == typeof(BigInteger)) {


### PR DESCRIPTION
also does some cleanup of `__cmp__`.