### PR TITLE
Separate intermediate item directories for .NET 5 and 6 builds

### DIFF
--- a/Build/After.targets
+++ b/Build/After.targets
@@ -43,7 +43,7 @@
   </Target>
 
   <Target Name="_StoreInDLLs" Condition=" '$(StoreInDLLs)' == 'true' ">
-    <Move SourceFiles="@(StageItem)" DestinationFolder="$(TargetDir)\%(StageItem.RecursiveDir)\DLLs" />
+    <Move SourceFiles="@(StageItem)" DestinationFolder="$(TargetDir)%(StageItem.RecursiveDir)DLLs" />
   </Target>
 
   <Target Name="Stage" DependsOnTargets="_LateStage;_MainStage;_StoreInDLLs" />

--- a/Build/net5.0-windows.props
+++ b/Build/net5.0-windows.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IntermediateOutputPath Condition=" '$(TargetFramework)' == 'net5.0-windows' ">$(BaseIntermediateOutputPath)$(Configuration)\net5.0</IntermediateOutputPath>
     <OutputPath Condition=" '$(TargetFramework)' == 'net5.0-windows' ">$(BaseOutputPath)\net5.0</OutputPath>
   </PropertyGroup>
 

--- a/Build/net6.0-windows.props
+++ b/Build/net6.0-windows.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IntermediateOutputPath Condition=" '$(TargetFramework)' == 'net6.0-windows' ">$(BaseIntermediateOutputPath)$(Configuration)\net6.0</IntermediateOutputPath>
     <OutputPath Condition=" '$(TargetFramework)' == 'net6.0-windows' ">$(BaseOutputPath)\net6.0</OutputPath>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -97,6 +97,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
     <BaseOutputPath>$(RootDir)bin\$(Configuration)</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Fixes intermittent build failures of _IronPython.Wpf_ and _IronPython.SQLite_ when parallel builds are enabled with multiple target frameworks.