### PR TITLE
Updated C# snippet in the README.md to use top level statements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,8 @@ C#:
 
 ```cs
 using System;
-class Hello
-{
-    static void Main() 
-    {
-        Console.WriteLine("Hello World");
-    }
-}
+
+Console.WriteLine("Hello World");
 ```
 
 IronPython:


### PR DESCRIPTION
Hello,
Top level statements were introduced in C# with .NET 5.  
https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/top-level-statements
For the comparison to be fair, I think the readme should use this.