### PR TITLE
Avoid StackOverflowException in mimetypes

### DIFF
--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -617,10 +617,6 @@ IsolationLevel=PROCESS # Also weakref failures; https://github.com/IronLanguages
 [CPython.test_metaclass]
 Ignore=true
 
-[CPython.test_mimetypes]
-Ignore=true
-Reason=StackOverflowException - https://github.com/IronLanguages/ironpython2/issues/182
-
 [CPython.test_mmap]
 RunCondition=NOT $(IS_POSIX)
 IsolationLevel=PROCESS

--- a/Src/StdLib/Lib/mimetypes.py
+++ b/Src/StdLib/Lib/mimetypes.py
@@ -252,19 +252,21 @@ class MimeTypes:
 
         with _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, '') as hkcr:
             for subkeyname in enum_types(hkcr):
-                try:
-                    with _winreg.OpenKey(hkcr, subkeyname) as subkey:
-                        # Only check file extensions
-                        if not subkeyname.startswith("."):
-                            continue
+                # ironpython: code modified to avoid StackOverflowException - https://github.com/IronLanguages/ironpython3/issues/1182
+                with _winreg.OpenKey(hkcr, subkeyname) as subkey:
+                    # Only check file extensions
+                    if not subkeyname.startswith("."):
+                        continue
+                    try:
                         # raises EnvironmentError if no 'Content Type' value
                         mimetype, datatype = _winreg.QueryValueEx(
                             subkey, 'Content Type')
+                    except EnvironmentError:
+                        pass
+                    else:
                         if datatype != _winreg.REG_SZ:
                             continue
                         self.add_type(mimetype, subkeyname, strict)
-                except EnvironmentError:
-                    continue
 
 def guess_type(url, strict=True):
     """Guess the type of a file based on its URL.


### PR DESCRIPTION
Changes to the standard library should be reverted once https://github.com/IronLanguages/ironpython3/issues/1182 is resolved.