### PR TITLE
Support starred arguments as class bases

### DIFF
--- a/Src/IronPython/Compiler/Ast/AstMethods.cs
+++ b/Src/IronPython/Compiler/Ast/AstMethods.cs
@@ -20,7 +20,7 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo IsTrue = GetMethod((Func<object, bool>)PythonOps.IsTrue);
         public static readonly MethodInfo RaiseAssertionError = GetMethod((Action<CodeContext, object>)PythonOps.RaiseAssertionError);
         public static readonly MethodInfo RaiseAssertionErrorNoMessage = GetMethod((Action<CodeContext>)PythonOps.RaiseAssertionError);
-        public static readonly MethodInfo MakeClass = GetMethod((Func<FunctionCode, Func<CodeContext, CodeContext>, CodeContext, string, object[], object, string, object>)PythonOps.MakeClass);
+        public static readonly MethodInfo MakeClass = GetMethod((Func<FunctionCode, Func<CodeContext, CodeContext>, CodeContext, string, PythonTuple, object, string, object>)PythonOps.MakeClass);
         public static readonly MethodInfo PrintExpressionValue = GetMethod((Action<CodeContext, object>)PythonOps.PrintExpressionValue);
         public static readonly MethodInfo ImportWithNames = GetMethod((Func<CodeContext, string, string[], int, object>)PythonOps.ImportWithNames);
         public static readonly MethodInfo ImportFrom = GetMethod((Func<CodeContext, object, string, object>)PythonOps.ImportFrom);
@@ -45,6 +45,7 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo CheckException = GetMethod((Func<CodeContext, object, object, object>)PythonOps.CheckException);
         public static readonly MethodInfo SetCurrentException = GetMethod((Func<CodeContext, Exception, object>)PythonOps.SetCurrentException);
         public static readonly MethodInfo MakeTuple = GetMethod((Func<object[], PythonTuple>)PythonOps.MakeTuple);
+        public static readonly MethodInfo MakeEmptyTuple = GetMethod((Func<PythonTuple>)PythonOps.MakeEmptyTuple);
         public static readonly MethodInfo IsNot = GetMethod((Func<object, object, object>)PythonOps.IsNot);
         public static readonly MethodInfo Is = GetMethod((Func<object, object, object>)PythonOps.Is);
         public static readonly MethodInfo ImportTop = GetMethod((Func<CodeContext, string, int, object>)PythonOps.ImportTop);

--- a/Src/IronPython/Compiler/Ast/CallExpression.cs
+++ b/Src/IronPython/Compiler/Ast/CallExpression.cs
@@ -134,6 +134,7 @@ namespace IronPython.Compiler.Ast {
                 }
             }
 
+            // Compare to: ClassDefinition.Reduce.__UnpackBasesHelper
             static MSAst.Expression UnpackListHelper(IReadOnlyList<Arg> args, int firstListPos) {
                 Debug.Assert(args.Count > 0);
                 Debug.Assert(args[firstListPos].ArgumentInfo.Kind == ArgumentType.List);

--- a/Src/IronPython/Compiler/Ast/FlowChecker.cs
+++ b/Src/IronPython/Compiler/Ast/FlowChecker.cs
@@ -328,7 +328,10 @@ namespace IronPython.Compiler.Ast {
             } else {
                 // analyze the class definition itself (it is visited while analyzing parent scope):
                 Define(node.Name);
-                foreach (Expression e in node.Bases) {
+                foreach (Arg e in node.Bases) {
+                    e.Walk(this);
+                }
+                foreach (Arg e in node.Keywords) {
                     e.Walk(this);
                 }
                 return false;

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -206,7 +206,7 @@ namespace IronPython.Compiler.Ast {
             node.PythonVariable = DefineName(node.Name);
 
             // Base references are in the outer context
-            foreach (Expression b in node.Bases) b.Walk(this);
+            foreach (Arg b in node.Bases) b.Walk(this);
 
             foreach (Arg a in node.Keywords) a.Walk(this);
 

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -844,6 +844,29 @@ class ClassTest(IronPythonTestCase):
 
         self.assertEqual(L.__mro__, (L, K, H, I, G, E, D, B, C, A, object))
 
+    def test_class_args(self):
+        class A1: pass
+        class A2: pass
+        class A3: pass
+
+        class B1(A1, *(A2, A3)): pass
+        self.assertEqual(B1.__mro__, (B1, A1, A2, A3, object))
+
+        clist = [A1, A2]
+        with self.assertRaisesMessage(TypeError, "duplicate base class A1"):
+            class B2(A1, *clist): pass
+
+        def foo(x): return x
+
+        class B3(foo(A1), clist[1], A3): pass
+        self.assertEqual(B3.__mro__, (B3, A1, A2, A3, object))
+
+        class B4(A1, *foo([A2, A3])): pass
+        self.assertEqual(B4.__mro__, (B4, A1, A2, A3, object))
+
+        with self.assertRaisesMessage(UnboundLocalError, "local variable 'A4' referenced before assignment"):
+            class B5(A1, *(A4,)): pass
+        class A4: pass
 
     def test_newstyle_lookup(self):
         """new-style classes should only lookup methods from the class, not from the instance"""


### PR DESCRIPTION
@slozier I know you are not a huge fan of `Compiler.Ast.Arg`, but the reason I changed the type of `ClassDefinition.Bases` from a ro list of `Expression` to a ro list of `Arg` is to align it more closely with `CallExpression`. [PEP 3115](https://www.python.org/dev/peps/pep-3115/) specifically declares that:

> the parameter list passed to a class definition will now support all of the features of a function call

so ideally this should be handled by the same code path as a function call. Indeed, this is what I think CPython does with routing class creation with a call to the internal `__build_class__` function. 

I looked first at implementing it here too, but eventually decided not to go ahead with such approach. The way how arguments are handled in `CallExpression` is tailored to what the DLR supports, which in turn does what it does to implement sophisticated overload resolution for .NET. On the other hand, `ClassDefinition` is optimized to call `PythonOps.MakeClass` directly, which in turn uses extra parameters to make a class efficiently.

Hence handling of class arguments is done separately from handling of function call arguments, except for some overlap in the parser. So unfortunately, when changes are made (e.g. Python 3.5 allows multiple starred arguments), this will have to be implemented in two places. To ease that, I wanted to keep both parts of the code aligned as much as possible without compromising on efficiency.