### PR TITLE
Fix str of ZipImportError

### DIFF
--- a/Src/IronPython.Modules/zipimport.cs
+++ b/Src/IronPython.Modules/zipimport.cs
@@ -286,7 +286,7 @@ the file wasn't found.")]
                     throw MakeError(context, "path too long");
                 }
 
-                path = path.Replace(_archive, string.Empty).TrimStart(Path.DirectorySeparatorChar);                
+                path = path.Replace(_archive, string.Empty).TrimStart(Path.DirectorySeparatorChar);
                 if (!__files.ContainsKey(path)) {
                     throw PythonOps.IOError(path);
                 }
@@ -612,22 +612,17 @@ contain the module, but has no source for it.")]
             }
         }
 
-        public static PythonType get_ZipImportError(CodeContext context) {
-            PythonContext pyContext = context.LanguageContext;
-            PythonType zipImportError = (PythonType)pyContext.GetModuleState("zipimport.ZipImportError");
-            return zipImportError;
-        }
+        internal static PythonType ZipImportError(CodeContext context)
+            => (PythonType)context.LanguageContext.GetModuleState("zipimport.ZipImportError");
 
-        internal static Exception MakeError(CodeContext context, params object[] args) {
-            return PythonOps.CreateThrowable(get_ZipImportError(context), args);
-        }
+        internal static Exception MakeError(CodeContext context, params object[] args)
+            => PythonExceptions.CreateThrowable(ZipImportError(context), args);
 
-        private static void InitModuleExceptions(PythonContext context,
-            PythonDictionary dict) {
+        private static void InitModuleExceptions(PythonContext context, PythonDictionary dict) {
             context.EnsureModuleException(
                 "zipimport.ZipImportError",
                 PythonExceptions.ImportError,
-                typeof(PythonExceptions.BaseException),
+                typeof(PythonExceptions._ImportError),
                 dict, "ZipImportError", "zipimport",
                 (msg, innerException) => new ImportException(msg, innerException));
         }

--- a/Tests/test_zipimport.py
+++ b/Tests/test_zipimport.py
@@ -4,6 +4,7 @@
 
 import os
 import unittest
+import zipimport
 
 from iptest import IronPythonTestCase, path_modifier, run_test, stdout_trapper, is_netcoreapp
 
@@ -15,5 +16,8 @@ class ZipImportTest(IronPythonTestCase):
         with path_modifier(os.path.join(self.test_dir, 'gh129.zip')):
             import something
             self.assertEqual(something.test(), u'\u041f\u0440\u0438\u0432\u0435\u0442 \u043c\u0438\u0440!')
+
+    def test_zipimport_str(self):
+        self.assertEqual(str(zipimport.ZipImportError("test")), "test")
 
 run_test(__name__)


### PR DESCRIPTION
Resolves the following:
````py
assert str(zipimport.ZipImportError("test")) == "test"
````
which was throwing a `TypeError`.