### PR TITLE
Change sys.maxunicode to 0xffff

### DIFF
--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -242,7 +242,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
         // hex_version is set by PythonContext
 
         public const int maxsize = Int32.MaxValue;
-        public const int maxunicode = 0x10ffff;
+        public const int maxunicode = 0xffff;
 
         // modules is set by PythonContext and only on the initial load
 

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -241,8 +241,8 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
 
         // hex_version is set by PythonContext
 
-        public const int maxsize = Int32.MaxValue;
-        public const int maxunicode = 0xffff;
+        public const int maxsize = int.MaxValue;
+        public const int maxunicode = char.MaxValue;
 
         // modules is set by PythonContext and only on the initial load
 

--- a/Src/StdLib/Lib/test/test_builtin.py
+++ b/Src/StdLib/Lib/test/test_builtin.py
@@ -283,7 +283,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(chr(0xff), '\xff')
         self.assertRaises(ValueError, chr, 1<<24)
         self.assertEqual(chr(sys.maxunicode),
-                         str('\\U0010ffff'.encode("ascii"), 'unicode-escape'))
+                         str(('\\U%08x' % (sys.maxunicode)).encode("ascii"), 'unicode-escape')) # ironpython: sys.maxunicode is still 0xffff
         self.assertRaises(TypeError, chr)
         self.assertEqual(chr(0x0000FFFF), "\U0000FFFF")
         self.assertEqual(chr(0x00010000), "\U00010000")

--- a/Src/StdLib/Lib/test/test_codecs.py
+++ b/Src/StdLib/Lib/test/test_codecs.py
@@ -2223,7 +2223,7 @@ class CharmapTest(unittest.TestCase):
 
         self.assertRaises(TypeError,
             codecs.charmap_decode, b"\x00\x01\x02", "strict",
-                                   {0: sys.maxunicode + 1, 1: b, 2: c}
+                                   {0: 0x110000, 1: b, 2: c} # ironpython: 0x110000 instead of sys.maxunicode + 1
         )
 
         self.assertRaises(UnicodeDecodeError,

--- a/Tests/test_builtinfunc.py
+++ b/Tests/test_builtinfunc.py
@@ -307,28 +307,19 @@ class BuiltinsTest2(IronPythonTestCase):
         sumtest([1.7976931348623157e+308, long(1.7976931348623157e+308)], inf)
         self.assertRaises(OverflowError, sum, [1.0, 100000000<<2000])
 
-    def test_unichr(self):
+    def test_chr(self):
+        self.assertEqual(sys.maxunicode, 0xFFFF if is_cli else 0x10FFFF)
 
-        #Added the following to resolve Codeplex WorkItem #3220.
-        max_uni = sys.maxunicode
-        self.assertTrue(max_uni==0xFFFF or max_uni==0x10FFFF)
-        max_uni_plus_one = max_uni + 1
+        max_chr = 0x10FFFF
+        max_chr_plus_one = max_chr + 1
+        overflow_chr = 1<<64
 
-        huger_than_max = 100000
-        max_ok_value = u'\uffff'
-
-        #special case for WorkItem #3220
-        if max_uni==0x10FFFF:
-            huger_than_max = 10000000
-            max_ok_value = u'\U0010FFFF'
-
-        unichr = chr
-
-        self.assertRaises(ValueError, unichr, -1) # arg must be in the range [0...65535] or [0...1114111] inclusive
-        self.assertRaises(ValueError, unichr, max_uni_plus_one)
-        self.assertRaises(ValueError, unichr, huger_than_max)
-        self.assertTrue(unichr(0) == '\x00')
-        self.assertTrue(unichr(max_uni) == max_ok_value)
+        # chr() arg must be in range(0x110000)
+        self.assertRaises(ValueError, chr, -1)
+        self.assertRaises(ValueError, chr, max_chr_plus_one)
+        self.assertRaises(OverflowError, chr, overflow_chr)
+        self.assertTrue(chr(0) == '\x00')
+        self.assertTrue(chr(max_chr) == u'\U0010FFFF')
 
     def test_max(self):
         self.assertEqual(max('123123'), '3')

--- a/Tests/test_nonlocal.py
+++ b/Tests/test_nonlocal.py
@@ -7,7 +7,6 @@ import unittest
 
 from iptest import IronPythonTestCase, run_test, is_cli, is_cpython
 
-
 class SyntaxTests(IronPythonTestCase):
 
     def check_compile_error(self, code, msg, lineno):
@@ -319,7 +318,7 @@ class FunctionalTests(IronPythonTestCase):
             from sys import maxunicode
             from sys import maxsize as some_number
         foo()
-        self.assertEqual(maxunicode, 1114111)
+        self.assertEqual(maxunicode, 0xFFFF if is_cli else 0x10FFFF)
         self.assertGreaterEqual(some_number, 0x7FFFFFFF)
 
 run_test(__name__)


### PR DESCRIPTION
Using `0xffff` for `sys.maxunicode` is probably more accurate since our implementation of unicode is closer that of CPython 3.2.

Some Python code uses this value to check if they can use "wide" characters, for example, from `docutils`:
```Python
if sys.maxunicode >= 0x10FFFF: # "wide" build
    delimiters += '\U00010100\U00010101\U0001039f\U000103d0\U00010857'
```
Another example from `pyyaml`:
```Python
has_ucs4 = sys.maxunicode > 0xffff
```

In both these modules, we end up with errors about "invalid" character ranges in a regular expressions:
```Python
re.compile("[\U00010000-\U0010ffff]")
```
> re.error: parsing "[-]" - [x-y] range in reverse order.