### PR TITLE
Remove os.py from build Lib folder

### DIFF
--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -38,9 +38,6 @@
     <None Update="Lib\**\*.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\StdLib\Lib\os.py" Link="Lib\os.py">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It seems like people are building the Release, running it and then trying to `import os` (e.g. https://github.com/IronLanguages/ironpython3/issues/821). This fails since `os` has dependencies on `stat` (and a number of other modules). This just removes `os.py` from the Lib folder so that people don't get the impression that they can `import os` without including the standard library (documentation is probably lacking about this).