### PR TITLE
Fix repr of metaclass

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -231,6 +231,15 @@ namespace IronPython.Runtime.Operations {
                     //     def __repr__(self): return "qwerty"
                     //
                     // assert repr(MyException) == "qwerty"
+                } else if (o is PythonType && o.GetType() != typeof(PythonType)) {
+                    // let is fall through since metaclass may be defining __repr__, resolves the following:
+                    // class MyMetaClass(type):
+                    //     def __repr__(self):
+                    //         return "qwerty"
+                    //
+                    // class test(metaclass=MyMetaClass): pass
+                    //
+                    // assert repr(test) == "qwerty"
                 } else {
                     return f.__repr__(context);
                 }

--- a/Tests/test_builtin_stdlib.py
+++ b/Tests/test_builtin_stdlib.py
@@ -60,7 +60,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_builtin.BuiltinTest('test_oct'))
         suite.addTest(test.test_builtin.BuiltinTest('test_open'))
         suite.addTest(test.test_builtin.BuiltinTest('test_open_default_encoding'))
-        suite.addTest(unittest.expectedFailure(test.test_builtin.BuiltinTest('test_open_non_inheritable')))
+        suite.addTest(unittest.expectedFailure(test.test_builtin.BuiltinTest('test_open_non_inheritable'))) # https://github.com/IronLanguages/ironpython3/issues/1225
         suite.addTest(test.test_builtin.BuiltinTest('test_ord'))
         suite.addTest(test.test_builtin.BuiltinTest('test_pow'))
         suite.addTest(test.test_builtin.BuiltinTest('test_repr'))

--- a/Tests/test_metaclass.py
+++ b/Tests/test_metaclass.py
@@ -671,4 +671,14 @@ class MetaclassTest(IronPythonTestCase):
         with self.assertRaises(Exception):
             Generic.test = 2
 
+    def test_repr_on_metaclass(self):
+        class MetaClass(type):
+            def __repr__(self):
+                return "qwerty"
+
+        class test(metaclass=MetaClass):
+            pass
+
+        self.assertEqual(repr(test), "qwerty")
+
 run_test(__name__)


### PR DESCRIPTION
Resolves:
```py
class test(type):
    def __repr__(self):
        return "A"

class test2(metaclass=test):
    pass

assert repr(test2) == "A"
```
which was causing a failure in the `typing` tests.