### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ IronPython 3
 
 IronPython is an open-source implementation of the Python programming language which is tightly integrated with .NET. IronPython can use .NET and Python libraries, and other .NET languages can use Python code just as easily.
 
+IronPython 3 targets Python 3, including the re-organized standard library, Unicode strings, and all of the other new features.
+
+
 | **What?** | **Where?** |
 | --------: | :------------: |
 | **Windows/Linux/macOS Builds** | [![Build status](https://dotnet.visualstudio.com/IronLanguages/_apis/build/status/ironpython3)](https://dotnet.visualstudio.com/IronLanguages/_build/latest?definitionId=43) [![Github build status](https://github.com/IronLanguages/ironpython3/workflows/CI/badge.svg)](https://github.com/IronLanguages/ironpython3/actions?workflow=CI) |
@@ -13,21 +16,39 @@ IronPython is an open-source implementation of the Python programming language w
 | **Help** | [![Gitter chat](https://badges.gitter.im/IronLanguages/ironpython.svg)](https://gitter.im/IronLanguages/ironpython) [![StackExchange](https://img.shields.io/stackexchange/stackoverflow/t/ironpython.svg)](http://stackoverflow.com/questions/tagged/ironpython) |
 
 
-Comparison of IronPython vs. C# for 'Hello World'
+## Examples
 
-C#:
+The following C# program:
 
 ```cs
-System.Console.WriteLine("Hello World");
+using System.Windows.Forms;
+
+MessageBox.Show("Hello World!", "Greetings", MessageBoxButtons.OKCancel);
 ```
 
-IronPython:
+can be written in IronPython as follows:
 
 ```py
-print("Hello World")
+import clr
+clr.AddReference("System.Windows.Forms")
+from System.Windows.Forms import MessageBox, MessageBoxButtons
+
+MessageBox.Show("Hello World!", "Greetings", MessageBoxButtons.OKCancel)
 ```
 
-IronPython 3 targets Python 3, including the re-organized standard library, Unicode strings, and all of the other new features.
+Here is an example how to call Python code from a C# program.
+
+```cs
+var eng = IronPython.Hosting.Python.CreateEngine();
+var scope = eng.CreateScope();
+eng.Execute(@"
+def greetings(name):
+    return 'Hello ' + name.title() + '!'
+", scope);
+dynamic greetings = scope.GetVariable("greetings");
+System.Console.WriteLine(greetings("world"));
+```
+This example assumes that `IronPython` has been added the the C# project as a NuGet package.
 
 ## Code of Conduct
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ def greetings(name):
 dynamic greetings = scope.GetVariable("greetings");
 System.Console.WriteLine(greetings("world"));
 ```
-This example assumes that `IronPython` has been added the the C# project as a NuGet package.
+This example assumes that `IronPython` has been added to the C# project as a NuGet package.
 
 ## Code of Conduct
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community.


### PR DESCRIPTION
I think it is safe to assume that visitors to the IronPython GitHub project page know what Python is. So the example to show how to print "Hello World!" in plain Python is kind of pointless. Also, they probably know C# and .NET, so the only reason for comparing IronPython code to C# would be to give an idea for people wondering "well, I know how to do .NET stuff in C#, how would that work in IronPython?"

I've come up here with two simple but-not-totally-trival examples: how to access .NET from IronPython and how to access IronPython form C#. Comments welcome.