### PR TITLE
Misc changes

### DIFF
--- a/Src/IronPython.Modules/_ctypes/_ctypes.cs
+++ b/Src/IronPython.Modules/_ctypes/_ctypes.cs
@@ -187,8 +187,10 @@ namespace IronPython.Modules {
             NativeFunctions.FreeLibrary(handle);
         }
 
-        private static object LoadDLL(string library, int mode) {
-            if (library.IndexOf((char)0) != -1) throw PythonOps.ValueError("embedded null byte");
+#nullable enable
+
+        private static object LoadDLL(string? library, int mode) {
+            if (library is not null && library.IndexOf((char)0) != -1) throw PythonOps.ValueError("embedded null byte");
             IntPtr res = NativeFunctions.LoadDLL(library, mode);
             if (res == IntPtr.Zero) {
                 throw PythonOps.OSError($"cannot load library {library}");
@@ -198,12 +200,14 @@ namespace IronPython.Modules {
         }
 
         [SupportedOSPlatform("windows"), PythonHidden(PlatformsAttribute.PlatformFamily.Unix)]
-        public static object LoadLibrary(string library, int mode = 0)
+        public static object LoadLibrary([NotNull] string library, int mode = 0)
             => LoadDLL(library, mode);
 
         [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
-        public static object dlopen(string library, int mode = 0)
+        public static object dlopen(string? library, int mode = 0)
             => LoadDLL(library, mode);
+
+#nullable restore
 
         /// <summary>
         /// Returns a new type which represents a pointer given the existing type.

--- a/Src/IronPython.Modules/_ctypes/_ctypes.cs
+++ b/Src/IronPython.Modules/_ctypes/_ctypes.cs
@@ -188,6 +188,7 @@ namespace IronPython.Modules {
         }
 
         private static object LoadDLL(string library, int mode) {
+            if (library.IndexOf((char)0) != -1) throw PythonOps.ValueError("embedded null byte");
             IntPtr res = NativeFunctions.LoadDLL(library, mode);
             if (res == IntPtr.Zero) {
                 throw PythonOps.OSError($"cannot load library {library}");

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -1390,6 +1390,8 @@ namespace IronPython.Modules {
                 }
             }
 
+            VerifyPath(path, functionName: nameof(stat), argName: nameof(path));
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 try {
                     FileInfo fi = new FileInfo(path);
@@ -2210,6 +2212,10 @@ the 'status' value."),
 
             if (numOptPosArgs + numKwArgs > numOptPosParms + numKwParms)
                 throw PythonOps.TypeErrorForOptionalArgumentCountMismatch(methodname ?? "<unknown>", numRegParms + numOptPosParms + numKwParms, numRegParms + numOptPosArgs + numKwArgs);
+        }
+
+        private static void VerifyPath(string path, string functionName, string argName) {
+            if (path.IndexOf((char)0) != -1) throw PythonOps.ValueError($"{functionName}: embedded null character in {argName}");
         }
 
         #endregion

--- a/Src/IronPython/Modules/_ast.cs
+++ b/Src/IronPython/Modules/_ast.cs
@@ -774,6 +774,31 @@ namespace IronPython.Modules {
         }
 
         [PythonType]
+        public class AsyncFunctionDef : stmt {
+            public AsyncFunctionDef() {
+                _fields = PythonTuple.MakeTuple(nameof(name), nameof(args), nameof(body), nameof(decorator_list), nameof(returns));
+            }
+
+            public AsyncFunctionDef(expr name, expr args, expr body, expr decorator_list, expr returns, [Optional] int? lineno, [Optional] int? col_offset)
+                : this() {
+                this.name = name;
+                this.args = args;
+                this.body = body;
+                this.decorator_list = decorator_list;
+                this.returns = returns;
+                _lineno = lineno;
+                _col_offset = col_offset;
+            }
+
+            // _fields
+            public expr name { get; set; }
+            public expr args { get; set; }
+            public expr body { get; set; }
+            public expr decorator_list { get; set; }
+            public expr returns { get; set; }
+        }
+
+        [PythonType]
         public class Attribute : expr {
             public Attribute() {
                 _fields = PythonTuple.MakeTuple(new[] { nameof(value), nameof(attr), nameof(ctx) });

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -242,7 +242,7 @@ namespace IronPython.Runtime.Operations {
             if (qmod == null) return Power(x, power);
             int mod = (int)qmod;
 
-            if (power < 0) throw PythonOps.TypeError("power", power, "power must be >= 0");
+            if (power < 0) throw PythonOps.ValueError("power must be >= 0");
 
             if (mod == 0) {
                 throw PythonOps.ZeroDivisionError();
@@ -534,6 +534,10 @@ namespace IronPython.Runtime.Operations {
             if (!signed && (bytesArr[bytesArr.Length - 1] & 0x80) == 0x80) Array.Resize(ref bytesArr, bytesArr.Length + 1);
             var val = new BigInteger(bytesArr);
 #endif
+
+            // prevents a TypeError: int.__new__(bool) is not safe
+            if (type == TypeCache.Boolean) return val == 0 ? ScriptingRuntimeHelpers.False : ScriptingRuntimeHelpers.True;
+
             return __new__(context, type, val);
         }
 

--- a/Src/IronPython/Runtime/PythonFunction.cs
+++ b/Src/IronPython/Runtime/PythonFunction.cs
@@ -39,6 +39,7 @@ namespace IronPython.Runtime {
         internal int _id;                               // ID flag used for testing in rules
         private FunctionCode _code;                     // the Python function code object.  Not currently used for much by us...        
         private string _name;                           // the name of the method
+        private string _qualname;                       // the qualified name of the method
         private object _doc;                            // the current documentation string
         private PythonDictionary _annotations;          // annotations for the function
 
@@ -69,6 +70,7 @@ namespace IronPython.Runtime {
             _code = code;
             _doc = code._initialDoc;
             _name = name ?? code.PythonCode.Name;
+            _qualname = _name;
             _annotations = new PythonDictionary();
 
             Closure = null;
@@ -91,6 +93,7 @@ namespace IronPython.Runtime {
             _code = funcInfo;
             _doc = funcInfo._initialDoc;
             _name = funcInfo.co_name;
+            _qualname = _name;
             _annotations = annotations ?? new PythonDictionary();
 
             Debug.Assert(_defaults.Length <= _code.co_argcount);
@@ -172,6 +175,12 @@ namespace IronPython.Runtime {
             get { return _name; }
             set {
                 _name = value ?? throw PythonOps.TypeError("__name__ must be set to a string object");
+            }
+        }
+        public string __qualname__ {
+            get { return _qualname; }
+            set {
+                _qualname = value ?? throw PythonOps.TypeError("__qualname__ must be set to a string object");
             }
         }
 

--- a/Src/StdLib/Lib/test/test_builtin.py
+++ b/Src/StdLib/Lib/test/test_builtin.py
@@ -1094,7 +1094,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertAlmostEqual(pow(-1, 0.5), 1j)
         self.assertAlmostEqual(pow(-1, 1/3), 0.5 + 0.8660254037844386j)
 
-        self.assertRaises(TypeError, pow, -1, -2, 3)
+        self.assertRaises(ValueError, pow, -1, -2, 3)
         self.assertRaises(ValueError, pow, 1, 2, 0)
 
         self.assertRaises(TypeError, pow)

--- a/Tests/test_functools_stdlib.py
+++ b/Tests/test_functools_stdlib.py
@@ -114,17 +114,17 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_functools.TestTotalOrdering('test_total_ordering_no_overwrite'))
         suite.addTest(test.test_functools.TestTotalOrdering('test_type_error_when_not_implemented'))
         suite.addTest(test.test_functools.TestUpdateWrapper('test_builtin_update'))
-        suite.addTest(unittest.expectedFailure(test.test_functools.TestUpdateWrapper('test_default_update'))) # AttributeError: 'function' object has no attribute '__qualname__'
+        suite.addTest(test.test_functools.TestUpdateWrapper('test_default_update'))
         suite.addTest(test.test_functools.TestUpdateWrapper('test_default_update_doc'))
         suite.addTest(test.test_functools.TestUpdateWrapper('test_missing_attributes'))
-        suite.addTest(unittest.expectedFailure(test.test_functools.TestUpdateWrapper('test_no_update'))) # AttributeError: 'function' object has no attribute '__qualname__'
-        suite.addTest(unittest.expectedFailure(test.test_functools.TestUpdateWrapper('test_selective_update'))) # AttributeError: 'function' object has no attribute '__qualname__'
+        suite.addTest(test.test_functools.TestUpdateWrapper('test_no_update'))
+        suite.addTest(test.test_functools.TestUpdateWrapper('test_selective_update'))
         suite.addTest(test.test_functools.TestWraps('test_builtin_update'))
-        suite.addTest(unittest.expectedFailure(test.test_functools.TestWraps('test_default_update'))) # AttributeError: 'function' object has no attribute '__qualname__'
+        suite.addTest(test.test_functools.TestWraps('test_default_update'))
         suite.addTest(test.test_functools.TestWraps('test_default_update_doc'))
         suite.addTest(test.test_functools.TestWraps('test_missing_attributes'))
-        suite.addTest(unittest.expectedFailure(test.test_functools.TestWraps('test_no_update'))) # AttributeError: 'function' object has no attribute '__qualname__'
-        suite.addTest(unittest.expectedFailure(test.test_functools.TestWraps('test_selective_update'))) # AttributeError: 'function' object has no attribute '__qualname__'
+        suite.addTest(test.test_functools.TestWraps('test_no_update'))
+        suite.addTest(test.test_functools.TestWraps('test_selective_update'))
         return suite
 
     else:

--- a/Tests/test_isinstance.py
+++ b/Tests/test_isinstance.py
@@ -177,7 +177,10 @@ class IsInstanceTest(IronPythonTestCase):
         reloaded_sys = importlib.reload(sys)
 
         # Most attributes get reset
-        self.assertEqual((old_copyright, old_byteorder), (reloaded_sys.copyright, reloaded_sys.byteorder))
+        if sys.version_info >= (3,5):
+            self.assertEqual(("foo", "foo"), (reloaded_sys.copyright, reloaded_sys.byteorder))
+        else:
+            self.assertEqual((old_copyright, old_byteorder), (reloaded_sys.copyright, reloaded_sys.byteorder))
         # Some attributes are not reset
         self.assertEqual(reloaded_sys.argv, "foo")
         # Put back the original values


### PR DESCRIPTION
Some misc changes for 3.5. Also adds `__qualname__` to `function` and `type` (part of https://github.com/IronLanguages/ironpython3/issues/30)

Just for the sake of clarity, these are the changes that are 3.5 specific:
- `_ast.AsyncFunctionDef` (which is just a stub)
- `pow(-1, -2, 3)` throws a `ValueError` instead of a `TypeError`

Everything else should be applicable to 3.4.