### PR TITLE
Improve metaclass logic

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1306,7 +1306,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object MakeClass(FunctionCode funcCode, Func<CodeContext, CodeContext> body, CodeContext/*!*/ parentContext, string name, PythonTuple bases, PythonDictionary? keywords, string selfNames) {
-            Func<CodeContext, CodeContext> func = getClassCode(parentContext, funcCode, body);
+            Func<CodeContext, CodeContext> func = GetClassCode(parentContext, funcCode, body);
 
             // Check and normalize bases
             foreach (object? dt in bases) {
@@ -1362,9 +1362,9 @@ namespace IronPython.Runtime.Operations {
                 return PythonType.__new__(parentContext, TypeCache.PythonType, name, bases, vars, selfNames);
             }
 
-            // Prepare classsdict
+            // Prepare classdict
             // TODO: prepared classdict should be used by `func` (PEP 3115)
-            object? classdict = callPrepare(parentContext, metaclass, name, bases, keywords, func(parentContext).Dict);
+            object? classdict = CallPrepare(parentContext, metaclass, name, bases, keywords, func(parentContext).Dict);
 
             // Dispatch to the metaclass to do class creation and initialization
             // metaclass could be simply a callable, eg:
@@ -1391,7 +1391,7 @@ namespace IronPython.Runtime.Operations {
             return obj;
             // ------------------------------------------------------------------------
 
-            static Func<CodeContext, CodeContext> getClassCode(CodeContext/*!*/ context, FunctionCode funcCode, Func<CodeContext, CodeContext> body) {
+            static Func<CodeContext, CodeContext> GetClassCode(CodeContext/*!*/ context, FunctionCode funcCode, Func<CodeContext, CodeContext> body) {
                 if (body == null) {
                     if (funcCode.Target == null) {
                         funcCode.UpdateDelegate(context.LanguageContext, true);
@@ -1406,7 +1406,7 @@ namespace IronPython.Runtime.Operations {
                 }
             }
 
-            static object? callPrepare(CodeContext/*!*/ context, object meta, string name, PythonTuple bases, PythonDictionary? keywords, PythonDictionary dict) {
+            static object? CallPrepare(CodeContext/*!*/ context, object meta, string name, PythonTuple bases, PythonDictionary? keywords, PythonDictionary dict) {
                 object? classdict = dict;
 
                 object? prepareFunc = null;

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -292,7 +292,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        public void __init__(string name, PythonTuple bases, PythonDictionary dict) {
+        public void __init__(string name, PythonTuple bases, PythonDictionary dict, [ParamDictionary] IDictionary<object, object> kwargs) {
         }
 
         internal static PythonType FindMetaClass(PythonType cls, PythonTuple bases) {

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -267,15 +267,15 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             object type;
 
             if (meta != TypeCache.PythonType) {
-                object classdict = PythonOps.CallPrepare(context, meta, name, bases, null, dict);
-
-                if (meta != cls) {
-                    // the user has a custom __new__ which picked the wrong meta class, call the correct metaclass
-                    type = PythonCalls.Call(context, meta, name, bases, classdict);
+                if (meta != cls // the user has a custom __new__ which picked the wrong meta class, call the correct metaclass __new__
+                    && meta.TryResolveSlot(context, "__new__", out PythonTypeSlot pts)
+                    && pts.TryGetValue(context, null, meta, out object value)
+                ) {
+                    type = PythonCalls.Call(context, value, meta, name, bases, dict);
                 } else {
                     // we have the right user __new__, call our ctor method which will do the actual
                     // creation.                   
-                    type = meta.CreateInstance(context, name, bases, classdict);
+                    type = meta.CreateInstance(context, name, bases, dict);
                 }
             } else {
                 // no custom user type for __new__


### PR DESCRIPTION
It addresses a part of the problem reported in #1154 (duplicate calls to `__prepare__`) and several other related issues. Off the top of my head:
* removes duplicate calls to `__init__`
* supports inheriting of `__prepare__`, `__new__`, `__init__` by metaclasses
* supports `__prepare__` on a function used as "metaclass"
* fixes interplay when mixing metaclasses provided classes and functions in various scenarios
* ...