### PR TITLE
Fix test_time

### DIFF
--- a/Src/IronPython.Modules/_datetime.cs
+++ b/Src/IronPython.Modules/_datetime.cs
@@ -1113,7 +1113,7 @@ namespace IronPython.Modules {
 
             public static datetime strptime(CodeContext/*!*/ context, string date_string, string format) {
                 var packed = PythonTime._strptime(context, date_string, format);
-                return new datetime((DateTime)packed[0]);
+                return new datetime(packed.Item1);
             }
 
             #region IRichComparable Members

--- a/Src/IronPython.Modules/time.cs
+++ b/Src/IronPython.Modules/time.cs
@@ -181,11 +181,11 @@ namespace IronPython.Modules {
 
         public static object strptime(CodeContext/*!*/ context, string @string, string format) {
             var packed = _strptime(context, @string, format);
-            return GetDateTimeTuple((DateTime)packed[0], (DayOfWeek?)packed[1]);
+            return GetDateTimeTuple(packed.Item1, packed.Item2);
         }
         
         // returns object array containing 2 elements: DateTime and DayOfWeek 
-        internal static object[] _strptime(CodeContext/*!*/ context, string @string, string format) {
+        internal static Tuple<DateTime, DayOfWeek?> _strptime(CodeContext/*!*/ context, string @string, string format) {
             bool postProc;
             FoundDateComponents foundDateComp;
             List<FormatInfo> formatInfo = PythonFormatToCLIFormat(format, true, out postProc, out foundDateComp);
@@ -255,7 +255,7 @@ namespace IronPython.Modules {
                 res = new DateTime(1900, res.Month, res.Day, res.Hour, res.Minute, res.Second, res.Millisecond, res.Kind);
             }
 
-            return new object[] { res, dayOfWeek };
+            return Tuple.Create(res, dayOfWeek);
         }
 
         private static string[] ExpandMicrosecondFormat(int fIdx, string [] formatParts) {

--- a/Src/StdLib/Lib/test/test_nntplib.py
+++ b/Src/StdLib/Lib/test/test_nntplib.py
@@ -69,7 +69,7 @@ class NetworkedNNTPTestsMixin:
         desc = self.server.description(self.GROUP_NAME)
         _check_desc(desc)
         # Another sanity check
-        self.assertIn("Python", desc)
+        self.assertIn(self.DESC, desc)
         # With a pattern
         desc = self.server.description(self.GROUP_PAT)
         _check_desc(desc)
@@ -289,6 +289,7 @@ class NetworkedNNTPTests(NetworkedNNTPTestsMixin, unittest.TestCase):
     NNTP_HOST = 'news.trigofacile.com'
     GROUP_NAME = 'fr.comp.lang.python'
     GROUP_PAT = 'fr.comp.lang.*'
+    DESC = 'Python'
 
     NNTP_CLASS = NNTP
 
@@ -311,8 +312,11 @@ class NetworkedNNTP_SSLTests(NetworkedNNTPTests):
     # 400 connections per day are accepted from each IP address."
 
     NNTP_HOST = 'nntp.aioe.org'
-    GROUP_NAME = 'comp.lang.python'
-    GROUP_PAT = 'comp.lang.*'
+    # bpo-42794: aioe.test is one of the official groups on this server
+    # used for testing: https://news.aioe.org/manual/aioe-hierarchy/
+    GROUP_NAME = 'aioe.test'
+    GROUP_PAT = 'aioe.*'
+    DESC = 'test'
 
     NNTP_CLASS = getattr(nntplib, 'NNTP_SSL', None)
 

--- a/Tests/modules/system_related/test_time.py
+++ b/Tests/modules/system_related/test_time.py
@@ -80,8 +80,12 @@ class TimeTest(unittest.TestCase):
 
         if is_cli: # https://github.com/IronLanguages/main/issues/239
             # TODO: day of the week does not work as expected
-            with self.assertRaises(ValueError):
-                time.strptime('Fri, July 9 7:30 PM', '%a, %B %d %I:%M %p')
+            import System.DateTime
+            if System.DateTime(System.DateTime.Now.Year, 7, 9).DayOfWeek == System.DayOfWeek.Friday:
+                self.assertEqual((1900, 7, 9, 19, 30, 0, 4, 190, -1), time.strptime('Fri, July 9 7:30 PM', '%a, %B %d %I:%M %p'))
+            else:
+                with self.assertRaises(ValueError):
+                    time.strptime('Fri, July 9 7:30 PM', '%a, %B %d %I:%M %p')
         else:
             self.assertEqual((1900, 7, 9, 19, 30, 0, 4, 190, -1), time.strptime('Fri, July 9 7:30 PM', '%a, %B %d %I:%M %p'))
 


### PR DESCRIPTION
The `assertRaises` started failing with the change of year. Related to https://github.com/IronLanguages/main/issues/239

Also patches `test_nntplib`. See https://bugs.python.org/issue42794