### PR TITLE
Enable some ctypes tests

### DIFF
--- a/Src/IronPython.Modules/ModuleOps.cs
+++ b/Src/IronPython.Modules/ModuleOps.cs
@@ -266,8 +266,12 @@ namespace IronPython.Modules {
         }
 
         public static IntPtr GetCharPointer(object value) {
-            if (value is string strVal) {
-                return Marshal.StringToCoTaskMemAnsi(strVal);
+            if (value is Bytes bytes) {
+                var data = bytes.UnsafeByteArray;
+                var ptr = Marshal.AllocCoTaskMem(data.Length + 1);
+                Marshal.Copy(data, 0, ptr, data.Length);
+                Marshal.WriteByte(ptr, data.Length, 0);
+                return ptr;
             }
 
             if (value == null) {

--- a/Src/IronPython.Modules/_ctypes/Array.cs
+++ b/Src/IronPython.Modules/_ctypes/Array.cs
@@ -82,7 +82,7 @@ namespace IronPython.Modules {
                         return new PythonList();
                     }
 
-                    if (elemType != null) {// && (elemType._type == SimpleTypeKind.WChar || elemType._type == SimpleTypeKind.Char)) {
+                    if (elemType != null) {
                         if (elemType._type == SimpleTypeKind.Char) {
                             Debug.Assert(((INativeType)elemType).Size == 1);
                             if (step == 1) {

--- a/Src/IronPython.Modules/_ctypes/Array.cs
+++ b/Src/IronPython.Modules/_ctypes/Array.cs
@@ -6,15 +6,15 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
-
-using Microsoft.Scripting.Runtime;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
-using System.Collections.Generic;
+
+using Microsoft.Scripting.Runtime;
 
 namespace IronPython.Modules {
     /// <summary>
@@ -33,7 +33,11 @@ namespace IronPython.Modules {
                 if (args.Length > ((ArrayType)nativeType).Length) {
                     throw PythonOps.IndexError("too many arguments");
                 }
-                nativeType.SetValue(_memHolder, 0, args);
+
+                INativeType elementType = ElementType;
+                for (var i = 0; i < args.Length; i++) {
+                    elementType.SetValue(_memHolder, checked(i * elementType.Size), args[i]);
+                }
             }
 
             public object this[int index] {

--- a/Src/IronPython.Modules/_ctypes/Array.cs
+++ b/Src/IronPython.Modules/_ctypes/Array.cs
@@ -111,7 +111,7 @@ namespace IronPython.Modules {
 
                     object[] ret = new object[count];
                     for (int i = 0, index = start; i < count; i++, index += step) {
-                        ret[i++] = this[index];
+                        ret[i] = this[index];
                     }
 
                     return PythonList.FromArrayNoCopy(ret);

--- a/Src/IronPython.Modules/_ctypes/ArrayType.cs
+++ b/Src/IronPython.Modules/_ctypes/ArrayType.cs
@@ -289,7 +289,7 @@ namespace IronPython.Modules {
             private void WriteBytes(MemoryHolder address, int offset, Bytes bytes) {
                 SimpleType st = (SimpleType)_type;
                 Debug.Assert(st._type == SimpleTypeKind.Char && bytes.Count <= _length);
-                address.WriteSpan(offset, bytes.AsMemory().Span);
+                address.WriteSpan(offset, bytes.AsSpan());
                 if (bytes.Count < _length) {
                     address.WriteByte(checked(offset + bytes.Count), 0);
                 }

--- a/Src/IronPython.Modules/_ctypes/MemoryHolder.cs
+++ b/Src/IronPython.Modules/_ctypes/MemoryHolder.cs
@@ -206,13 +206,13 @@ namespace IronPython.Modules {
         internal static Bytes ReadBytes(IntPtr addr, int offset, int length) {
             // instead of Marshal.PtrToStringAnsi we do this because
             // ptrToStringAnsi gives special treatment to values >= 128.
-            MemoryStream res = new MemoryStream();
-            if (checked(offset + length) < Int32.MaxValue) {
+            var buffer = new byte[length];
+            if (checked(offset + length) < int.MaxValue) {
                 for (int i = 0; i < length; i++) {
-                    res.WriteByte(Marshal.ReadByte(addr, offset + i));
+                    buffer[i] = Marshal.ReadByte(addr, offset + i);
                 }
             }
-            return Bytes.Make(res.ToArray());
+            return Bytes.Make(buffer);
         }
 
         internal static Bytes ReadBytes(IntPtr addr, int offset) {
@@ -280,11 +280,9 @@ namespace IronPython.Modules {
                 WriteInt16(checked(offset + i * 2), (short)value[i]);
             }
         }
-
-        internal void WriteAnsiString(int offset, string value) {
-            // TODO: There's gotta be a better way to do this
+        internal void WriteSpan(int offset, ReadOnlySpan<byte> value) {
             for (int i = 0; i < value.Length; i++) {
-                WriteByte(checked(offset + i), (byte)value[i]);
+                WriteByte(checked(offset + i), value[i]);
             }
         }
 

--- a/Src/IronPython.Modules/_ctypes/SimpleCData.cs
+++ b/Src/IronPython.Modules/_ctypes/SimpleCData.cs
@@ -53,8 +53,10 @@ namespace IronPython.Modules {
                         }
                         break;
                     case SimpleTypeKind.WChar: {
-                            if (!(value is string t && t.Length == 1)) {
-                                throw PythonOps.TypeError("one character unicode string expected");
+                            if (value is string t) {
+                                if (t.Length != 1) throw PythonOps.TypeError("one character unicode string expected");
+                            } else {
+                                throw PythonOps.TypeError("unicode string expected instead of {0} instance", DynamicHelpers.GetPythonType(value).Name);
                             }
                         }
                         break;

--- a/Src/IronPython.Modules/_ctypes/_ctypes.cs
+++ b/Src/IronPython.Modules/_ctypes/_ctypes.cs
@@ -708,49 +708,49 @@ namespace IronPython.Modules {
         }
 
         // TODO: Move these to an Ops class
+        [PythonHidden]
         public static object GetCharArrayValue(_Array arr) {
             return arr.NativeType.GetValue(arr._memHolder, arr, 0, false);
         }
 
+        [PythonHidden]
         public static void SetCharArrayValue(_Array arr, object value) {
             arr.NativeType.SetValue(arr._memHolder, 0, value);
         }
 
-        public static void DeleteCharArrayValue(_Array arr, object value) {
+        [PythonHidden]
+        public static void DeleteCharArrayValue(_Array arr) {
             throw PythonOps.TypeError("cannot delete char array value");
         }
 
+        [PythonHidden]
+        public static object GetCharArrayRaw(_Array arr) {
+            return ((ArrayType)arr.NativeType).GetRawValue(arr._memHolder, 0);
+        }
+
+        [PythonHidden]
+        public static void SetCharArrayRaw(_Array arr, object value) {
+            ((ArrayType)arr.NativeType).SetRawValue(arr._memHolder, 0, value);
+        }
+
+        [PythonHidden]
+        public static void DeleteCharArrayRaw(_Array arr) {
+            throw PythonOps.AttributeError("cannot delete char array raw");
+        }
+
+        [PythonHidden]
         public static object GetWCharArrayValue(_Array arr) {
             return arr.NativeType.GetValue(arr._memHolder, arr, 0, false);
         }
 
+        [PythonHidden]
         public static void SetWCharArrayValue(_Array arr, object value) {
             arr.NativeType.SetValue(arr._memHolder, 0, value);
         }
 
+        [PythonHidden]
         public static object DeleteWCharArrayValue(_Array arr) {
             throw PythonOps.TypeError("cannot delete wchar array value");
-        }
-
-        public static object GetWCharArrayRaw(_Array arr) {
-            return ((ArrayType)arr.NativeType).GetRawValue(arr._memHolder, 0);
-        }
-
-        public static void SetWCharArrayRaw(_Array arr, object value) {
-            MemoryView view = value as MemoryView;
-            if ((object)view != null) {
-                string strVal = view.tobytes().MakeString();
-                if (strVal.Length > arr.__len__()) {
-                    throw PythonOps.ValueError("string too long");
-                }
-                value = strVal;
-            }
-
-            arr.NativeType.SetValue(arr._memHolder, 0, value);
-        }
-
-        public static object DeleteWCharArrayRaw(_Array arr) {
-            throw PythonOps.TypeError("cannot delete wchar array raw");
         }
 
         private class RefCountInfo {

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -2230,7 +2230,7 @@ the 'status' value."),
         }
 
 #endif
-        private static string ToFsString(this Bytes b) => _filesystemEncoding.GetString(b.AsMemory().Span);
+        private static string ToFsString(this Bytes b) => _filesystemEncoding.GetString(b.AsSpan());
 
         private static Bytes ToFsBytes(this string s) => Bytes.Make(_filesystemEncoding.GetBytes(s));
 

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -1011,9 +1011,9 @@ namespace IronPython.Runtime {
 
         #region Implementation Details
 
-        internal ReadOnlyMemory<byte> AsMemory() {
-            return _bytes.AsMemory();
-        }
+        internal ReadOnlyMemory<byte> AsMemory() => _bytes.AsMemory();
+
+        internal ReadOnlySpan<byte> AsSpan() => _bytes.AsSpan();
 
         internal static bool TryInvokeBytesOperator(CodeContext context, object? obj, [NotNullWhen(true)] out Bytes? bytes) {
             if (PythonTypeOps.TryInvokeUnaryOperator(context, obj, "__bytes__", out object? res)) {

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -95,9 +95,6 @@ Ignore=true
 [CPython.ctypes.test_stringptr]
 Ignore=true
 
-[CPython.ctypes.test_strings]
-Ignore=true
-
 [CPython.ctypes.test_structures]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -16,9 +16,6 @@ Ignore=true
 [CPython.ctypes.test_bitfields]
 Ignore=true
 
-[CPython.ctypes.test_buffers]
-Ignore=true
-
 [CPython.ctypes.test_callbacks]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -25,9 +25,6 @@ Ignore=true
 [CPython.ctypes.test_callbacks]
 Ignore=true
 
-[CPython.ctypes.test_cast]
-Ignore=true
-
 [CPython.ctypes.test_errno]
 Ignore=true
 Reason=Current implementation of get_last_error needs to be debugged

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -19,9 +19,6 @@ Ignore=true
 [CPython.ctypes.test_buffers]
 Ignore=true
 
-[CPython.ctypes.test_bytes]
-Ignore=true
-
 [CPython.ctypes.test_callbacks]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -35,9 +35,6 @@ Ignore=true
 [CPython.ctypes.test_functions]
 Ignore=true
 
-[CPython.ctypes.test_incomplete]
-Ignore=true
-
 [CPython.ctypes.test_internals]
 Ignore=true
 

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -7,9 +7,6 @@ Timeout=120000 # 2 minute timeout
 [CPython.ctypes]
 RunCondition=NOT $(IS_OSX) # TODO: debug
 
-[CPython.ctypes.test_arrays]
-Ignore=true
-
 [CPython.ctypes.test_as_parameter]
 Ignore=true
 


### PR DESCRIPTION
There are a bunch of tests that broke in the transition from ipy2 (mostly due to str/unicode changes). This re-enables some of them.