### PR TITLE
Remove IronPython.Compiler.Ast.Arg

### DIFF
--- a/Src/IronPython/Compiler/Ast/CallExpression.cs
+++ b/Src/IronPython/Compiler/Ast/CallExpression.cs
@@ -160,7 +160,7 @@ namespace IronPython.Compiler.Ast {
 
                 if (args.Length == 1) return ((StarredExpression)args[0]).Value;
 
-                return UnpackSequenceHelper<Expression>(args, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend);
+                return UnpackSequenceHelper<PythonList>(args, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend);
             }
 
             // Compare to: CallExpression.Reduce.__UnpackKeywordsHelper

--- a/Src/IronPython/Compiler/Ast/CallExpression.cs
+++ b/Src/IronPython/Compiler/Ast/CallExpression.cs
@@ -22,20 +22,25 @@ using MSAst = System.Linq.Expressions;
 namespace IronPython.Compiler.Ast {
 
     public class CallExpression : Expression, IInstructionProvider {
-        public CallExpression(Expression target, IReadOnlyList<Arg>? args, IReadOnlyList<Arg>? kwargs) {
+        private readonly Expression[] _args;
+        private readonly Keyword[] _kwargs;
+        private Expression[]? _implicitArgs;
+
+        public CallExpression(Expression target, IReadOnlyList<Expression>? args, IReadOnlyList<Keyword>? kwargs) {
             Target = target;
-            Args = args?.ToArray() ?? Array.Empty<Arg>();
-            Kwargs = kwargs?.ToArray() ?? Array.Empty<Arg>();
+            _args = args?.ToArray() ?? Array.Empty<Expression>();
+            _kwargs = kwargs?.ToArray() ?? Array.Empty<Keyword>();
         }
 
         public Expression Target { get; }
 
-        public IReadOnlyList<Arg> Args { get; }
+        public IReadOnlyList<Expression> Args => _args;
 
-        public IReadOnlyList<Arg> Kwargs { get; }
+        public IReadOnlyList<Keyword> Kwargs => _kwargs;
 
-        internal IList<Arg> ImplicitArgs => _implicitArgs ??= new List<Arg>();
-        private List<Arg>? _implicitArgs;
+        internal void SetImplicitArgs(params Expression[] args) {
+            _implicitArgs = args;
+        }
 
         public bool NeedsLocalsDictionary() {
             if (!(Target is NameExpression nameExpr)) return false;
@@ -43,25 +48,30 @@ namespace IronPython.Compiler.Ast {
             if (nameExpr.Name == "eval" || nameExpr.Name == "exec") return true;
             if (nameExpr.Name == "dir" || nameExpr.Name == "vars" || nameExpr.Name == "locals") {
                 // could be splatting empty list or dict resulting in 0-param call which needs context
-                return Args.All(arg => arg.Name == "*") && Kwargs.All(arg => arg.Name == "**");
+                return Args.All(arg => arg is StarredExpression) && Kwargs.All(arg => arg.Name is null);
             }
 
             return false;
         }
 
+        private static readonly Argument _listTypeArgument = new(ArgumentType.List);
+        private static readonly Argument _dictTypeArgument = new(ArgumentType.Dictionary);
+
         public override MSAst.Expression Reduce() {
-            IReadOnlyList<Arg> args = Args;
-            if (Args.Count == 0 && _implicitArgs != null && _implicitArgs.Count > 0) {
+            ReadOnlySpan<Expression> args = _args;
+            ReadOnlySpan<Keyword> kwargs = _kwargs;
+
+            if (args.Length == 0 && _implicitArgs != null) {
                 args = _implicitArgs;
             }
 
             // count splatted list args and find the lowest index of a list argument, if any
-            ScanArgs(args, ArgumentType.List, out var numList, out int firstListPos);
-            Debug.Assert(numList == 0 || firstListPos < args.Count);
+            ScanArgs(args, out var numList, out int firstListPos);
+            Debug.Assert(numList == 0 || firstListPos < args.Length);
 
             // count splatted dictionary args and find the lowest index of a dict argument, if any
-            ScanArgs(Kwargs, ArgumentType.Dictionary, out var numDict, out int firstDictPos);
-            Debug.Assert(numDict == 0 || firstDictPos < Kwargs.Count);
+            ScanKwargs(kwargs, out var numDict, out int firstDictPos);
+            Debug.Assert(numDict == 0 || firstDictPos < kwargs.Length);
 
             // all list arguments and all simple arguments after the first list will be collated into a single list for the actual call
             // all dictionary arguments will be merged into a single dictionary for the actual call
@@ -77,28 +87,25 @@ namespace IronPython.Compiler.Ast {
             if (firstListPos > 0) {
                 foreach (var arg in args) {
                     if (i == firstListPos) break;
-                    Debug.Assert(arg.ArgumentInfo.Kind == ArgumentType.Simple);
-                    kinds[i] = arg.ArgumentInfo;
-                    values[i + 2] = arg.Expression;
+                    Debug.Assert(arg is not StarredExpression);
+                    kinds[i] = Argument.Simple;
+                    values[i + 2] = arg;
                     i++;
                 }
             }
 
             // unpack list arguments
             if (numList > 0) {
-                var arg = args[firstListPos];
-                Debug.Assert(arg.ArgumentInfo.Kind == ArgumentType.List);
-                kinds[i] = arg.ArgumentInfo;
-                values[i + 2] = UnpackListHelper(args, firstListPos);
+                kinds[i] = _listTypeArgument;
+                values[i + 2] = UnpackListHelper(args.Slice(firstListPos));
                 i++;
             }
 
             // add named arguments
             if (Kwargs.Count != numDict) {
                 foreach (var arg in Kwargs) {
-                    var info = arg.ArgumentInfo;
-                    if (info.Kind == ArgumentType.Named) {
-                        kinds[i] = info;
+                    if (arg.Name is not null) {
+                        kinds[i] = new Argument(arg.Name);
                         values[i + 2] = arg.Expression;
                         i++;
                     }
@@ -107,10 +114,8 @@ namespace IronPython.Compiler.Ast {
 
             // unpack dict arguments
             if (numDict > 0) {
-                var arg = Kwargs[firstDictPos];
-                Debug.Assert(arg.ArgumentInfo.Kind == ArgumentType.Dictionary);
-                kinds[i] = arg.ArgumentInfo;
-                values[i + 2] = UnpackDictHelper(Parent.LocalContext, Kwargs, numDict, firstDictPos);
+                kinds[i] = _dictTypeArgument;
+                values[i + 2] = UnpackDictHelper(Parent.LocalContext, kwargs.Slice(firstDictPos), numDict);
             }
 
             return Parent.Invoke(
@@ -118,16 +123,30 @@ namespace IronPython.Compiler.Ast {
                 values
             );
 
-            static void ScanArgs(IReadOnlyList<Arg> args, ArgumentType scanForType, out int numArgs, out int firstArgPos) {
+            static void ScanArgs(ReadOnlySpan<Expression> args, out int numArgs, out int firstArgPos) {
                 numArgs = 0;
-                firstArgPos = args.Count;
+                firstArgPos = args.Length;
 
-                if (args.Count == 0) return;
+                if (args.Length == 0) return;
 
-                for (var i = args.Count - 1; i >= 0; i--) {
+                for (var i = args.Length - 1; i >= 0; i--) {
                     var arg = args[i];
-                    var info = arg.ArgumentInfo;
-                    if (info.Kind == scanForType) {
+                    if (arg is StarredExpression) {
+                        firstArgPos = i;
+                        numArgs++;
+                    }
+                }
+            }
+
+            static void ScanKwargs(ReadOnlySpan<Keyword> kwargs, out int numArgs, out int firstArgPos) {
+                numArgs = 0;
+                firstArgPos = kwargs.Length;
+
+                if (kwargs.Length == 0) return;
+
+                for (var i = kwargs.Length - 1; i >= 0; i--) {
+                    var kwarg = kwargs[i];
+                    if (kwarg.Name is null) {
                         firstArgPos = i;
                         numArgs++;
                     }
@@ -135,41 +154,28 @@ namespace IronPython.Compiler.Ast {
             }
 
             // Compare to: ClassDefinition.Reduce.__UnpackBasesHelper
-            static MSAst.Expression UnpackListHelper(IReadOnlyList<Arg> args, int firstListPos) {
-                Debug.Assert(args.Count > 0);
-                Debug.Assert(args[firstListPos].ArgumentInfo.Kind == ArgumentType.List);
+            static MSAst.Expression UnpackListHelper(ReadOnlySpan<Expression> args) {
+                Debug.Assert(args.Length > 0);
+                Debug.Assert(args[0] is StarredExpression);
 
-                if (args.Count - firstListPos == 1) return args[firstListPos].Expression;
+                if (args.Length == 1) return ((StarredExpression)args[0]).Value;
 
-                var expressions = new ReadOnlyCollectionBuilder<MSAst.Expression>(args.Count - firstListPos + 2);
-                var varExpr = Expression.Variable(typeof(PythonList), "$coll");
-                expressions.Add(Expression.Assign(varExpr, Expression.Call(AstMethods.MakeEmptyList)));
-                for (int i = firstListPos; i < args.Count; i++) {
-                    var arg = args[i];
-                    if (arg.ArgumentInfo.Kind == ArgumentType.List) {
-                        expressions.Add(Expression.Call(AstMethods.ListExtend, varExpr, AstUtils.Convert(arg.Expression, typeof(object))));
-                    } else {
-                        expressions.Add(Expression.Call(AstMethods.ListAppend, varExpr, AstUtils.Convert(arg.Expression, typeof(object))));
-                    }
-                }
-                expressions.Add(varExpr);
-                return Expression.Block(typeof(PythonList), new MSAst.ParameterExpression[] { varExpr }, expressions);
+                return UnpackSequenceHelper<Expression>(args, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend);
             }
 
-            // Compare to: ClassDefinition.Reduce.__UnpackKeywordsHelper
-            static MSAst.Expression UnpackDictHelper(MSAst.Expression context, IReadOnlyList<Arg> kwargs, int numDict, int firstDictPos) {
-                Debug.Assert(kwargs.Count > 0);
-                Debug.Assert(0 < numDict && numDict <= kwargs.Count);
-                Debug.Assert(kwargs[firstDictPos].ArgumentInfo.Kind == ArgumentType.Dictionary);
+            // Compare to: CallExpression.Reduce.__UnpackKeywordsHelper
+            static MSAst.Expression UnpackDictHelper(MSAst.Expression context, ReadOnlySpan<Keyword> kwargs, int numDict) {
+                Debug.Assert(kwargs.Length > 0);
+                Debug.Assert(0 < numDict && numDict <= kwargs.Length);
+                Debug.Assert(kwargs[0].Name is null);
 
-                if (numDict == 1) return kwargs[firstDictPos].Expression;
+                if (numDict == 1) return kwargs[0].Expression;
 
                 var expressions = new ReadOnlyCollectionBuilder<MSAst.Expression>(numDict + 2);
                 var varExpr = Expression.Variable(typeof(PythonDictionary), "$dict");
                 expressions.Add(Expression.Assign(varExpr, Expression.Call(AstMethods.MakeEmptyDict)));
-                for (int i = firstDictPos; i < kwargs.Count; i++) {
-                    var arg = kwargs[i];
-                    if (arg.ArgumentInfo.Kind == ArgumentType.Dictionary) {
+                foreach (var arg in kwargs) {
+                    if (arg.Name is null) {
                         expressions.Add(Expression.Call(AstMethods.DictMerge, context, varExpr, arg.Expression));
                     }
                 }
@@ -181,8 +187,8 @@ namespace IronPython.Compiler.Ast {
         #region IInstructionProvider Members
 
         void IInstructionProvider.AddInstructions(LightCompiler compiler) {
-            IReadOnlyList<Arg> args = Args;
-            if (args.Count == 0 && _implicitArgs != null && _implicitArgs.Count > 0) {
+            ReadOnlySpan<Expression> args = _args;
+            if (args.Length == 0 && _implicitArgs != null) {
                 args = _implicitArgs;
             }
 
@@ -191,14 +197,14 @@ namespace IronPython.Compiler.Ast {
                 return;
             }
 
-            for (int i = 0; i < args.Count; i++) {
-                if (!args[i].ArgumentInfo.IsSimple) {
+            for (int i = 0; i < args.Length; i++) {
+                if (args[i] is StarredExpression) {
                     compiler.Compile(Reduce());
                     return;
                 }
             }
 
-            switch (args.Count) {
+            switch (args.Length) {
                 #region Generated Python Call Expression Instruction Switch
 
                 // *** BEGIN GENERATED CODE ***
@@ -212,52 +218,52 @@ namespace IronPython.Compiler.Ast {
                 case 1:
                     compiler.Compile(Parent.LocalContext);
                     compiler.Compile(Target);
-                    compiler.Compile(args[0].Expression);
+                    compiler.Compile(args[0]);
                     compiler.Instructions.Emit(new Invoke1Instruction(Parent.PyContext));
                     return;
                 case 2:
                     compiler.Compile(Parent.LocalContext);
                     compiler.Compile(Target);
-                    compiler.Compile(args[0].Expression);
-                    compiler.Compile(args[1].Expression);
+                    compiler.Compile(args[0]);
+                    compiler.Compile(args[1]);
                     compiler.Instructions.Emit(new Invoke2Instruction(Parent.PyContext));
                     return;
                 case 3:
                     compiler.Compile(Parent.LocalContext);
                     compiler.Compile(Target);
-                    compiler.Compile(args[0].Expression);
-                    compiler.Compile(args[1].Expression);
-                    compiler.Compile(args[2].Expression);
+                    compiler.Compile(args[0]);
+                    compiler.Compile(args[1]);
+                    compiler.Compile(args[2]);
                     compiler.Instructions.Emit(new Invoke3Instruction(Parent.PyContext));
                     return;
                 case 4:
                     compiler.Compile(Parent.LocalContext);
                     compiler.Compile(Target);
-                    compiler.Compile(args[0].Expression);
-                    compiler.Compile(args[1].Expression);
-                    compiler.Compile(args[2].Expression);
-                    compiler.Compile(args[3].Expression);
+                    compiler.Compile(args[0]);
+                    compiler.Compile(args[1]);
+                    compiler.Compile(args[2]);
+                    compiler.Compile(args[3]);
                     compiler.Instructions.Emit(new Invoke4Instruction(Parent.PyContext));
                     return;
                 case 5:
                     compiler.Compile(Parent.LocalContext);
                     compiler.Compile(Target);
-                    compiler.Compile(args[0].Expression);
-                    compiler.Compile(args[1].Expression);
-                    compiler.Compile(args[2].Expression);
-                    compiler.Compile(args[3].Expression);
-                    compiler.Compile(args[4].Expression);
+                    compiler.Compile(args[0]);
+                    compiler.Compile(args[1]);
+                    compiler.Compile(args[2]);
+                    compiler.Compile(args[3]);
+                    compiler.Compile(args[4]);
                     compiler.Instructions.Emit(new Invoke5Instruction(Parent.PyContext));
                     return;
                 case 6:
                     compiler.Compile(Parent.LocalContext);
                     compiler.Compile(Target);
-                    compiler.Compile(args[0].Expression);
-                    compiler.Compile(args[1].Expression);
-                    compiler.Compile(args[2].Expression);
-                    compiler.Compile(args[3].Expression);
-                    compiler.Compile(args[4].Expression);
-                    compiler.Compile(args[5].Expression);
+                    compiler.Compile(args[0]);
+                    compiler.Compile(args[1]);
+                    compiler.Compile(args[2]);
+                    compiler.Compile(args[3]);
+                    compiler.Compile(args[4]);
+                    compiler.Compile(args[5]);
                     compiler.Instructions.Emit(new Invoke6Instruction(Parent.PyContext));
                     return;
 
@@ -424,17 +430,15 @@ namespace IronPython.Compiler.Ast {
         public override void Walk(PythonWalker walker) {
             if (walker.Walk(this)) {
                 Target?.Walk(walker);
-                if (Args != null) {
-                    foreach (Arg arg in Args) {
+                if (_implicitArgs is not null) {
+                    foreach (var arg in _implicitArgs) {
                         arg.Walk(walker);
                     }
                 }
-                if (_implicitArgs != null && _implicitArgs.Count > 0) {
-                    foreach (Arg arg in ImplicitArgs) {
-                        arg.Walk(walker);
-                    }
+                foreach (var arg in _args) {
+                    arg.Walk(walker);
                 }
-                foreach (Arg arg in Kwargs) {
+                foreach (var arg in _kwargs) {
                     arg.Walk(walker);
                 }
             }

--- a/Src/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -209,7 +209,7 @@ namespace IronPython.Compiler.Ast {
                 foreach (var arg in bases) {
                     if (arg is StarredExpression) {
                         return Expression.Call(AstMethods.ListToTuple,
-                            Expression.UnpackSequenceHelper<Expression>(bases, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend)
+                            Expression.UnpackSequenceHelper<PythonList>(bases, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend)
                         );
                     }
                 }

--- a/Src/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -27,8 +27,8 @@ namespace IronPython.Compiler.Ast {
 
     public class ClassDefinition : ScopeStatement {
         private readonly string _name;
-        private readonly Arg[] _bases;
-        private readonly Arg[] _keywords;
+        private readonly Expression[] _bases;
+        private readonly Keyword[] _keywords;
 
         private LightLambdaExpression? _dlrBody;       // the transformed body including all of our initialization, etc...
 
@@ -37,10 +37,10 @@ namespace IronPython.Compiler.Ast {
         private static readonly MSAst.ParameterExpression _parentContextParam = Ast.Parameter(typeof(CodeContext), "$parentContext");
         private static readonly MSAst.Expression _tupleExpression = MSAst.Expression.Call(AstMethods.GetClosureTupleFromContext, _parentContextParam);
 
-        public ClassDefinition(string name, IReadOnlyList<Arg>? bases, IReadOnlyList<Arg>? keywords, Statement? body = null) {
+        public ClassDefinition(string name, IReadOnlyList<Expression>? bases, IReadOnlyList<Keyword>? keywords, Statement? body = null) {
             _name = name;
-            _bases = bases?.ToArray() ?? Array.Empty<Arg>();
-            _keywords = keywords?.ToArray() ?? Array.Empty<Arg>();
+            _bases = bases?.ToArray() ?? Array.Empty<Expression>();
+            _keywords = keywords?.ToArray() ?? Array.Empty<Keyword>();
             Body = body ?? EmptyStatement.PreCompiledInstance;
         }
 
@@ -50,9 +50,9 @@ namespace IronPython.Compiler.Ast {
 
         public override string Name => _name;
 
-        public IReadOnlyList<Arg> Bases => _bases;
+        public IReadOnlyList<Expression> Bases => _bases;
 
-        public IReadOnlyList<Arg> Keywords => _keywords;
+        public IReadOnlyList<Keyword> Keywords => _keywords;
 
         public Statement Body { get; set; }
 
@@ -194,7 +194,7 @@ namespace IronPython.Compiler.Ast {
             classDef = AddDecorators(classDef, Decorators);
 
             return GlobalParent.AddDebugInfoAndVoid(
-                AssignValue(Parent.GetVariableExpression(PythonVariable!), classDef), 
+                AssignValue(Parent.GetVariableExpression(PythonVariable!), classDef),
                 new SourceSpan(
                     GlobalParent.IndexToLocation(StartIndex),
                     GlobalParent.IndexToLocation(HeaderIndex)
@@ -202,34 +202,27 @@ namespace IronPython.Compiler.Ast {
             );
 
             // Compare to: CallExpression.Reduce.__UnpackListHelper
-            static MSAst.Expression UnpackBasesHelper(IReadOnlyList<Arg> bases) {
-                if (bases.Count == 0) {
+            static MSAst.Expression UnpackBasesHelper(ReadOnlySpan<Expression> bases) {
+                if (bases.Length == 0) {
                     return Expression.Call(AstMethods.MakeEmptyTuple);
-                } else if (bases.All(arg => arg.ArgumentInfo.Kind is ArgumentType.Simple)) {
-                    return Expression.Call(AstMethods.MakeTuple,
-                        Expression.NewArrayInit(
-                            typeof(object),
-                            ToObjectArray(bases.Select(arg => arg.Expression).ToList())
-                        )
-                    );
-                } else {
-                    var expressions = new ReadOnlyCollectionBuilder<MSAst.Expression>(bases.Count + 2);
-                    var varExpr = Expression.Variable(typeof(PythonList), "$coll");
-                    expressions.Add(Expression.Assign(varExpr, Expression.Call(AstMethods.MakeEmptyList)));
-                    foreach (var arg in bases) {
-                        if (arg.ArgumentInfo.Kind == ArgumentType.List) {
-                            expressions.Add(Expression.Call(AstMethods.ListExtend, varExpr, AstUtils.Convert(arg.Expression, typeof(object))));
-                        } else {
-                            expressions.Add(Expression.Call(AstMethods.ListAppend, varExpr, AstUtils.Convert(arg.Expression, typeof(object))));
-                        }
-                    }
-                    expressions.Add(Expression.Call(AstMethods.ListToTuple, varExpr));
-                    return Expression.Block(typeof(PythonTuple), new MSAst.ParameterExpression[] { varExpr }, expressions);
                 }
+                foreach (var arg in bases) {
+                    if (arg is StarredExpression) {
+                        return Expression.Call(AstMethods.ListToTuple,
+                            Expression.UnpackSequenceHelper<Expression>(bases, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend)
+                        );
+                    }
+                }
+                return Expression.Call(AstMethods.MakeTuple,
+                    Expression.NewArrayInit(
+                        typeof(object),
+                        ToObjectArray(bases)
+                    )
+                );
             }
 
             // Compare to: CallExpression.Reduce.__UnpackDictHelper
-            static MSAst.Expression UnpackKeywordsHelper(MSAst.Expression context, IReadOnlyList<Arg> kwargs) {
+            static MSAst.Expression UnpackKeywordsHelper(MSAst.Expression context, IReadOnlyList<Keyword> kwargs) {
                 if (kwargs.Count == 0) {
                     return AstUtils.Constant(null, typeof(PythonDictionary));
                 }
@@ -238,7 +231,7 @@ namespace IronPython.Compiler.Ast {
                 var varExpr = Expression.Variable(typeof(PythonDictionary), "$dict");
                 expressions.Add(Expression.Assign(varExpr, Expression.Call(AstMethods.MakeEmptyDict)));
                 foreach (var arg in kwargs) {
-                    if (arg.ArgumentInfo.Kind == ArgumentType.Dictionary) {
+                    if (arg.Name is null) {
                         expressions.Add(Expression.Call(AstMethods.DictMerge, context, varExpr, AstUtils.Convert(arg.Expression, typeof(object))));
                     } else {
                         expressions.Add(Expression.Call(AstMethods.DictMergeOne, context, varExpr, AstUtils.Constant(arg.Name, typeof(object)), AstUtils.Convert(arg.Expression, typeof(object))));
@@ -346,10 +339,10 @@ namespace IronPython.Compiler.Ast {
                         decorator.Walk(walker);
                     }
                 }
-                foreach (Arg b in _bases) {
+                foreach (var b in _bases) {
                     b.Walk(walker);
                 }
-                foreach (Arg b in _keywords) {
+                foreach (var b in _keywords) {
                     b.Walk(walker);
                 }
                 Body.Walk(walker);

--- a/Src/IronPython/Compiler/Ast/Expression.cs
+++ b/Src/IronPython/Compiler/Ast/Expression.cs
@@ -21,21 +21,6 @@ namespace IronPython.Compiler.Ast {
     public abstract class Expression : Node {
         internal static readonly Expression[] EmptyArray = Array.Empty<Expression>();
 
-        protected internal static MSAst.BlockExpression UnpackSequenceHelper<T>(IList<Expression> items, MethodInfo makeEmpty, MethodInfo append, MethodInfo extend) {
-            var expressions = new ReadOnlyCollectionBuilder<MSAst.Expression>(items.Count + 2);
-            var varExpr = Expression.Variable(typeof(T), "$coll");
-            expressions.Add(Expression.Assign(varExpr, Expression.Call(makeEmpty)));
-            foreach (var item in items) {
-                if (item is StarredExpression starredExpression) {
-                    expressions.Add(Expression.Call(extend, varExpr, AstUtils.Convert(starredExpression.Value, typeof(object))));
-                } else {
-                    expressions.Add(Expression.Call(append, varExpr, AstUtils.Convert(item, typeof(object))));
-                }
-            }
-            expressions.Add(varExpr);
-            return Expression.Block(typeof(T), new MSAst.ParameterExpression[] { varExpr }, expressions);
-        }
-
         protected internal static MSAst.BlockExpression UnpackSequenceHelper<T>(ReadOnlySpan<Expression> items, MethodInfo makeEmpty, MethodInfo append, MethodInfo extend) {
             var expressions = new ReadOnlyCollectionBuilder<MSAst.Expression>(items.Length + 2);
             var varExpr = Expression.Variable(typeof(T), "$coll");

--- a/Src/IronPython/Compiler/Ast/Expression.cs
+++ b/Src/IronPython/Compiler/Ast/Expression.cs
@@ -36,6 +36,21 @@ namespace IronPython.Compiler.Ast {
             return Expression.Block(typeof(T), new MSAst.ParameterExpression[] { varExpr }, expressions);
         }
 
+        protected internal static MSAst.BlockExpression UnpackSequenceHelper<T>(ReadOnlySpan<Expression> items, MethodInfo makeEmpty, MethodInfo append, MethodInfo extend) {
+            var expressions = new ReadOnlyCollectionBuilder<MSAst.Expression>(items.Length + 2);
+            var varExpr = Expression.Variable(typeof(T), "$coll");
+            expressions.Add(Expression.Assign(varExpr, Expression.Call(makeEmpty)));
+            foreach (var item in items) {
+                if (item is StarredExpression starredExpression) {
+                    expressions.Add(Expression.Call(extend, varExpr, AstUtils.Convert(starredExpression.Value, typeof(object))));
+                } else {
+                    expressions.Add(Expression.Call(append, varExpr, AstUtils.Convert(item, typeof(object))));
+                }
+            }
+            expressions.Add(varExpr);
+            return Expression.Block(typeof(T), new MSAst.ParameterExpression[] { varExpr }, expressions);
+        }
+
         internal virtual MSAst.Expression TransformSet(SourceSpan span, MSAst.Expression right, PythonOperationKind op) {
             // unreachable, CheckAssign prevents us from calling this at parse time.
             Debug.Assert(false);

--- a/Src/IronPython/Compiler/Ast/FlowChecker.cs
+++ b/Src/IronPython/Compiler/Ast/FlowChecker.cs
@@ -328,10 +328,10 @@ namespace IronPython.Compiler.Ast {
             } else {
                 // analyze the class definition itself (it is visited while analyzing parent scope):
                 Define(node.Name);
-                foreach (Arg e in node.Bases) {
+                foreach (var e in node.Bases) {
                     e.Walk(this);
                 }
-                foreach (Arg e in node.Keywords) {
+                foreach (var e in node.Keywords) {
                     e.Walk(this);
                 }
                 return false;

--- a/Src/IronPython/Compiler/Ast/IndexExpression.cs
+++ b/Src/IronPython/Compiler/Ast/IndexExpression.cs
@@ -32,7 +32,7 @@ namespace IronPython.Compiler.Ast {
 
         private MSAst.Expression[] GetActionArgumentsForGetOrDelete() {
             if (Index is TupleExpression te && te.IsExpandable) {
-                return ArrayUtils.Insert(Target, te.Items);
+                return ArrayUtils.Insert(Target, te.UnsafeItems);
             }
 
             if (Index is SliceExpression se) {

--- a/Src/IronPython/Compiler/Ast/Keyword.cs
+++ b/Src/IronPython/Compiler/Ast/Keyword.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
@@ -7,29 +7,15 @@
 using Microsoft.Scripting.Actions;
 
 namespace IronPython.Compiler.Ast {
-    public class Arg : Node {
-        private static readonly Argument _listTypeArgument = new(ArgumentType.List);
-        private static readonly Argument _dictTypeArgument = new(ArgumentType.Dictionary);
-
-        public Arg(Expression expression) : this(null, expression) { }
-
-        public Arg(string? name, Expression expression) {
+    public class Keyword : Node {
+        public Keyword(string? name, Expression expression) {
             Name = name;
             Expression = expression;
-
-            ArgumentInfo = name switch {
-                null => Argument.Simple,
-                "*"  => _listTypeArgument,
-                "**" => _dictTypeArgument,
-                _    => new Argument(name)
-            };
         }
 
         public string? Name { get; }
 
         public Expression Expression { get; }
-
-        internal Argument ArgumentInfo { get; }
 
         public override string ToString() {
             return base.ToString() + ":" + Name;

--- a/Src/IronPython/Compiler/Ast/ListExpression.cs
+++ b/Src/IronPython/Compiler/Ast/ListExpression.cs
@@ -20,14 +20,14 @@ namespace IronPython.Compiler.Ast {
             }
 
             if (HasStarredExpression) {
-                return UnpackSequenceHelper<PythonList>(Items, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend);
+                return UnpackSequenceHelper<PythonList>(_items, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend);
             }
 
             return Call(
                 AstMethods.MakeListNoCopy,  // method
                 NewArrayInit(           // parameters
                     typeof(object),
-                    ToObjectArray(Items)
+                    ToObjectArray(_items)
                 )
             );
         }

--- a/Src/IronPython/Compiler/Ast/Node.cs
+++ b/Src/IronPython/Compiler/Ast/Node.cs
@@ -164,14 +164,6 @@ namespace IronPython.Compiler.Ast {
 
         #region Transformation Helpers
 
-        internal static MSAst.Expression[] ToObjectArray(IList<Expression> expressions) {
-            MSAst.Expression[] to = new MSAst.Expression[expressions.Count];
-            for (int i = 0; i < expressions.Count; i++) {
-                to[i] = AstUtils.Convert(expressions[i], typeof(object));
-            }
-            return to;
-        }
-
         internal static MSAst.Expression[] ToObjectArray(ReadOnlySpan<Expression> expressions) {
             MSAst.Expression[] to = new MSAst.Expression[expressions.Length];
             for (int i = 0; i < expressions.Length; i++) {

--- a/Src/IronPython/Compiler/Ast/Node.cs
+++ b/Src/IronPython/Compiler/Ast/Node.cs
@@ -172,6 +172,14 @@ namespace IronPython.Compiler.Ast {
             return to;
         }
 
+        internal static MSAst.Expression[] ToObjectArray(ReadOnlySpan<Expression> expressions) {
+            MSAst.Expression[] to = new MSAst.Expression[expressions.Length];
+            for (int i = 0; i < expressions.Length; i++) {
+                to[i] = AstUtils.Convert(expressions[i], typeof(object));
+            }
+            return to;
+        }
+
         internal static MSAst.Expression TransformOrConstantNull(Expression expression, Type/*!*/ type) {
             if (expression == null) {
                 return AstUtils.Constant(null, type);

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -206,9 +206,9 @@ namespace IronPython.Compiler.Ast {
             node.PythonVariable = DefineName(node.Name);
 
             // Base references are in the outer context
-            foreach (Arg b in node.Bases) b.Walk(this);
+            foreach (var b in node.Bases) b.Walk(this);
 
-            foreach (Arg a in node.Keywords) a.Walk(this);
+            foreach (var a in node.Keywords) a.Walk(this);
 
             // process the decorators in the outer context
             if (node.Decorators != null) {
@@ -333,11 +333,6 @@ namespace IronPython.Compiler.Ast {
             node.Parent = _currentScope;
             return base.Walk(node);
         }
-        // Arg
-        public override bool Walk(Arg node) {
-            node.Parent = _currentScope;
-            return base.Walk(node);
-        }
         // AssertStatement
         public override bool Walk(AssertStatement node) {
             node.Parent = _currentScope;
@@ -410,6 +405,11 @@ namespace IronPython.Compiler.Ast {
         }
         // IndexExpression
         public override bool Walk(IndexExpression node) {
+            node.Parent = _currentScope;
+            return base.Walk(node);
+        }
+        // Keyword
+        public override bool Walk(Keyword node) {
             node.Parent = _currentScope;
             return base.Walk(node);
         }
@@ -836,8 +836,7 @@ namespace IronPython.Compiler.Ast {
             if (node.Target is NameExpression nameExpr && nameExpr.Name == "super" && _currentScope is FunctionDefinition func) {
                 _currentScope.Reference("__class__");
                 if (node.Args.Count == 0 && node.Kwargs.Count == 0 && func.ParameterNames.Length > 0) {
-                    node.ImplicitArgs.Add(new Arg(new NameExpression("__class__")));
-                    node.ImplicitArgs.Add(new Arg(new NameExpression(func.ParameterNames[0])));
+                    node.SetImplicitArgs(new NameExpression("__class__"), new NameExpression(func.ParameterNames[0]));
                 }
             }
             return base.Walk(node);

--- a/Src/IronPython/Compiler/Ast/PythonWalker.Generated.cs
+++ b/Src/IronPython/Compiler/Ast/PythonWalker.Generated.cs
@@ -72,7 +72,6 @@ namespace IronPython.Compiler.Ast {
         public virtual bool Walk(MemberExpression node) { return true; }
         public virtual void PostWalk(MemberExpression node) { }
 
-
         // NameExpression
         public virtual bool Walk(NameExpression node) { return true; }
         public virtual void PostWalk(NameExpression node) { }
@@ -213,10 +212,6 @@ namespace IronPython.Compiler.Ast {
         public virtual bool Walk(WithStatement node) { return true; }
         public virtual void PostWalk(WithStatement node) { }
 
-        // Arg
-        public virtual bool Walk(Arg node) { return true; }
-        public virtual void PostWalk(Arg node) { }
-
         // ComprehensionFor
         public virtual bool Walk(ComprehensionFor node) { return true; }
         public virtual void PostWalk(ComprehensionFor node) { }
@@ -232,6 +227,10 @@ namespace IronPython.Compiler.Ast {
         // IfStatementTest
         public virtual bool Walk(IfStatementTest node) { return true; }
         public virtual void PostWalk(IfStatementTest node) { }
+
+        // Keyword
+        public virtual bool Walk(Keyword node) { return true; }
+        public virtual void PostWalk(Keyword node) { }
 
         // ModuleName
         public virtual bool Walk(ModuleName node) { return true; }
@@ -460,10 +459,6 @@ namespace IronPython.Compiler.Ast {
         public override bool Walk(WithStatement node) { return false; }
         public override void PostWalk(WithStatement node) { }
 
-        // Arg
-        public override bool Walk(Arg node) { return false; }
-        public override void PostWalk(Arg node) { }
-
         // ComprehensionFor
         public override bool Walk(ComprehensionFor node) { return false; }
         public override void PostWalk(ComprehensionFor node) { }
@@ -479,6 +474,10 @@ namespace IronPython.Compiler.Ast {
         // IfStatementTest
         public override bool Walk(IfStatementTest node) { return false; }
         public override void PostWalk(IfStatementTest node) { }
+
+        // Keyword
+        public override bool Walk(Keyword node) { return false; }
+        public override void PostWalk(Keyword node) { }
 
         // ModuleName
         public override bool Walk(ModuleName node) { return false; }

--- a/Src/IronPython/Compiler/Ast/SequenceExpression.cs
+++ b/Src/IronPython/Compiler/Ast/SequenceExpression.cs
@@ -18,13 +18,15 @@ using MSAst = System.Linq.Expressions;
 
 namespace IronPython.Compiler.Ast {
     public abstract class SequenceExpression : Expression {
-        private readonly Expression[] _items;
+        protected readonly Expression[] _items;
 
         protected SequenceExpression(Expression[] items) {
             _items = items;
         }
 
-        public IList<Expression> Items => _items;
+        public IReadOnlyList<Expression> Items => _items;
+
+        internal Expression[] UnsafeItems => _items; // TODO: get rid of this
 
         protected bool HasStarredExpression => Items.OfType<StarredExpression>().Any();
 

--- a/Src/IronPython/Compiler/Ast/SetExpression.cs
+++ b/Src/IronPython/Compiler/Ast/SetExpression.cs
@@ -24,13 +24,13 @@ namespace IronPython.Compiler.Ast {
             _items = items;
         }
 
-        public IList<Expression> Items => _items;
+        public IReadOnlyList<Expression> Items => _items;
 
         protected bool HasStarredExpression => Items.OfType<StarredExpression>().Any();
 
         public override MSAst.Expression Reduce() {
             if (HasStarredExpression) {
-                return UnpackSequenceHelper<SetCollection>(Items, AstMethods.MakeEmptySet, AstMethods.SetAdd, AstMethods.SetUpdate);
+                return UnpackSequenceHelper<SetCollection>(_items, AstMethods.MakeEmptySet, AstMethods.SetAdd, AstMethods.SetUpdate);
             }
 
             return Expression.Call(

--- a/Src/IronPython/Compiler/Ast/StarredExpression.cs
+++ b/Src/IronPython/Compiler/Ast/StarredExpression.cs
@@ -69,16 +69,36 @@ namespace IronPython.Compiler.Ast {
 
         public override bool Walk(CallExpression node) {
             node.Target?.Walk(this);
-            foreach (var item in node.Args) {
-                if (item is StarredExpression starred) {
+            foreach (var arg in node.Args) {
+                if (arg is StarredExpression starred) {
                     starred.Value.Walk(this);
                 } else {
-                    item.Walk(this);
+                    arg.Walk(this);
                 }
             }
             foreach (var arg in node.Kwargs) {
                 arg.Walk(this);
             };
+            return false;
+        }
+
+        public override bool Walk(ClassDefinition node) {
+            if (node.Decorators != null) {
+                foreach (Expression decorator in node.Decorators) {
+                    decorator.Walk(this);
+                }
+            }
+            foreach (var b in node.Bases) {
+                if (b is StarredExpression starred) {
+                    starred.Value.Walk(this);
+                } else {
+                    b.Walk(this);
+                }
+            }
+            foreach (var b in node.Keywords) {
+                b.Walk(this);
+            }
+            node.Body.Walk(this);
             return false;
         }
 

--- a/Src/IronPython/Compiler/Ast/StarredExpression.cs
+++ b/Src/IronPython/Compiler/Ast/StarredExpression.cs
@@ -67,6 +67,21 @@ namespace IronPython.Compiler.Ast {
             return false;
         }
 
+        public override bool Walk(CallExpression node) {
+            node.Target?.Walk(this);
+            foreach (var item in node.Args) {
+                if (item is StarredExpression starred) {
+                    starred.Value.Walk(this);
+                } else {
+                    item.Walk(this);
+                }
+            }
+            foreach (var arg in node.Kwargs) {
+                arg.Walk(this);
+            };
+            return false;
+        }
+
         public override bool Walk(ForStatement node) {
             WalkAssignmentTarget(node.Left);
             node.List?.Walk(this);

--- a/Src/IronPython/Compiler/Ast/StarredExpression.cs
+++ b/Src/IronPython/Compiler/Ast/StarredExpression.cs
@@ -119,7 +119,7 @@ namespace IronPython.Compiler.Ast {
             }
         }
 
-        private bool WalkItems(IList<Expression> items) {
+        private bool WalkItems(IReadOnlyList<Expression> items) {
             foreach (var item in items) {
                 if (item is StarredExpression starred) {
                     starred.Value.Walk(this);

--- a/Src/IronPython/Compiler/Ast/TupleExpression.cs
+++ b/Src/IronPython/Compiler/Ast/TupleExpression.cs
@@ -35,7 +35,7 @@ namespace IronPython.Compiler.Ast {
             if (IsExpandable) {
                 return Expression.NewArrayInit(
                     typeof(object),
-                    ToObjectArray(Items)
+                    ToObjectArray(_items)
                 );
             }
 
@@ -47,14 +47,14 @@ namespace IronPython.Compiler.Ast {
             }
 
             if (HasStarredExpression) {
-                return Expression.Call(AstMethods.ListToTuple, UnpackSequenceHelper<PythonList>(Items, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend));
+                return Expression.Call(AstMethods.ListToTuple, UnpackSequenceHelper<PythonList>(_items, AstMethods.MakeEmptyList, AstMethods.ListAppend, AstMethods.ListExtend));
             }
 
             return Expression.Call(
                 AstMethods.MakeTuple,
                 Expression.NewArrayInit(
                     typeof(object),
-                    ToObjectArray(Items)
+                    ToObjectArray(_items)
                 )
             );
         }

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -2175,7 +2175,7 @@ namespace IronPython.Compiler {
         }
 
         private void CheckUniqueArgument(List<Node> names, Keyword arg) {
-            if (arg != null && arg.Name != null) {
+            if (arg.Name != null) {
                 for (int i = 0; i < names.Count; i++) {
                     if (names[i] is Keyword k && k.Name == arg.Name) {
                         ReportSyntaxError(IronPython.Resources.DuplicateKeywordArg);
@@ -2201,20 +2201,16 @@ namespace IronPython.Compiler {
                 }
                 var start = GetStart();
                 Node a;
-                if (PeekToken(TokenKind.Multiply)) {
-                    var s = GetStart();
-                    NextToken();
+                if (MaybeEat(TokenKind.Multiply)) {
                     a = new StarredExpression(ParseTest());
-                    a.SetLoc(_globalParent, s, GetEnd());
+                    a.SetLoc(_globalParent, start, GetEnd());
                 } else if (MaybeEat(TokenKind.Power)) {
-                    Expression t = ParseTest();
-                    a = new Keyword(null, t);
+                    a = new Keyword(null, ParseTest());
                 } else {
                     Expression e = ParseTest();
                     if (MaybeEat(TokenKind.Assign)) {
-                        var k = FinishKeywordArgument(e);
-                        a = k;
-                        CheckUniqueArgument(l, k);
+                        a = FinishKeywordArgument(e);
+                        CheckUniqueArgument(l, (Keyword)a);
                     } else {
                         a = e;
                     }

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -1009,10 +1009,10 @@ namespace IronPython.Compiler {
                 return new ClassDefinition(string.Empty, null, null, ErrorStmt());
             }
 
-            List<Arg> bases = null;
-            List<Arg> keywords = null;
+            List<Expression> bases = null;
+            List<Keyword> keywords = null;
             if (MaybeEat(TokenKind.LeftParenthesis)) {
-                IReadOnlyList<Arg> args = FinishArgumentList(null);
+                IReadOnlyList<Node> args = FinishArgumentList(null);
                 SplitAndValidateArguments(args, out bases, out keywords);
             }
             var mid = GetEnd();
@@ -1058,7 +1058,7 @@ namespace IronPython.Compiler {
 
                 if (MaybeEat(TokenKind.LeftParenthesis)) {
                     ParserSink?.StartParameters(GetSourceSpan());
-                    IReadOnlyList<Arg> args = FinishArgumentList(null);
+                    IReadOnlyList<Node> args = FinishArgumentList(null);
                     decorator = FinishCallExpr(decorator, args);
                 }
                 decorator.SetLoc(_globalParent, start, GetEnd());
@@ -1982,7 +1982,7 @@ namespace IronPython.Compiler {
                             if (!allowGeneratorExpression) return ret;
 
                             NextToken();
-                            IReadOnlyList<Arg> args = FinishArgListOrGenExpr();
+                            IReadOnlyList<Node> args = FinishArgListOrGenExpr();
                             CallExpression call = FinishCallExpr(ret, args);
                             call.SetLoc(_globalParent, ret.StartIndex, GetEnd());
                             ret = call;
@@ -2120,8 +2120,8 @@ namespace IronPython.Compiler {
         //             expression "=" expression      rest_of_arguments
         //             expression "for" gen_expr_rest
         //
-        private IReadOnlyList<Arg> FinishArgListOrGenExpr() {
-            Arg a = null;
+        private IReadOnlyList<Node> FinishArgListOrGenExpr() {
+            Node a = null;
 
             ParserSink?.StartParameters(GetSourceSpan());
 
@@ -2135,20 +2135,14 @@ namespace IronPython.Compiler {
 
                 if (MaybeEat(TokenKind.Assign)) {               //  Keyword argument
                     a = FinishKeywordArgument(e);
-
-                    if (a == null) {                            // Error recovery
-                        a = new Arg(e);
-                        a.SetLoc(_globalParent, e.StartIndex, GetEnd());
-                    }
                 } else if (PeekToken(Tokens.KeywordForToken)) {    //  Generator expression
-                    a = new Arg(ParseGeneratorExpression(e));
+                    a = ParseGeneratorExpression(e);
                     Eat(TokenKind.RightParenthesis);
                     a.SetLoc(_globalParent, start, GetEnd());
                     ParserSink?.EndParameters(GetSourceSpan());
-                    return new Arg[1] { a };       //  Generator expression is the argument
+                    return new Node[1] { a };       //  Generator expression is the argument
                 } else {
-                    a = new Arg(e);
-                    a.SetLoc(_globalParent, e.StartIndex, e.EndIndex);
+                    a = e;
                 }
 
                 //  Was this all?
@@ -2159,31 +2153,31 @@ namespace IronPython.Compiler {
                     Eat(TokenKind.RightParenthesis);
                     a.SetLoc(_globalParent, start, GetEnd());
                     ParserSink?.EndParameters(GetSourceSpan());
-                    return new Arg[1] { a };
+                    return new Node[1] { a };
                 }
             }
 
             return FinishArgumentList(a);
         }
 
-        private Arg FinishKeywordArgument(Expression t) {
+        private Keyword FinishKeywordArgument(Expression t) {
             if (t is NameExpression n) {
                 Expression val = ParseTest();
-                Arg arg = new Arg(n.Name, val);
+                var arg = new Keyword(n.Name, val);
                 arg.SetLoc(_globalParent, n.StartIndex, val.EndIndex);
                 return arg;
             } else {
                 ReportSyntaxError(IronPython.Resources.ExpectedName);
-                Arg arg = new Arg(null, t);
+                var arg = new Keyword(null, t);
                 arg.SetLoc(_globalParent, t.StartIndex, t.EndIndex);
                 return arg;
             }
         }
 
-        private void CheckUniqueArgument(List<Arg> names, Arg arg) {
+        private void CheckUniqueArgument(List<Node> names, Keyword arg) {
             if (arg != null && arg.Name != null) {
                 for (int i = 0; i < names.Count; i++) {
-                    if (names[i].Name == arg.Name) {
+                    if (names[i] is Keyword k && k.Name == arg.Name) {
                         ReportSyntaxError(IronPython.Resources.DuplicateKeywordArg);
                     }
                 }
@@ -2192,9 +2186,9 @@ namespace IronPython.Compiler {
 
         //arglist: (argument ',')* (argument [',']| '*' expression [',' '**' expression] | '**' expression)
         //argument: [expression '='] expression    # Really [keyword '='] expression
-        private IReadOnlyList<Arg> FinishArgumentList(Arg first) {
+        private IReadOnlyList<Node> FinishArgumentList(Node first) {
             const TokenKind terminator = TokenKind.RightParenthesis;
-            List<Arg> l = new List<Arg>();
+            List<Node> l = new List<Node>();
 
             if (first != null) {
                 l.Add(first);
@@ -2206,20 +2200,23 @@ namespace IronPython.Compiler {
                     break;
                 }
                 var start = GetStart();
-                Arg a;
-                if (MaybeEat(TokenKind.Multiply)) {
-                    Expression t = ParseTest();
-                    a = new Arg("*", t);
+                Node a;
+                if (PeekToken(TokenKind.Multiply)) {
+                    var s = GetStart();
+                    NextToken();
+                    a = new StarredExpression(ParseTest());
+                    a.SetLoc(_globalParent, s, GetEnd());
                 } else if (MaybeEat(TokenKind.Power)) {
                     Expression t = ParseTest();
-                    a = new Arg("**", t);
+                    a = new Keyword(null, t);
                 } else {
                     Expression e = ParseTest();
                     if (MaybeEat(TokenKind.Assign)) {
-                        a = FinishKeywordArgument(e);
-                        CheckUniqueArgument(l, a);
+                        var k = FinishKeywordArgument(e);
+                        a = k;
+                        CheckUniqueArgument(l, k);
                     } else {
-                        a = new Arg(e);
+                        a = e;
                     }
                 }
                 a.SetLoc(_globalParent, start, GetEnd());
@@ -2887,9 +2884,9 @@ namespace IronPython.Compiler {
             _functions.Push(function);
         }
 
-        private CallExpression FinishCallExpr(Expression target, IEnumerable<Arg> args) {
-            List<Arg> posargs = null;
-            List<Arg> kwargs = null;
+        private CallExpression FinishCallExpr(Expression target, IEnumerable<Node> args) {
+            List<Expression> posargs = null;
+            List<Keyword> kwargs = null;
 
             if (args is not null) {
                 SplitAndValidateArguments(args, out posargs, out kwargs); 
@@ -2898,35 +2895,38 @@ namespace IronPython.Compiler {
             return new CallExpression(target, posargs, kwargs);
         }
 
-        private void SplitAndValidateArguments(IEnumerable<Arg> args, out List<Arg> posargs, out List<Arg> kwargs) {
+        private void SplitAndValidateArguments(IEnumerable<Node> args, out List<Expression> posargs, out List<Keyword> kwargs) {
             bool hasKeyword = false;
             bool hasKeywordUnpacking = false;
 
-            posargs = kwargs = null;
+            posargs = null;
+            kwargs = null;
 
-            foreach (Arg arg in args) {
-                if (arg.Name == null) {
+            foreach (Node arg in args) {
+                if (arg is Keyword keyword) {
+                    if (keyword.Name is null) {
+                        hasKeywordUnpacking = true;
+                    } else {
+                        hasKeyword = true;
+                    }
+                    kwargs ??= new List<Keyword>();
+                    kwargs.Add(keyword);
+                } else if (arg is StarredExpression starredExpression) {
+                    if (hasKeywordUnpacking) {
+                        ReportSyntaxError(arg.StartIndex, arg.EndIndex, "iterable argument unpacking follows keyword argument unpacking");
+                    }
+                    posargs ??= new List<Expression>();
+                    posargs.Add(starredExpression);
+                } else {
+                    var expr = (Expression)arg;
                     if (hasKeywordUnpacking) {
                         ReportSyntaxError(arg.StartIndex, arg.EndIndex, "positional argument follows keyword argument unpacking");
                     } else if (hasKeyword) {
                         ReportSyntaxError(arg.StartIndex, arg.EndIndex, "positional argument follows keyword argument");
                     }
-                    posargs ??= new List<Arg>();
-                    posargs.Add(arg);
-                } else if (arg.Name == "*") {
-                    if (hasKeywordUnpacking) {
-                        ReportSyntaxError(arg.StartIndex, arg.EndIndex, "iterable argument unpacking follows keyword argument unpacking");
-                    }
-                    posargs ??= new List<Arg>();
-                    posargs.Add(arg);
-                } else if (arg.Name == "**") {
-                    hasKeywordUnpacking = true;
-                    kwargs ??= new List<Arg>();
-                    kwargs.Add(arg);
-                } else {
-                    hasKeyword = true;
-                    kwargs ??= new List<Arg>();
-                    kwargs.Add(arg);
+                    posargs ??= new List<Expression>();
+                    posargs.Add(expr);
+
                 }
             }
         }

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -2151,7 +2151,6 @@ namespace IronPython.Compiler {
                     ParserSink?.NextParameter(GetSourceSpan());
                 } else {
                     Eat(TokenKind.RightParenthesis);
-                    a.SetLoc(_globalParent, start, GetEnd());
                     ParserSink?.EndParameters(GetSourceSpan());
                     return new Node[1] { a };
                 }
@@ -2199,15 +2198,17 @@ namespace IronPython.Compiler {
                 if (MaybeEat(terminator)) {
                     break;
                 }
-                var start = GetStart();
                 Node a;
                 if (MaybeEat(TokenKind.Multiply)) {
+                    var start = GetStart();
                     a = new StarredExpression(ParseTest());
                     a.SetLoc(_globalParent, start, GetEnd());
                 } else if (MaybeEat(TokenKind.Power)) {
-                    a = new Keyword(null, ParseTest());
+                    var e = ParseTest();
+                    a = new Keyword(null, e);
+                    a.SetLoc(_globalParent, e.StartIndex, e.EndIndex);
                 } else {
-                    Expression e = ParseTest();
+                    var e = ParseTest();
                     if (MaybeEat(TokenKind.Assign)) {
                         a = FinishKeywordArgument(e);
                         CheckUniqueArgument(l, (Keyword)a);
@@ -2215,7 +2216,6 @@ namespace IronPython.Compiler {
                         a = e;
                     }
                 }
-                a.SetLoc(_globalParent, start, GetEnd());
                 l.Add(a);
                 if (MaybeEat(TokenKind.Comma)) {
                     ParserSink?.NextParameter(GetSourceSpan());

--- a/Src/Scripts/generate_calls.py
+++ b/Src/Scripts/generate_calls.py
@@ -488,7 +488,7 @@ def gen_call_expression_instruction_switch(cw):
         cw.write('compiler.Compile(Parent.LocalContext);')
         cw.write('compiler.Compile(Target);')
         for j in range(i):
-            cw.write('compiler.Compile(args[%d].Expression);' % j)
+            cw.write('compiler.Compile(args[%d]);' % j)
         cw.write('compiler.Instructions.Emit(new Invoke%dInstruction(Parent.PyContext));' % i)        
         cw.write('return;')
         cw.dedent()


### PR DESCRIPTION
Gets rid of the annoying (to me) `Arg` construct. :smile:

@BCSharp if you have any feedback. Not sure if this will creates merge conflicts with your PR.