### PR TITLE
Misc changes

### DIFF
--- a/Src/IronPython.Modules/faulthandler.cs
+++ b/Src/IronPython.Modules/faulthandler.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
 using System.Runtime.InteropServices;
 
 using IronPython.Runtime;
@@ -8,11 +14,17 @@ namespace IronPython.Modules {
     public static class PythonFaultHandler {
         private const int STDERR = 2;
 
-        public static void dump_traceback(CodeContext context, [DefaultParameterValue(STDERR)]object file, bool all_threads=true) {
+        public static void dump_traceback(CodeContext context, [DefaultParameterValue(STDERR)] object? file, bool all_threads = true) {
             // TODO: the default file object should be sys.stderr
 
             // TODO: fill this up
             throw new NotImplementedException();
-        }        
+        }
+
+        public static void enable(CodeContext context, [DefaultParameterValue(STDERR)] object? file, bool all_threads = true) {
+            // TODO: the default file object should be sys.stderr
+
+            // TODO: fill this up
+        }
     }
 }

--- a/Src/IronPython.Modules/msvcrt.cs
+++ b/Src/IronPython.Modules/msvcrt.cs
@@ -29,6 +29,15 @@ namespace IronPython.Modules {
 
         #region Public API
 
+        public const int SEM_FAILCRITICALERRORS = 1;
+        public const int SEM_NOGPFAULTERRORBOX = 2;
+        public const int SEM_NOALIGNMENTFAULTEXCEPT = 4;
+        public const int SEM_NOOPENFILEERRORBOX = 32768;
+
+        public static void SetErrorMode(int mode) {
+            // TODO: fill this up
+        }
+
         [Documentation(@"heapmin() -> None
 
 Force the malloc() heap to clean itself up and return unused blocks
@@ -226,7 +235,9 @@ Wide char variant of ungetch(), accepting a Unicode value.")]
 
         [DllImport("msvcr100", SetLastError=true, CallingConvention=CallingConvention.Cdecl)]
         private static extern ushort _ungetwch(ushort c);
+
         #endregion
     }
 }
+
 #endif

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -1583,6 +1583,27 @@ namespace IronPython.Modules {
             }
         }
 
+        public static void truncate(CodeContext context, [NotNull] string path, BigInteger length) {
+            using var stream = new FileStream(path, FileMode.Open);
+            stream.SetLength((long)length);
+        }
+
+        [Documentation("")]
+        public static void truncate(CodeContext context, [NotNull] Bytes path, BigInteger length)
+            => truncate(context, path.ToFsString(), length);
+
+        [Documentation("")]
+        public static void truncate(CodeContext context, [NotNull] IBufferProtocol path, BigInteger length) {
+            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, $"{nameof(truncate)}: {nameof(path)} should be string or bytes, not {PythonTypeOps.GetName(path)}"); // deprecated in 3.6
+            truncate(context, path.ToFsBytes(context), length);
+        }
+
+        public static void truncate(CodeContext context, int fd, BigInteger length)
+            => ftruncate(context, fd, length);
+
+        public static void ftruncate(CodeContext context, int fd, BigInteger length)
+            => context.LanguageContext.FileManager.GetFileFromId(context.LanguageContext, fd).truncate(context, length);
+
 #if FEATURE_FILESYSTEM
         public static object times() {
             System.Diagnostics.Process p = System.Diagnostics.Process.GetCurrentProcess();

--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -1951,6 +1951,7 @@ namespace IronPython.Modules {
             private object _encoder, _decoder;
 
             private bool _line_buffering;
+            private bool _write_through;
             private bool _readUniversal;
             private bool _readTranslate;
             internal bool _writeTranslate;
@@ -1969,12 +1970,12 @@ namespace IronPython.Modules {
 
             internal static TextIOWrapper Create(CodeContext/*!*/ context,
                 object buffer,
-                string encoding=null,
-                string errors=null,
-                string newline=null,
-                bool line_buffering=false) {
+                string encoding = null,
+                string errors = null,
+                string newline = null,
+                bool line_buffering = false, bool write_through = false) {
                 var res = new TextIOWrapper(context);
-                res.__init__(context, buffer, encoding, errors, newline, line_buffering);
+                res.__init__(context, buffer, encoding, errors, newline, line_buffering, write_through);
                 return res;
             }
 
@@ -1983,8 +1984,9 @@ namespace IronPython.Modules {
                 object buffer,
                 string encoding = null,
                 string errors = null,
-                string newline=null,
-                bool line_buffering=false
+                string newline = null,
+                bool line_buffering = false,
+                bool write_through = false
             ) {
                 switch(newline) {
                     case null:
@@ -2017,6 +2019,7 @@ namespace IronPython.Modules {
                     PythonOps.IsTrue(PythonOps.Invoke(context, _buffer, "seekable"));
 
                 _line_buffering = line_buffering;
+                _write_through = write_through;
                 _readUniversal = string.IsNullOrEmpty(newline);
                 _readTranslate = newline == null;
                 _readNL = newline;
@@ -2029,23 +2032,15 @@ namespace IronPython.Modules {
 
             #region Public API
 
-            public object buffer {
-                get {
-                    return _buffer;
-                }
-            }
+            public object buffer => _buffer;
 
-            public override string encoding {
-                get { return _encoding; }
-            }
+            public override string encoding => _encoding;
 
-            public override string errors {
-                get { return _errors; }
-            }
+            public override string errors => _errors;
 
-            public bool line_buffering {
-                get { return _line_buffering; }
-            }
+            public bool line_buffering => _line_buffering;
+
+            public bool write_through => _write_through;
 
             public override object newlines {
                 get {
@@ -2157,7 +2152,7 @@ namespace IronPython.Modules {
                     PythonOps.Invoke(context, _buffer, "write", bytes);
                 }
 
-                if (_line_buffering && (hasLF || str.Contains("\r"))) {
+                if (_write_through || _line_buffering && (hasLF || str.Contains("\r"))) {
                     flush(context);
                 }
 

--- a/Src/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/Src/IronPython/Runtime/Operations/ObjectOps.cs
@@ -329,6 +329,11 @@ namespace IronPython.Runtime.Operations {
         /// Implements the default __reduce_ex__ method as specified by PEP 307 case 3 (new-style instance, protocol 2)
         /// </summary>
         private static PythonTuple ReduceProtocol2(CodeContext/*!*/ context, object self) {
+            // builtin types which can't be pickled (due to tp_itemsize != 0)
+            if (self is MemoryView) {
+                throw PythonOps.TypeError("can't pickle memoryview objects");
+            }
+
             PythonType myType = DynamicHelpers.GetPythonType(self);
 
             object? state;

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2698,6 +2698,7 @@ namespace IronPython.Runtime.Operations {
             {
                 float f => (double)f,
                 double d => d,
+                sbyte sb => (int)sb,
                 byte b => (int)b,
                 char c => (int)c,
                 short s => (int)s,


### PR DESCRIPTION
- `nt.truncate` and `nt.ftruncate` are new in CPython 3.5 (on Windows)
- can't pickle `memoryview` with protocol 2 is a change in 3.5
- `write_through` argument in 3.3