### PR TITLE
Prefer local class namespace over lexical scoping

### DIFF
--- a/Src/IronPython/Compiler/Ast/AstMethods.cs
+++ b/Src/IronPython/Compiler/Ast/AstMethods.cs
@@ -61,6 +61,7 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo MakeClosureCell = GetMethod((Func<ClosureCell>)PythonOps.MakeClosureCell);
         public static readonly MethodInfo MakeClosureCellWithValue = GetMethod((Func<object, ClosureCell>)PythonOps.MakeClosureCellWithValue);
         public static readonly MethodInfo LookupName = GetMethod((Func<CodeContext, string, object>)PythonOps.LookupName);
+        public static readonly MethodInfo LookupLocalName = GetMethod((Func<CodeContext, string, object>)PythonOps.LookupLocalName);
         public static readonly MethodInfo RemoveName = GetMethod((Action<CodeContext, string>)PythonOps.RemoveName);
         public static readonly MethodInfo SetName = GetMethod((Func<CodeContext, string, object, object>)PythonOps.SetName);
         public static readonly MethodInfo KeepAlive = GetMethod((Action<object>)GC.KeepAlive);

--- a/Src/IronPython/Compiler/Ast/AstMethods.cs
+++ b/Src/IronPython/Compiler/Ast/AstMethods.cs
@@ -61,7 +61,7 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo MakeClosureCell = GetMethod((Func<ClosureCell>)PythonOps.MakeClosureCell);
         public static readonly MethodInfo MakeClosureCellWithValue = GetMethod((Func<object, ClosureCell>)PythonOps.MakeClosureCellWithValue);
         public static readonly MethodInfo LookupName = GetMethod((Func<CodeContext, string, object>)PythonOps.LookupName);
-        public static readonly MethodInfo LookupLocalName = GetMethod((Func<CodeContext, string, object>)PythonOps.LookupLocalName);
+        public static readonly MethodInfo LookupLocalName = GetMethod((Func<CodeContext, string, object, object>)PythonOps.LookupLocalName);
         public static readonly MethodInfo RemoveName = GetMethod((Action<CodeContext, string>)PythonOps.RemoveName);
         public static readonly MethodInfo SetName = GetMethod((Func<CodeContext, string, object, object>)PythonOps.SetName);
         public static readonly MethodInfo KeepAlive = GetMethod((Action<object>)GC.KeepAlive);

--- a/Src/IronPython/Compiler/Ast/NameExpression.cs
+++ b/Src/IronPython/Compiler/Ast/NameExpression.cs
@@ -39,7 +39,7 @@ namespace IronPython.Compiler.Ast {
                     Ast.Constant(Name)
                 );
             } else {
-                read = Parent.GetVariableExpression(Reference.PythonVariable);
+                read = Parent.LookupVariableExpression(Reference.PythonVariable);
             }
 
             if (!Assigned && !(read is IPythonGlobalExpression)) {

--- a/Src/IronPython/Compiler/Ast/ScopeStatement.cs
+++ b/Src/IronPython/Compiler/Ast/ScopeStatement.cs
@@ -698,6 +698,9 @@ namespace IronPython.Compiler.Ast {
             return _variableMapping[variable.LimitVariable];
         }
 
+        internal virtual Ast LookupVariableExpression(PythonVariable variable)
+            => GetVariableExpression(variable);
+
         internal void CreateVariables(ReadOnlyCollectionBuilder<MSAst.ParameterExpression> locals, List<MSAst.Expression> init) {
             if (Variables != null) {
                 foreach (PythonVariable variable in Variables.Values) {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3340,8 +3340,8 @@ namespace IronPython.Runtime.Operations {
             throw PythonOps.NameError(name);
         }
 
-        public static object? LookupLocalName(CodeContext context, string name) {
-            return context.TryGetVariable(name, out object? value) ? value : null;
+        public static object? LookupLocalName(CodeContext context, string name, object? defaultValue) {
+            return context.TryGetVariable(name, out object? value) ? value : defaultValue;
         }
 
         /// <summary>

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3340,6 +3340,10 @@ namespace IronPython.Runtime.Operations {
             throw PythonOps.NameError(name);
         }
 
+        public static object? LookupLocalName(CodeContext context, string name) {
+            return context.TryGetVariable(name, out object? value) ? value : null;
+        }
+
         /// <summary>
         /// Called from generated code, helper to do name assignment
         /// </summary>

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -2749,6 +2749,27 @@ class ClassTest(IronPythonTestCase):
 
         self.assertEqual(Child.attr_Child, 'attribute set on Child by MetaClass')
 
+    def test_metaclass_scope(self):
+        class MetaClass(type): pass
+
+        def foo():
+            outer = "lexically scoped"
+            class C(metaclass=MetaClass):
+                x = outer
+            return C.x
+
+        self.assertEqual(foo(), "lexically scoped")
+
+        class MetaClass(type):
+            def __prepare__(*args):
+                return dict(outer="from metaclass")
+
+        if is_cli:
+            # https://github.com/IronLanguages/ironpython3/issues/1154
+            self.assertEqual(foo(), "lexically scoped")
+        else:
+            self.assertEqual(foo(), "from metaclass")
+
     def test_binary_operator_subclass(self):
         """subclassing but not overriding shouldn't call __radd__"""
         class A(object):

--- a/Tests/test_namebinding.py
+++ b/Tests/test_namebinding.py
@@ -211,10 +211,7 @@ def test_namebinding_locals_and_class_impl():
         locals()["xyz"] = True
         passed = xyz
 
-    if is_cli: # https://github.com/IronLanguages/ironpython3/issues/1030
-        selph.assertTrue(C.passed == False)
-    else:
-        selph.assertTrue(C.passed == True)
+    selph.assertTrue(C.passed == True)
 
 def localsAfterExpr():
     exec("pass")
@@ -293,10 +290,7 @@ class NameBindingTest(IronPythonTestCase):
                 abc = a
             return c
 
-        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/1030
-            self.assertEqual(f().abc, 2)
-        else:
-            self.assertEqual(f().abc, 42)
+        self.assertEqual(f().abc, 42)
 
     def test_DelBuiltin(self):
         # Check that "pow" is defined

--- a/Tests/test_scope_stdlib.py
+++ b/Tests/test_scope_stdlib.py
@@ -20,7 +20,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_scope.ScopeTests('testCellIsKwonlyArg'))
         suite.addTest(test.test_scope.ScopeTests('testCellLeak'))
         suite.addTest(test.test_scope.ScopeTests('testClassAndGlobal'))
-        suite.addTest(unittest.expectedFailure(test.test_scope.ScopeTests('testClassNamespaceOverridesClosure'))) # TODO: figure out
+        suite.addTest(test.test_scope.ScopeTests('testClassNamespaceOverridesClosure'))
         suite.addTest(test.test_scope.ScopeTests('testComplexDefinitions'))
         suite.addTest(test.test_scope.ScopeTests('testEvalExecFreeVars'))
         suite.addTest(test.test_scope.ScopeTests('testEvalFreeVars'))


### PR DESCRIPTION
Resolves #1030.

The original bug got fixed in CPython 3.4 ([bpo-17853](https://bugs.python.org/issue17853)) because of an interesting metaclass scenario. I tried to add that scenario to the IronPython tests, but it fails, presumably because [PEP 3115](https://www.python.org/dev/peps/pep-3115/) is not implemented yet? Are the old-style metaclasses supposed to work?