### PR TITLE
Don't use VS prerelease

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
     - name: Install tools

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -6,7 +6,7 @@ jobs:
   displayName: Windows
   timeoutInMinutes: 180
   pool:
-    vmImage: windows-2022
+    vmImage: windows-latest
   steps:
   - template: Build/steps.yml
     parameters:

--- a/make.ps1
+++ b/make.ps1
@@ -22,7 +22,7 @@ function EnsureMSBuild() {
     $_VSINSTPATH = ''
 
     if([System.IO.File]::Exists($_VSWHERE)) {
-        $_VSINSTPATH = & "$_VSWHERE" -latest -prerelease -requires Microsoft.Component.MSBuild -property installationPath
+        $_VSINSTPATH = & "$_VSWHERE" -latest -requires Microsoft.Component.MSBuild -property installationPath
     } else {
         Write-Error "Visual Studio 2019 16.8 or later is required"
         Exit 1


### PR DESCRIPTION
Reverts some changes from https://github.com/IronLanguages/ironpython3/pull/1095 once CI upgrades to VS 2022.