### PR TITLE
Type name

### DIFF
--- a/Src/IronPython.Modules/IterTools.cs
+++ b/Src/IronPython.Modules/IterTools.cs
@@ -219,7 +219,7 @@ namespace IronPython.Modules {
                 if (iter == null ||
                     !PythonOps.HasAttr(context, iter, "__iter__") &&
                     !PythonOps.HasAttr(context, iter, "__getitem__")) {
-                        throw PythonOps.TypeError("'{0}' object is not iterable", PythonTypeOps.GetName(iter));
+                        throw PythonOps.TypeError("'{0}' object is not iterable", PythonOps.GetPythonTypeName(iter));
                 }
             }
 

--- a/Src/IronPython.Modules/ModuleOps.cs
+++ b/Src/IronPython.Modules/ModuleOps.cs
@@ -192,7 +192,7 @@ namespace IronPython.Modules {
             PythonContext pc = ((PythonType)type).Context;
             return PythonExceptions.CreateThrowable(
                 (PythonType)pc.GetModuleState("ArgumentError"),
-                string.Format("expected {0}, got {1}", expected, DynamicHelpers.GetPythonType(got).Name)
+                string.Format("expected {0}, got {1}", expected, PythonOps.GetPythonTypeName(got))
             );
         }
 
@@ -639,7 +639,7 @@ namespace IronPython.Modules {
                 return GetWChar(asParam, type);
             }
 
-            throw PythonOps.TypeError("unicode string expected instead of {0} instance", DynamicHelpers.GetPythonType(value).Name);
+            throw PythonOps.TypeError("unicode string expected instead of {0} instance", PythonOps.GetPythonTypeName(value));
         }
 
         public static object IntPtrToObject(IntPtr address) {

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -113,12 +113,12 @@ namespace IronPython.Modules {
                     using IPythonBuffer buffer = bp.GetBuffer();
                     return StringOps.DoDecode(context, buffer, errors, lc.GetDefaultEncodingName(), lc.DefaultEncoding);
                 } else {
-                    throw PythonOps.TypeError("expected bytes-like object, got {0}", PythonTypeOps.GetName(obj));
+                    throw PythonOps.TypeError("expected bytes-like object, got {0}", PythonOps.GetPythonTypeName(obj));
                 }
             } else {
                 object? decoder = lookup(context, encoding)[DecoderIndex];
                 if (!PythonOps.IsCallable(context, decoder)) {
-                    throw PythonOps.TypeError("decoding with '{0}' codec failed; decoder must be callable ('{1}' object is not callable)", encoding, PythonTypeOps.GetName(decoder));
+                    throw PythonOps.TypeError("decoding with '{0}' codec failed; decoder must be callable ('{1}' object is not callable)", encoding, PythonOps.GetPythonTypeName(decoder));
                 }
                 return PythonOps.GetIndex(context, PythonCalls.Call(context, decoder, obj, errors), 0);
             }
@@ -130,12 +130,12 @@ namespace IronPython.Modules {
                     PythonContext lc = context.LanguageContext;
                     return StringOps.DoEncode(context, str, errors, lc.GetDefaultEncodingName(), lc.DefaultEncoding, includePreamble: true);
                 } else {
-                    throw PythonOps.TypeError("expected str, got {0}", PythonTypeOps.GetName(obj));
+                    throw PythonOps.TypeError("expected str, got {0}", PythonOps.GetPythonTypeName(obj));
                 }
             } else {
                 object? encoder = lookup(context, encoding)[EncoderIndex];
                 if (!PythonOps.IsCallable(context, encoder)) {
-                    throw PythonOps.TypeError("encoding with '{0}' codec failed; encoder must be callable ('{1}' object is not callable)", encoding, PythonTypeOps.GetName(encoder));
+                    throw PythonOps.TypeError("encoding with '{0}' codec failed; encoder must be callable ('{1}' object is not callable)", encoding, PythonOps.GetPythonTypeName(encoder));
                 }
                 return PythonOps.GetIndex(context, PythonCalls.Call(context, encoder, obj, errors), 0);
             }
@@ -885,7 +885,7 @@ namespace IronPython.Modules {
                     return 1;
 
                 default:
-                    throw PythonOps.TypeError("character mapping must return integer, bytes or None, not {0}", PythonTypeOps.GetName(replacement));
+                    throw PythonOps.TypeError("character mapping must return integer, bytes or None, not {0}", PythonOps.GetPythonTypeName(replacement));
             }
         }
 
@@ -928,7 +928,7 @@ namespace IronPython.Modules {
                             continue;
                         }
                     } else {
-                        throw PythonOps.TypeError("character mapping must return integer, None or str, not {0}", PythonTypeOps.GetName(val));
+                        throw PythonOps.TypeError("character mapping must return integer, None or str, not {0}", PythonOps.GetPythonTypeName(val));
                     }
                 }
 

--- a/Src/IronPython.Modules/_collections.cs
+++ b/Src/IronPython.Modules/_collections.cs
@@ -580,7 +580,7 @@ namespace IronPython.Modules {
 
             public static deque operator +([NotNull] deque x, object y) {
                 if (y is deque t) return x + t;
-                throw PythonOps.TypeError($"can only concatenate deque (not \"{PythonTypeOps.GetName(y)}\") to deque");
+                throw PythonOps.TypeError($"can only concatenate deque (not \"{PythonOps.GetPythonTypeName(y)}\") to deque");
             }
 
             public static deque operator +([NotNull] deque x, [NotNull] deque y) {

--- a/Src/IronPython.Modules/_csv.cs
+++ b/Src/IronPython.Modules/_csv.cs
@@ -902,7 +902,7 @@ elements will be converted to string.")]
             public void writerow(CodeContext/*!*/ context, object sequence) {
                 IEnumerator e;
                 if (!PythonOps.TryGetEnumerator(context, sequence, out e))
-                    throw MakeError($"iterable expected, not {PythonTypeOps.GetName(sequence)}");
+                    throw MakeError($"iterable expected, not {PythonOps.GetPythonTypeName(sequence)}");
 
                 // join all fields in internal buffer
                 JoinReset();

--- a/Src/IronPython.Modules/_ctypes/ArrayType.cs
+++ b/Src/IronPython.Modules/_ctypes/ArrayType.cs
@@ -243,7 +243,7 @@ namespace IronPython.Modules {
 
                             return null;
                         }
-                        throw PythonOps.TypeError("bytes expected instead of {0} instance", DynamicHelpers.GetPythonType(value).Name);
+                        throw PythonOps.TypeError("bytes expected instead of {0} instance", PythonOps.GetPythonTypeName(value));
                     }
                     if (st._type == SimpleTypeKind.WChar) {
                         if (value is string str) {
@@ -255,7 +255,7 @@ namespace IronPython.Modules {
 
                             return null;
                         }
-                        throw PythonOps.TypeError("unicode string expected instead of {0} instance", DynamicHelpers.GetPythonType(value).Name);
+                        throw PythonOps.TypeError("unicode string expected instead of {0} instance", PythonOps.GetPythonTypeName(value));
                     }
                 }
 
@@ -280,7 +280,7 @@ namespace IronPython.Modules {
                         return arr._memHolder.EnsureObjects();
                     }
 
-                    throw PythonOps.TypeError("unexpected {0} instance, got {1}", Name, DynamicHelpers.GetPythonType(value).Name);
+                    throw PythonOps.TypeError("unexpected {0} instance, got {1}", Name, PythonOps.GetPythonTypeName(value));
                 }
 
                 return null;

--- a/Src/IronPython.Modules/_ctypes/StructType.cs
+++ b/Src/IronPython.Modules/_ctypes/StructType.cs
@@ -116,7 +116,7 @@ namespace IronPython.Modules {
             /// </summary>
             public object from_param(object obj) {
                 if (!Builtin.isinstance(obj, this)) {
-                    throw PythonOps.TypeError("expected {0} instance got {1}", Name, PythonTypeOps.GetName(obj));
+                    throw PythonOps.TypeError("expected {0} instance got {1}", Name, PythonOps.GetPythonTypeName(obj));
                 }
 
                 return obj;

--- a/Src/IronPython.Modules/_ctypes/_ctypes.cs
+++ b/Src/IronPython.Modules/_ctypes/_ctypes.cs
@@ -577,12 +577,12 @@ namespace IronPython.Modules {
 
             fieldName = pt[0] as string;
             if (fieldName == null) {
-                throw PythonOps.TypeError("first item in _fields_ tuple must be a string, got", PythonTypeOps.GetName(pt[0]));
+                throw PythonOps.TypeError("first item in _fields_ tuple must be a string, got", PythonOps.GetPythonTypeName(pt[0]));
             }
 
             cdata = pt[1] as INativeType;
             if (cdata == null) {
-                throw PythonOps.TypeError("second item in _fields_ tuple must be a C type, got {0}", PythonTypeOps.GetName(pt[0]));
+                throw PythonOps.TypeError("second item in _fields_ tuple must be a C type, got {0}", PythonOps.GetPythonTypeName(pt[0]));
             } else if (cdata == type) {
                 throw StructureCannotContainSelf();
             }

--- a/Src/IronPython.Modules/_datetime.cs
+++ b/Src/IronPython.Modules/_datetime.cs
@@ -606,7 +606,7 @@ namespace IronPython.Modules {
 
             private static bool CheckTypeError(object other, bool shouldThrow) {
                 if (shouldThrow) {
-                    throw PythonOps.TypeError("can't compare datetime.date to {0}", PythonTypeOps.GetName(other));
+                    throw PythonOps.TypeError("can't compare datetime.date to {0}", PythonOps.GetPythonTypeName(other));
                 } else {
                     return true;
                 }
@@ -766,7 +766,7 @@ namespace IronPython.Modules {
                 }
 
                 if (args.Length > 7 && !(args[7] is tzinfo || args[7] == null)) {
-                    throw PythonOps.TypeError("tzinfo argument must be None or of a tzinfo subclass, not type '{0}'", PythonTypeOps.GetName(args[7]));
+                    throw PythonOps.TypeError("tzinfo argument must be None or of a tzinfo subclass, not type '{0}'", PythonOps.GetPythonTypeName(args[7]));
                 }
 
                 // the above cases should cover all binding failures...
@@ -1113,7 +1113,7 @@ namespace IronPython.Modules {
 
                 datetime combo = other as datetime;
                 if (combo == null)
-                    throw PythonOps.TypeError("can't compare datetime.datetime to {0}", PythonTypeOps.GetName(other));
+                    throw PythonOps.TypeError("can't compare datetime.datetime to {0}", PythonOps.GetPythonTypeName(other));
 
                 if (CheckTzInfoBeforeCompare(this, combo)) {
                     int res = this.InternalDateTime.CompareTo(combo.InternalDateTime);
@@ -1411,7 +1411,7 @@ namespace IronPython.Modules {
             private int CompareTo(object other) {
                 time other2 = other as time;
                 if (other2 == null)
-                    throw PythonOps.TypeError("can't compare datetime.time to {0}", PythonTypeOps.GetName(other));
+                    throw PythonOps.TypeError("can't compare datetime.time to {0}", PythonOps.GetPythonTypeName(other));
 
                 if (CheckTzInfoBeforeCompare(this, other2)) {
                     int res = this._timeSpan.CompareTo(other2._timeSpan);

--- a/Src/IronPython.Modules/_operator.cs
+++ b/Src/IronPython.Modules/_operator.cs
@@ -427,9 +427,9 @@ types and lengths of a and b--but not their values.")]
 
         private static void TestBothSequence(object? a, object? b) {
             if (!isSequenceType(a)) {
-                throw PythonOps.TypeError("'{0}' object cannot be concatenated", PythonTypeOps.GetName(a));
+                throw PythonOps.TypeError("'{0}' object cannot be concatenated", PythonOps.GetPythonTypeName(a));
             } else if (!isSequenceType(b)) {
-                throw PythonOps.TypeError("cannot concatenate '{0}' and '{1} objects", PythonTypeOps.GetName(a), PythonTypeOps.GetName(b));
+                throw PythonOps.TypeError("cannot concatenate '{0}' and '{1} objects", PythonOps.GetPythonTypeName(a), PythonOps.GetPythonTypeName(b));
             }
         }
     }

--- a/Src/IronPython.Modules/_ssl.cs
+++ b/Src/IronPython.Modules/_ssl.cs
@@ -95,7 +95,7 @@ namespace IronPython.Modules {
 
         public static void RAND_add(object buf, double entropy) {
             if (!(buf is string) && !(buf is IBufferProtocol)) {
-                throw PythonOps.TypeError($"'{DynamicHelpers.GetPythonType(buf).Name}' does not support the buffer interface");
+                throw PythonOps.TypeError($"'{PythonOps.GetPythonTypeName(buf)}' does not support the buffer interface");
             }
         }
 

--- a/Src/IronPython.Modules/_struct.cs
+++ b/Src/IronPython.Modules/_struct.cs
@@ -808,7 +808,7 @@ namespace IronPython.Modules {
             if (fmt is IList<byte> b) {
                 return PythonOps.MakeString(b);
             }
-            throw PythonOps.TypeError("Struct() argument 1 must be a str or bytes object, not {0}", DynamicHelpers.GetPythonType(fmt).Name);
+            throw PythonOps.TypeError("Struct() argument 1 must be a str or bytes object, not {0}", PythonOps.GetPythonTypeName(fmt));
         }
 
         private static Struct GetStructFromCache(CodeContext/*!*/ context, object fmt) {

--- a/Src/IronPython.Modules/_weakref.cs
+++ b/Src/IronPython.Modules/_weakref.cs
@@ -781,7 +781,7 @@ namespace IronPython.Modules {
             if (proxy == null)
                 throw PythonOps.TypeError("descriptor for {0} object doesn't apply to {1} object",
                     PythonOps.Repr(context, _type.Name),
-                    PythonOps.Repr(context, PythonTypeOps.GetName(instance)));
+                    PythonOps.Repr(context, PythonOps.GetPythonTypeName(instance)));
 
             if (!DynamicHelpers.GetPythonType(proxy.Target).TryGetBoundMember(context, proxy.Target, _name, out value))
                 return false;

--- a/Src/IronPython.Modules/array.cs
+++ b/Src/IronPython.Modules/array.cs
@@ -314,7 +314,7 @@ namespace IronPython.Modules {
                     if (!_data.CanStore(ie.Current)) {
                         throw PythonOps.TypeError("expected {0}, got {1}",
                             DynamicHelpers.GetPythonTypeFromType(_data.StorageType).Name,
-                            DynamicHelpers.GetPythonType(ie.Current).Name);
+                            PythonOps.GetPythonTypeName(ie.Current));
                     }
                     items.Add(ie.Current);
                 }

--- a/Src/IronPython.Modules/array.cs
+++ b/Src/IronPython.Modules/array.cs
@@ -38,7 +38,7 @@ namespace IronPython.Modules {
 
         private static array ArrayReconstructor(CodeContext context, [NotNull]PythonType cls, [NotNull]string typecode, int mformat_code, [NotNull]Bytes items) {
             if (typecode.Length != 1)
-                throw PythonOps.TypeError("expected character, got {0}", PythonTypeOps.GetName(typecode));
+                throw PythonOps.TypeError("expected character, got {0}", PythonOps.GetPythonTypeName(typecode));
             if (!typecodes.Contains(typecode))
                 throw PythonOps.ValueError("bad typecode (must be b, B, u, h, H, i, I, l, L, q, Q, f or d)");
 
@@ -117,7 +117,7 @@ namespace IronPython.Modules {
 
             public array([NotNull]string type) {
                 if (type == null || type.Length != 1) {
-                    throw PythonOps.TypeError("expected character, got {0}", PythonTypeOps.GetName(type));
+                    throw PythonOps.TypeError("expected character, got {0}", PythonOps.GetPythonTypeName(type));
                 }
 
                 _typeCode = type[0];
@@ -531,7 +531,7 @@ namespace IronPython.Modules {
 
             private array CheckSliceAssignType([System.Diagnostics.CodeAnalysis.NotNull]object? value) {
                 if (!(value is array pa)) {
-                    throw PythonOps.TypeError("can only assign array (not \"{0}\") to array slice", PythonTypeOps.GetName(value));
+                    throw PythonOps.TypeError("can only assign array (not \"{0}\") to array slice", PythonOps.GetPythonTypeName(value));
                 } else if (pa._typeCode != _typeCode) {
                     throw PythonOps.TypeError("bad argument type for built-in operation");
                 }

--- a/Src/IronPython.Modules/marshal.cs
+++ b/Src/IronPython.Modules/marshal.cs
@@ -42,7 +42,7 @@ namespace IronPython.Modules {
 
         private static IEnumerator<byte> FileEnumerator(CodeContext/*!*/ context, PythonIOModule._IOBase/*!*/ file) {
             object bytes = file.read(context, 0);
-            if (!(bytes is Bytes)) throw PythonOps.TypeError($"file.read() returned not bytes but {Runtime.Types.DynamicHelpers.GetPythonType(bytes).Name}");
+            if (!(bytes is Bytes)) throw PythonOps.TypeError($"file.read() returned not bytes but {PythonOps.GetPythonTypeName(bytes)}");
 
             for (; ; ) {
                 Bytes data = (Bytes)file.read(context, 1);

--- a/Src/IronPython.Modules/math.cs
+++ b/Src/IronPython.Modules/math.cs
@@ -531,7 +531,7 @@ namespace IronPython.Modules {
             if (PythonOps.TryGetBoundAttr(value, "__trunc__", out func)) {
                 return PythonOps.CallWithContext(context, func);
             } else {
-                throw PythonOps.TypeError("type {0} doesn't define __trunc__ method", PythonTypeOps.GetName(value));
+                throw PythonOps.TypeError("type {0} doesn't define __trunc__ method", PythonOps.GetPythonTypeName(value));
             }
         }
 

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -1594,7 +1594,7 @@ namespace IronPython.Modules {
 
         [Documentation("")]
         public static void truncate(CodeContext context, [NotNull] IBufferProtocol path, BigInteger length) {
-            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, $"{nameof(truncate)}: {nameof(path)} should be string or bytes, not {PythonTypeOps.GetName(path)}"); // deprecated in 3.6
+            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, $"{nameof(truncate)}: {nameof(path)} should be string or bytes, not {PythonOps.GetPythonTypeName(path)}"); // deprecated in 3.6
             truncate(context, path.ToFsBytes(context), length);
         }
 
@@ -2240,7 +2240,7 @@ the 'status' value."),
 
         private static Bytes ToFsBytes(this IBufferProtocol bp, CodeContext context) {
             // TODO: Python 3.6: "path should be string, bytes or os.PathLike"
-            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "path should be string or bytes, not {0}", PythonTypeOps.GetName(bp));
+            PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "path should be string or bytes, not {0}", PythonOps.GetPythonTypeName(bp));
             return new Bytes(bp); // accepts FULL_RO buffers in CPython
         }
 

--- a/Src/IronPython.Modules/pyexpat.cs
+++ b/Src/IronPython.Modules/pyexpat.cs
@@ -649,7 +649,7 @@ namespace IronPython.Modules {
                         }
                     }
                 } else {
-                    throw PythonOps.TypeError("read() did not return a bytes object (type={0})", DynamicHelpers.GetPythonType(readResult).Name);
+                    throw PythonOps.TypeError("read() did not return a bytes object (type={0})", PythonOps.GetPythonTypeName(readResult));
                 }
 
 

--- a/Src/IronPython.Modules/pyexpat.cs
+++ b/Src/IronPython.Modules/pyexpat.cs
@@ -259,8 +259,8 @@ namespace IronPython.Modules {
         }
 
         public static object ParserCreate(object encoding, object namespace_separator, object intern) {
-            var encoding_str = encoding == null ? null : (encoding as string ?? throw PythonOps.TypeError($"ParserCreate() argument 1 must be string or None, not {PythonTypeOps.GetName(encoding)}"));
-            var namespace_separator_str = namespace_separator == null ? null : (namespace_separator as string ?? throw PythonOps.TypeError($"ParserCreate() argument 2 must be string or None, not {PythonTypeOps.GetName(namespace_separator)}"));
+            var encoding_str = encoding == null ? null : (encoding as string ?? throw PythonOps.TypeError($"ParserCreate() argument 1 must be string or None, not {PythonOps.GetPythonTypeName(encoding)}"));
+            var namespace_separator_str = namespace_separator == null ? null : (namespace_separator as string ?? throw PythonOps.TypeError($"ParserCreate() argument 2 must be string or None, not {PythonOps.GetPythonTypeName(namespace_separator)}"));
 
             return ParserCreateImpl(encoding_str, namespace_separator_str, intern);
         }

--- a/Src/IronPython.Modules/re.cs
+++ b/Src/IronPython.Modules/re.cs
@@ -567,7 +567,7 @@ namespace IronPython.Modules {
                             break;
                         case string _:
                         case ExtensibleString _:
-                            throw PythonOps.TypeError($"expected a bytes-like object, {PythonTypeOps.GetName(repl)} found");
+                            throw PythonOps.TypeError($"expected a bytes-like object, {PythonOps.GetPythonTypeName(repl)} found");
                         default:
                             break;
                     }
@@ -581,7 +581,7 @@ namespace IronPython.Modules {
                             break;
                         case IBufferProtocol _:
                         case IList<byte> _:
-                            throw PythonOps.TypeError($"expected str instance, {PythonTypeOps.GetName(repl)} found");
+                            throw PythonOps.TypeError($"expected str instance, {PythonOps.GetPythonTypeName(repl)} found");
                         default:
                             break;
                     }

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -100,7 +100,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
                 return value;
             }
 
-            throw PythonOps.TypeError("bad operand type for abs(): '{0}'", PythonTypeOps.GetName(o));
+            throw PythonOps.TypeError("bad operand type for abs(): '{0}'", PythonOps.GetPythonTypeName(o));
         }
 
         public static bool all(CodeContext context, object? x) {
@@ -400,7 +400,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
                 out res);
 
             if (!(res is string strRes)) {
-                throw PythonOps.TypeError("{0}.__format__ must return string, not {1}", PythonTypeOps.GetName(argValue), PythonTypeOps.GetName(res));
+                throw PythonOps.TypeError("{0}.__format__ must return string, not {1}", PythonOps.GetPythonTypeName(argValue), PythonOps.GetPythonTypeName(res));
             }
 
             return strRes;
@@ -1170,7 +1170,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
                 return bytes[0];
             }
 
-            throw PythonOps.TypeError("expected a character, but {0} found", PythonTypeOps.GetName(value));
+            throw PythonOps.TypeError("expected a character, but {0} found", PythonOps.GetPythonTypeName(value));
         }
 
         public static object pow(CodeContext/*!*/ context, object? x, object? y) {
@@ -1192,12 +1192,12 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         public static void print(CodeContext/*!*/ context, [ParamDictionary, NotNull]IDictionary<string, object?> kwargs, [NotNull]params object?[] args) {
             object? sep = AttrCollectionPop(kwargs, "sep", " ");
             if (sep != null && !(sep is string)) {
-                throw PythonOps.TypeError("sep must be None or str, not {0}", PythonTypeOps.GetName(sep));
+                throw PythonOps.TypeError("sep must be None or str, not {0}", PythonOps.GetPythonTypeName(sep));
             }
 
             object? end = AttrCollectionPop(kwargs, "end", "\n");
             if (end != null && !(end is string)) {
-                throw PythonOps.TypeError("end must be None or str, not {0}", PythonTypeOps.GetName(end));
+                throw PythonOps.TypeError("end must be None or str, not {0}", PythonOps.GetPythonTypeName(end));
             }
 
             object? file = AttrCollectionPop(kwargs, "file", null);
@@ -1338,7 +1338,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
                 return val;
             }
 
-            throw PythonOps.TypeError("type {0} doesn't define __round__ method", PythonTypeOps.GetName(number));
+            throw PythonOps.TypeError("type {0} doesn't define __round__ method", PythonOps.GetPythonTypeName(number));
         }
 
         public static object? round(CodeContext/*!*/ context, object? number, object? ndigits) {
@@ -1375,7 +1375,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
                 return val;
             }
 
-            throw PythonOps.TypeError("type {0} doesn't define __round__ method", PythonTypeOps.GetName(number));
+            throw PythonOps.TypeError("type {0} doesn't define __round__ method", PythonOps.GetPythonTypeName(number));
         }
 
         public static void setattr(CodeContext/*!*/ context, object? o, [NotNull]string name, object? val) {

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -346,7 +346,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             if (globals == null) globals = context.GlobalDict;
 
             if (locals != null && !PythonOps.IsMappingType(context, locals)) {
-                throw PythonOps.TypeError($"locals must be mapping or None, not {DynamicHelpers.GetPythonType(locals).Name}");
+                throw PythonOps.TypeError($"locals must be mapping or None, not {PythonOps.GetPythonTypeName(locals)}");
             }
 
             CodeContext execContext = Builtin.GetExecEvalScope(context, globals, Builtin.GetAttrLocals(context, locals), true, false);

--- a/Src/IronPython/Modules/_ast.cs
+++ b/Src/IronPython/Modules/_ast.cs
@@ -114,7 +114,7 @@ namespace IronPython.Modules {
             public int lineno {
                 get {
                     if (_lineno != null) return (int)_lineno;
-                    throw PythonOps.AttributeErrorForMissingAttribute(PythonTypeOps.GetName(this), "lineno");
+                    throw PythonOps.AttributeErrorForMissingAttribute(PythonOps.GetPythonTypeName(this), "lineno");
                 }
                 set { _lineno = value; }
             }
@@ -122,7 +122,7 @@ namespace IronPython.Modules {
             public int col_offset {
                 get {
                     if (_col_offset != null) return (int)_col_offset;
-                    throw PythonOps.AttributeErrorForMissingAttribute(PythonTypeOps.GetName(this), "col_offset");
+                    throw PythonOps.AttributeErrorForMissingAttribute(PythonOps.GetPythonTypeName(this), "col_offset");
                 }
                 set { _col_offset = value; }
             }

--- a/Src/IronPython/Modules/_bytesio.cs
+++ b/Src/IronPython/Modules/_bytesio.cs
@@ -145,7 +145,7 @@ namespace IronPython.Modules {
                 )]
             public BigInteger readinto([NotNull] IBufferProtocol buffer) {
                 using var pythonBuffer = buffer.GetBufferNoThrow(BufferFlags.Writable)
-                    ?? throw PythonOps.TypeError("readinto() argument must be read-write bytes-like object, not {0}", PythonTypeOps.GetName(buffer));
+                    ?? throw PythonOps.TypeError("readinto() argument must be read-write bytes-like object, not {0}", PythonOps.GetPythonTypeName(buffer));
 
                 _checkClosed();
 
@@ -198,7 +198,7 @@ namespace IronPython.Modules {
 
                 _checkClosed();
 
-                throw PythonOps.TypeError("integer argument expected, got '{0}'", PythonTypeOps.GetName(size));
+                throw PythonOps.TypeError("integer argument expected, got '{0}'", PythonOps.GetPythonTypeName(size));
             }
 
             [Documentation("readlines([size]) -> list of bytes objects, each a line from the file.\n\n"
@@ -317,7 +317,7 @@ namespace IronPython.Modules {
 
                 _checkClosed();
 
-                throw PythonOps.TypeError("integer argument expected, got '{0}'", PythonTypeOps.GetName(size));
+                throw PythonOps.TypeError("integer argument expected, got '{0}'", PythonOps.GetPythonTypeName(size));
             }
 
             public override bool writable(CodeContext/*!*/ context) {
@@ -331,7 +331,7 @@ namespace IronPython.Modules {
             public override BigInteger write(CodeContext/*!*/ context, [NotNull] object bytes) {
                 _checkClosed();
                 if (bytes is IBufferProtocol bufferProtocol) return DoWrite(bufferProtocol);
-                throw PythonOps.TypeError("a bytes-like object is required, not '{0}'", PythonTypeOps.GetName(bytes));
+                throw PythonOps.TypeError("a bytes-like object is required, not '{0}'", PythonOps.GetPythonTypeName(bytes));
             }
 
             // TODO: get rid of virtual? see https://github.com/IronLanguages/ironpython3/issues/1070
@@ -371,11 +371,11 @@ namespace IronPython.Modules {
 
                 var initial_bytes = tuple[0] as IBufferProtocol;
                 if (!(tuple[0] is IBufferProtocol)) {
-                    throw PythonOps.TypeError($"'{PythonTypeOps.GetName(tuple[0])}' does not support the buffer interface");
+                    throw PythonOps.TypeError($"'{PythonOps.GetPythonTypeName(tuple[0])}' does not support the buffer interface");
                 }
 
                 if (!(tuple[1] is int i)) {
-                    throw PythonOps.TypeError($"second item of state must be an integer, not {PythonTypeOps.GetName(tuple[1])}");
+                    throw PythonOps.TypeError($"second item of state must be an integer, not {PythonOps.GetPythonTypeName(tuple[1])}");
                 }
                 if (i < 0) {
                     throw PythonOps.ValueError("position value cannot be negative");
@@ -383,7 +383,7 @@ namespace IronPython.Modules {
 
                 var dict = tuple[2] as PythonDictionary;
                 if (!(tuple[2] is PythonDictionary || tuple[2] is null)) {
-                    throw PythonOps.TypeError($"third item of state should be a dict, got a {PythonTypeOps.GetName(tuple[2])}");
+                    throw PythonOps.TypeError($"third item of state should be a dict, got a {PythonOps.GetPythonTypeName(tuple[2])}");
                 }
 
                 __init__(initial_bytes);

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -414,7 +414,7 @@ namespace IronPython.Modules {
                 EnsureReadable();
 
                 using var pythonBuffer = buffer.GetBufferNoThrow(BufferFlags.Writable)
-                    ?? throw PythonOps.TypeError("readinto() argument must be read-write bytes-like object, not {0}", PythonTypeOps.GetName(buffer));
+                    ?? throw PythonOps.TypeError("readinto() argument must be read-write bytes-like object, not {0}", PythonOps.GetPythonTypeName(buffer));
 
                 _checkClosed();
 

--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -393,7 +393,7 @@ namespace IronPython.Modules {
             internal Exception UnsupportedOperation(CodeContext/*!*/ context, string attr) {
                 throw PythonExceptions.CreateThrowable(
                     (PythonType)context.LanguageContext.GetModuleState(_unsupportedOperationKey),
-                    string.Format("{0}.{1} not supported", PythonTypeOps.GetName(this), attr)
+                    string.Format("{0}.{1} not supported", PythonOps.GetPythonTypeName(this), attr)
                 );
             }
 
@@ -401,7 +401,7 @@ namespace IronPython.Modules {
                 => PythonExceptions.CreateThrowable((PythonType)context.LanguageContext.GetModuleState(_unsupportedOperationKey), msg);
 
             internal Exception AttributeError(string attrName) {
-                throw PythonOps.AttributeError("'{0}' object has no attribute '{1}'", PythonTypeOps.GetName(this), attrName);
+                throw PythonOps.AttributeError("'{0}' object has no attribute '{1}'", PythonOps.GetPythonTypeName(this), attrName);
             }
 
             internal Exception InvalidPosition(BigInteger pos) {
@@ -516,7 +516,7 @@ namespace IronPython.Modules {
                     return data.Count;
                 }
 
-                throw PythonOps.TypeError("must be read-write buffer, not " + PythonTypeOps.GetName(buf));
+                throw PythonOps.TypeError("must be read-write buffer, not " + PythonOps.GetPythonTypeName(buf));
             }
 
             public override BigInteger write(CodeContext/*!*/ context, object buf) {
@@ -1918,16 +1918,16 @@ namespace IronPython.Modules {
 
                 var initial_value = tuple[0] as string;
                 if (!(tuple[0] is string || tuple[0] is null)) {
-                    throw PythonOps.TypeError($"initial_value must be str or None, not '{PythonTypeOps.GetName(tuple[0])}'");
+                    throw PythonOps.TypeError($"initial_value must be str or None, not '{PythonOps.GetPythonTypeName(tuple[0])}'");
                 }
 
                 var newline = tuple[1] as string;
                 if (!(tuple[1] is string || tuple[1] is null)) {
-                    throw PythonOps.TypeError($"newline must be str or None, not '{PythonTypeOps.GetName(tuple[0])}'");
+                    throw PythonOps.TypeError($"newline must be str or None, not '{PythonOps.GetPythonTypeName(tuple[0])}'");
                 }
 
                 if (!(tuple[2] is int i)) {
-                    throw PythonOps.TypeError($"third item of state must be an integer, not {PythonTypeOps.GetName(tuple[1])}");
+                    throw PythonOps.TypeError($"third item of state must be an integer, not {PythonOps.GetPythonTypeName(tuple[1])}");
                 }
                 if (i < 0) {
                     throw PythonOps.ValueError("position value cannot be negative");
@@ -1935,7 +1935,7 @@ namespace IronPython.Modules {
 
                 var dict = tuple[3] as PythonDictionary;
                 if (!(tuple[3] is PythonDictionary || tuple[3] is null)) {
-                    throw PythonOps.TypeError($"fourth item of state should be a dict, got a {PythonTypeOps.GetName(tuple[2])}");
+                    throw PythonOps.TypeError($"fourth item of state should be a dict, got a {PythonOps.GetPythonTypeName(tuple[2])}");
                 }
 
                 __init__(context, initial_value: initial_value, newline: newline);
@@ -2147,7 +2147,7 @@ namespace IronPython.Modules {
             public override BigInteger write(CodeContext/*!*/ context, object s) {
                 if (!(s is string str)) {
                     if (!(s is Extensible<string> es)) {
-                        throw PythonOps.TypeError("must be unicode, not {0}", PythonTypeOps.GetName(s));
+                        throw PythonOps.TypeError("must be unicode, not {0}", PythonOps.GetPythonTypeName(s));
                     }
                     str = es.Value;
                 }
@@ -2974,7 +2974,7 @@ namespace IronPython.Modules {
                     if (output is Extensible<string>) {
                         decoded = ((Extensible<string>)output).Value;
                     } else {
-                        throw PythonOps.TypeError("decoder produced {0}, expected str", PythonTypeOps.GetName(output));
+                        throw PythonOps.TypeError("decoder produced {0}, expected str", PythonOps.GetPythonTypeName(output));
                     }
                 }
 
@@ -3176,7 +3176,7 @@ namespace IronPython.Modules {
             }
 
             if (msg == null) {
-                throw PythonOps.TypeError("integer argument expected, got '{0}'", PythonTypeOps.GetName(i));
+                throw PythonOps.TypeError("integer argument expected, got '{0}'", PythonOps.GetPythonTypeName(i));
             }
             
             throw PythonOps.TypeError(msg, args);

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -91,7 +91,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
         public static void excepthookImpl(CodeContext/*!*/ context, object exctype, object value, object traceback) {
             PythonContext pc = context.LanguageContext;
             var exc = PythonExceptions.ToClr(value);
-            if (exc is null) throw PythonOps.TypeError($"Exception expected for {nameof(value)}, {PythonTypeOps.GetName(value)} found");
+            if (exc is null) throw PythonOps.TypeError($"Exception expected for {nameof(value)}, {PythonOps.GetPythonTypeName(value)} found");
 
             PythonOps.PrintWithDest(
                 context,

--- a/Src/IronPython/Runtime/ArrayData.cs
+++ b/Src/IronPython/Runtime/ArrayData.cs
@@ -202,10 +202,10 @@ namespace IronPython.Runtime {
             if (value != null && typeof(T).IsPrimitive && typeof(T) != typeof(char))
                 throw PythonOps.OverflowError("couldn't convert {1} to {0}",
                     DynamicHelpers.GetPythonTypeFromType(typeof(T)).Name,
-                    DynamicHelpers.GetPythonType(value).Name);
+                    PythonOps.GetPythonTypeName(value));
             throw PythonOps.TypeError("expected {0}, got {1}",
                 DynamicHelpers.GetPythonTypeFromType(typeof(T)).Name,
-                DynamicHelpers.GetPythonType(value).Name);
+                PythonOps.GetPythonTypeName(value));
         }
 
         public int IndexOf(T item)

--- a/Src/IronPython/Runtime/Binding/MetaPythonType.Members.cs
+++ b/Src/IronPython/Runtime/Binding/MetaPythonType.Members.cs
@@ -398,7 +398,7 @@ namespace IronPython.Runtime.Binding {
                                         "AttributeErrorForMissingAttribute",
                                         new Type[] { typeof(string), typeof(string) }
                                     ),
-                                    AstUtils.Constant(DynamicHelpers.GetPythonType(Value).Name),
+                                    AstUtils.Constant(PythonOps.GetPythonTypeName(Value)),
                                     AstUtils.Constant(pb.Name)
                                 ),
                                 typeof(object)

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -1010,7 +1010,7 @@ namespace IronPython.Runtime {
                 return translate(table, buffer.AsReadOnlySpan().ToArray());
             }
             ValidateTable(table);
-            throw PythonOps.TypeError("a bytes-like object is required, not '{0}", PythonTypeOps.GetName(delete));
+            throw PythonOps.TypeError("a bytes-like object is required, not '{0}", PythonOps.GetPythonTypeName(delete));
         }
 
         public ByteArray upper() {
@@ -1055,7 +1055,7 @@ namespace IronPython.Runtime {
                 return IndexOf(((Extensible<BigInteger>)value).Value.ToByteChecked()) != -1;
             }
 
-            throw PythonOps.TypeError("Type {0} doesn't support the buffer API", PythonTypeOps.GetName(value));
+            throw PythonOps.TypeError("Type {0} doesn't support the buffer API", PythonOps.GetPythonTypeName(value));
         }
 
         public IEnumerator<int> __iter__()
@@ -1130,7 +1130,7 @@ namespace IronPython.Runtime {
         }
 
         private static Exception TypeErrorForConcat(object self, object? other)
-            => PythonOps.TypeError($"can't concat {PythonTypeOps.GetName(self)} to {PythonTypeOps.GetName(other)}");
+            => PythonOps.TypeError($"can't concat {PythonOps.GetPythonTypeName(self)} to {PythonOps.GetPythonTypeName(other)}");
 
         private static ByteArray MultiplyWorker(ByteArray self, int count) {
             lock (self) {
@@ -1323,7 +1323,7 @@ namespace IronPython.Runtime {
 
         [SpecialName]
         public void DeleteItem(object? slice) {
-            throw PythonOps.TypeError("bytearray indices must be integers or slices, not {0}", PythonTypeOps.GetName(slice));
+            throw PythonOps.TypeError("bytearray indices must be integers or slices, not {0}", PythonOps.GetPythonTypeName(slice));
         }
 
         #endregion

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -822,7 +822,7 @@ namespace IronPython.Runtime {
                 return translate(table, buffer.AsReadOnlySpan().ToArray());
             }
             ValidateTable(table);
-            throw PythonOps.TypeError("a bytes-like object is required, not '{0}", PythonTypeOps.GetName(delete));
+            throw PythonOps.TypeError("a bytes-like object is required, not '{0}", PythonOps.GetPythonTypeName(delete));
         }
 
         public Bytes upper() {
@@ -860,7 +860,7 @@ namespace IronPython.Runtime {
                     return IndexOf(ebi.Value.ToByteChecked()) != -1;
             }
 
-            throw PythonOps.TypeError("Type {0} doesn't support the buffer API", PythonTypeOps.GetName(value));
+            throw PythonOps.TypeError("Type {0} doesn't support the buffer API", PythonOps.GetPythonTypeName(value));
         }
 
         public PythonTuple __getnewargs__()
@@ -911,7 +911,7 @@ namespace IronPython.Runtime {
 
         public static Bytes operator +([NotNull] Bytes self, [NotNull] IBufferProtocol other) {
             using var buffer = other.GetBufferNoThrow();
-            if (buffer is null) throw PythonOps.TypeError("can't concat {0} to bytes", PythonTypeOps.GetName(other));
+            if (buffer is null) throw PythonOps.TypeError("can't concat {0} to bytes", PythonOps.GetPythonTypeName(other));
             var span = buffer.AsReadOnlySpan();
             var bytes = new byte[self._bytes.Length + span.Length];
             self._bytes.CopyTo(bytes, 0);
@@ -920,7 +920,7 @@ namespace IronPython.Runtime {
         }
 
         public static Bytes operator +([NotNull]Bytes self, object? other) {
-            throw PythonOps.TypeError("can't concat {0} to bytes", PythonTypeOps.GetName(other));
+            throw PythonOps.TypeError("can't concat {0} to bytes", PythonOps.GetPythonTypeName(other));
         }
 
         private static Bytes MultiplyWorker(Bytes self, int count) {

--- a/Src/IronPython/Runtime/Converter.cs
+++ b/Src/IronPython/Runtime/Converter.cs
@@ -410,7 +410,7 @@ namespace IronPython.Runtime {
         }
 
         internal static Exception CannotConvertOverflow(string name, object value) {
-            return PythonOps.OverflowError("Cannot convert {0}({1}) to {2}", PythonTypeOps.GetName(value), value, name);
+            return PythonOps.OverflowError("Cannot convert {0}({1}) to {2}", PythonOps.GetPythonTypeName(value), value, name);
         }
 
         private static Exception MakeTypeError(Type expectedType, object o) {

--- a/Src/IronPython/Runtime/Converter.cs
+++ b/Src/IronPython/Runtime/Converter.cs
@@ -363,10 +363,10 @@ namespace IronPython.Runtime {
                     return res;
                 }
 
-                throw PythonOps.TypeError("__index__ returned non-int (type {0})", DynamicHelpers.GetPythonType(index).Name);
+                throw PythonOps.TypeError("__index__ returned non-int (type {0})", PythonOps.GetPythonTypeName(index));
             }
 
-            throw PythonOps.TypeError("expected integer value, got {0}", DynamicHelpers.GetPythonType(value).Name);
+            throw PythonOps.TypeError("expected integer value, got {0}", PythonOps.GetPythonTypeName(value));
         }
 
         internal static bool TryGetInt(object o, out int value, bool throwOverflowError) {

--- a/Src/IronPython/Runtime/Descriptors.cs
+++ b/Src/IronPython/Runtime/Descriptors.cs
@@ -120,7 +120,7 @@ namespace IronPython.Runtime {
                 // http://bugs.python.org/issue5890
                 PythonDictionary dict = UserTypeOps.GetDictionary((IPythonObject)this);
                 if (dict == null) {
-                    throw PythonOps.AttributeError("{0} object has no __doc__ attribute", PythonTypeOps.GetName(this));
+                    throw PythonOps.AttributeError("{0} object has no __doc__ attribute", PythonOps.GetPythonTypeName(this));
                 }
 
                 dict["__doc__"] = ((PythonFunction)_fget).__doc__;

--- a/Src/IronPython/Runtime/Enumerate.cs
+++ b/Src/IronPython/Runtime/Enumerate.cs
@@ -219,7 +219,7 @@ namespace IronPython.Runtime {
         public static IEnumerator Create(object baseObject) {
             IEnumerator res;
             if (!TryCreate(baseObject, out res)) {
-                throw PythonOps.TypeError("cannot convert {0} to IEnumerator", PythonTypeOps.GetName(baseObject));
+                throw PythonOps.TypeError("cannot convert {0} to IEnumerator", PythonOps.GetPythonTypeName(baseObject));
             }
             return res;
         }
@@ -305,7 +305,7 @@ namespace IronPython.Runtime {
         public static IEnumerable Create(object baseObject) {
             IEnumerable res;
             if (!TryCreate(baseObject, out res)) {
-                throw PythonOps.TypeError("cannot convert {0} to IEnumerable", PythonTypeOps.GetName(baseObject));
+                throw PythonOps.TypeError("cannot convert {0} to IEnumerable", PythonOps.GetPythonTypeName(baseObject));
             }
             return res;
         }

--- a/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
+++ b/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
@@ -92,7 +92,7 @@ namespace IronPython.Runtime.Exceptions {
                 if (args[0] is string || args[0] is Extensible<string>) {
                     @object = args[0];
                 } else {
-                    throw PythonOps.TypeError("argument 4 must be unicode, not {0}", DynamicHelpers.GetPythonType(args[0]).Name);
+                    throw PythonOps.TypeError("argument 4 must be unicode, not {0}", PythonOps.GetPythonTypeName(args[0]));
                 }
 
                 start = args[1];
@@ -101,7 +101,7 @@ namespace IronPython.Runtime.Exceptions {
                 if (args[3] is string || args[3] is Extensible<string>) {
                     reason = args[3];
                 } else {
-                    throw PythonOps.TypeError("argument 4 must be str, not {0}", DynamicHelpers.GetPythonType(args[3]).Name);
+                    throw PythonOps.TypeError("argument 4 must be str, not {0}", PythonOps.GetPythonTypeName(args[3]));
                 }
 
                 base.__init__(args);

--- a/Src/IronPython/Runtime/Generator.cs
+++ b/Src/IronPython/Runtime/Generator.cs
@@ -125,7 +125,7 @@ namespace IronPython.Runtime {
             } else if (type is PythonType pt && typeof(PythonExceptions.BaseException).IsAssignableFrom(pt.UnderlyingSystemType)) {
                 // ok
             } else {
-                throw PythonOps.TypeError("exceptions must be classes or instances deriving from BaseException, not {0}", PythonTypeOps.GetName(type));
+                throw PythonOps.TypeError("exceptions must be classes or instances deriving from BaseException, not {0}", PythonOps.GetPythonTypeName(type));
             }
 
             // Set fields which will then be used by CheckThrowable.

--- a/Src/IronPython/Runtime/ObjectDebugView.cs
+++ b/Src/IronPython/Runtime/ObjectDebugView.cs
@@ -29,7 +29,9 @@ namespace IronPython.Runtime {
         }
 
         public string GetClassName() {
+#pragma warning disable IPY04 // Direct call to PythonTypeOps.GetName
             return PythonTypeOps.GetName(_value);
+#pragma warning restore IPY04
         }
 
         public string GetName() {

--- a/Src/IronPython/Runtime/Operations/ByteOps.cs
+++ b/Src/IronPython/Runtime/Operations/ByteOps.cs
@@ -103,7 +103,7 @@ namespace IronPython.Runtime.Operations {
                     return buf.AsReadOnlySpan().ToArray();
                 }
             }
-            throw PythonOps.TypeError("a bytes-like object is required, not '{0}'", PythonTypeOps.GetName(obj));
+            throw PythonOps.TypeError("a bytes-like object is required, not '{0}'", PythonOps.GetPythonTypeName(obj));
         }
 
         internal static IList<byte> GetBytes(object? value, bool useHint, CodeContext? context = null) {
@@ -163,7 +163,7 @@ namespace IronPython.Runtime.Operations {
                 }
             }
 
-            throw PythonOps.TypeError($"'{PythonTypeOps.GetName(o)}' object cannot be interpreted as an integer");
+            throw PythonOps.TypeError($"'{PythonOps.GetPythonTypeName(o)}' object cannot be interpreted as an integer");
         }
     }
 }

--- a/Src/IronPython/Runtime/Operations/ComplexOps.cs
+++ b/Src/IronPython/Runtime/Operations/ComplexOps.cs
@@ -33,8 +33,8 @@ namespace IronPython.Runtime.Operations {
 
         [StaticExtensionMethod]
         public static object __new__(CodeContext context, PythonType cls, [Optional] object? real, [Optional] object? imag) {
-            if (real == null) throw PythonOps.TypeError($"complex() first argument must be a string or a number, not '{PythonTypeOps.GetName(real)}'");
-            if (imag == null) throw PythonOps.TypeError($"complex() second argument must be a number, not '{PythonTypeOps.GetName(real)}'");
+            if (real == null) throw PythonOps.TypeError($"complex() first argument must be a string or a number, not '{PythonOps.GetPythonTypeName(real)}'");
+            if (imag == null) throw PythonOps.TypeError($"complex() second argument must be a number, not '{PythonOps.GetPythonTypeName(real)}'");
 
             Complex imag2;
             if (imag is Missing) {
@@ -43,7 +43,7 @@ namespace IronPython.Runtime.Operations {
                 if (real is string) throw PythonOps.TypeError("complex() can't take second arg if first is a string");
                 if (imag is string) throw PythonOps.TypeError("complex() second arg can't be a string");
                 if (!Converter.TryConvertToComplex(imag, out imag2)) {
-                    throw PythonOps.TypeError($"complex() second argument must be a number, not '{PythonTypeOps.GetName(real)}'");
+                    throw PythonOps.TypeError($"complex() second argument must be a number, not '{PythonOps.GetPythonTypeName(real)}'");
                 }
             }
 
@@ -58,7 +58,7 @@ namespace IronPython.Runtime.Operations {
                 if (imag is Missing && cls == TypeCache.Complex) return real;
                 else real2 = (Complex)real;
             } else if (!Converter.TryConvertToComplex(real, out real2)) {
-                throw PythonOps.TypeError($"complex() first argument must be a string or a number, not '{PythonTypeOps.GetName(real)}'");
+                throw PythonOps.TypeError($"complex() first argument must be a string or a number, not '{PythonOps.GetPythonTypeName(real)}'");
             }
 
             double real3 = real2.Real - imag2.Imaginary;

--- a/Src/IronPython/Runtime/Operations/FloatOps.cs
+++ b/Src/IronPython/Runtime/Operations/FloatOps.cs
@@ -64,11 +64,11 @@ namespace IronPython.Runtime.Operations {
                             result = ed.Value; // Python 3.6: return the int value
                             return true;
                         default:
-                            throw PythonOps.TypeError("__float__ returned non-float (type {0})", PythonTypeOps.GetName(result));
+                            throw PythonOps.TypeError("__float__ returned non-float (type {0})", PythonOps.GetPythonTypeName(result));
                     }
 
                     static void Warn(CodeContext context, object result) {
-                        PythonOps.Warn(context, PythonExceptions.DeprecationWarning, $"__float__ returned non-float (type {PythonTypeOps.GetName(result)}).  The ability to return an instance of a strict subclass of float is deprecated, and may be removed in a future version of Python.");
+                        PythonOps.Warn(context, PythonExceptions.DeprecationWarning, $"__float__ returned non-float (type {PythonOps.GetPythonTypeName(result)}).  The ability to return an instance of a strict subclass of float is deprecated, and may be removed in a future version of Python.");
                     }
                 }
                 return false;

--- a/Src/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/Src/IronPython/Runtime/Operations/InstanceOps.cs
@@ -238,7 +238,7 @@ namespace IronPython.Runtime.Operations {
 
         public static string SimpleRepr(object self) {
             return String.Format("<{0} object at {1}>",
-                PythonTypeOps.GetName(self),
+                PythonOps.GetPythonTypeName(self),
                 PythonOps.HexId(self));
         }
 

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -73,12 +73,12 @@ namespace IronPython.Runtime.Operations {
                             if (TryInvokeInt(context, result, out var intResult)) {
                                 return intResult;
                             }
-                            throw PythonOps.TypeError("__trunc__ returned non-Integral (type {0})", PythonTypeOps.GetName(result));
+                            throw PythonOps.TypeError("__trunc__ returned non-Integral (type {0})", PythonOps.GetPythonTypeName(result));
                         }
                 }
             }
 
-            throw PythonOps.TypeError("int() argument must be a string, a bytes-like object or a number, not '{0}'", PythonTypeOps.GetName(o));
+            throw PythonOps.TypeError("int() argument must be a string, a bytes-like object or a number, not '{0}'", PythonOps.GetPythonTypeName(o));
 
             static bool TryInvokeInt(CodeContext context, object o, out object result) {
                 if (PythonTypeOps.TryInvokeUnaryOperator(context, o, "__int__", out result)) {
@@ -101,11 +101,11 @@ namespace IronPython.Runtime.Operations {
                             result = ebi.Value.IsInt32() ? (object)(int)ebi.Value : ebi.Value; // Python 3.6: return the int value
                             return true;
                         default:
-                            throw PythonOps.TypeError("__int__ returned non-int (type {0})", PythonTypeOps.GetName(result));
+                            throw PythonOps.TypeError("__int__ returned non-int (type {0})", PythonOps.GetPythonTypeName(result));
                     }
 
                     static void Warn(CodeContext context, object result) {
-                        PythonOps.Warn(context, PythonExceptions.DeprecationWarning, $"__int__ returned non-int (type {PythonTypeOps.GetName(result)}).  The ability to return an instance of a strict subclass of int is deprecated, and may be removed in a future version of Python.");
+                        PythonOps.Warn(context, PythonExceptions.DeprecationWarning, $"__int__ returned non-int (type {PythonOps.GetPythonTypeName(result)}).  The ability to return an instance of a strict subclass of int is deprecated, and may be removed in a future version of Python.");
                     }
                 }
                 return false;

--- a/Src/IronPython/Runtime/Operations/LongOps.cs
+++ b/Src/IronPython/Runtime/Operations/LongOps.cs
@@ -80,7 +80,7 @@ namespace IronPython.Runtime.Operations {
                     result is Extensible<int> || result is Extensible<BigInteger>) {
                     return ReturnObject(context, cls, result);
                 } else {
-                    throw PythonOps.TypeError("__long__ returned non-long (type {0})", PythonTypeOps.GetName(result));
+                    throw PythonOps.TypeError("__long__ returned non-long (type {0})", PythonOps.GetPythonTypeName(result));
                 }
             } else if (PythonOps.TryGetBoundAttr(context, x, "__trunc__", out result)) {
                 result = PythonOps.CallWithContext(context, result);
@@ -89,7 +89,7 @@ namespace IronPython.Runtime.Operations {
                 } else if (Converter.TryConvertToBigInteger(result, out bigintRes)) {
                     return ReturnObject(context, cls, bigintRes);
                 } else {
-                    throw PythonOps.TypeError("__trunc__ returned non-Integral (type {0})", PythonTypeOps.GetName(result));
+                    throw PythonOps.TypeError("__trunc__ returned non-Integral (type {0})", PythonOps.GetPythonTypeName(result));
                 }
             }
 

--- a/Src/IronPython/Runtime/Operations/LongOps.cs
+++ b/Src/IronPython/Runtime/Operations/LongOps.cs
@@ -94,7 +94,7 @@ namespace IronPython.Runtime.Operations {
             }
 
             throw PythonOps.TypeError("long() argument must be a string or a number, not '{0}'",
-                    DynamicHelpers.GetPythonType(x).Name);
+                    PythonOps.GetPythonTypeName(x));
         }
 
         private static object ReturnObject(CodeContext context, PythonType cls, object value) {

--- a/Src/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/Src/IronPython/Runtime/Operations/ObjectOps.cs
@@ -158,7 +158,7 @@ namespace IronPython.Runtime.Operations {
         /// a string which consists of the type and a unique numerical identifier.
         /// </summary>
         public static string __repr__(object self) {
-            return $"<{DynamicHelpers.GetPythonType(self).Name} object at {PythonOps.HexId(self)}>";
+            return $"<{PythonOps.GetPythonTypeName(self)} object at {PythonOps.HexId(self)}>";
         }
 
         /// <summary>

--- a/Src/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/Src/IronPython/Runtime/Operations/ObjectOps.cs
@@ -253,7 +253,7 @@ namespace IronPython.Runtime.Operations {
 
         public static string __format__(CodeContext/*!*/ context, object self, [NotNull]string/*!*/ formatSpec) {
             if (formatSpec != string.Empty)
-                throw PythonOps.TypeError("unsupported format string passed to {0}.__format__", PythonTypeOps.GetName(self));
+                throw PythonOps.TypeError("unsupported format string passed to {0}.__format__", PythonOps.GetPythonTypeName(self));
 
             return PythonOps.ToString(context, self);
         }

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -279,7 +279,7 @@ namespace IronPython.Runtime.Operations {
             object value = PythonContext.InvokeUnaryOperator(context, UnaryOperators.String, o);
             if (!(value is string ret)) {
                 if (!(value is Extensible<string> es)) {
-                    throw PythonOps.TypeError("expected str, got {0} from __str__", PythonTypeOps.GetName(value));
+                    throw PythonOps.TypeError("expected str, got {0} from __str__", PythonOps.GetPythonTypeName(value));
                 }
 
                 ret = es.Value;
@@ -535,7 +535,7 @@ namespace IronPython.Runtime.Operations {
 
         internal static int GetSequenceMultiplier(object sequence, object count) {
             if (!Converter.TryConvertToIndex(count, out int icount)) {
-                throw TypeError("can't multiply sequence by non-int of type '{0}'", PythonTypeOps.GetName(count));
+                throw TypeError("can't multiply sequence by non-int of type '{0}'", PythonOps.GetPythonTypeName(count));
             }
             return icount;
         }
@@ -742,7 +742,7 @@ namespace IronPython.Runtime.Operations {
 
         public static object Index(object? o) {
             if (TryToIndex(o, out object? index)) return index;
-            throw TypeError("'{0}' object cannot be interpreted as an integer", PythonTypeOps.GetName(o));
+            throw TypeError("'{0}' object cannot be interpreted as an integer", PythonOps.GetPythonTypeName(o));
         }
 
         internal static bool TryToIndex(object? o, [NotNullWhen(true)] out object? index) {
@@ -784,10 +784,10 @@ namespace IronPython.Runtime.Operations {
                 if (index is int || index is BigInteger)
                     return true;
                 if (index is Extensible<int> || index is Extensible<BigInteger>) {
-                    Warn(context, PythonExceptions.DeprecationWarning, $"__index__ returned non-int (type {PythonTypeOps.GetName(index)}).  The ability to return an instance of a strict subclass of int is deprecated, and may be removed in a future version of Python.");
+                    Warn(context, PythonExceptions.DeprecationWarning, $"__index__ returned non-int (type {PythonOps.GetPythonTypeName(index)}).  The ability to return an instance of a strict subclass of int is deprecated, and may be removed in a future version of Python.");
                     return true;
                 }
-                throw TypeError("__index__ returned non-int (type {0})", PythonTypeOps.GetName(index));
+                throw TypeError("__index__ returned non-int (type {0})", PythonOps.GetPythonTypeName(index));
             }
 
             index = default;
@@ -966,7 +966,7 @@ namespace IronPython.Runtime.Operations {
 
         public static object GetBoundAttr(CodeContext/*!*/ context, object? o, string name) {
             if (!DynamicHelpers.GetPythonType(o).TryGetBoundAttr(context, o, name, out object ret)) {
-                throw PythonOps.AttributeError("'{0}' object has no attribute '{1}'", PythonTypeOps.GetName(o), name);
+                throw PythonOps.AttributeError("'{0}' object has no attribute '{1}'", PythonOps.GetPythonTypeName(o), name);
             }
 
             return ret;
@@ -1034,7 +1034,7 @@ namespace IronPython.Runtime.Operations {
         public static void CheckInitializedAttribute(object o, object self, string name) {
             if (o == Uninitialized.Instance) {
                 throw PythonOps.AttributeError("'{0}' object has no attribute '{1}'",
-                    PythonTypeOps.GetName(self),
+                    PythonOps.GetPythonTypeName(self),
                     name);
             }
         }
@@ -1545,7 +1545,7 @@ namespace IronPython.Runtime.Operations {
         public static void DictMerge(CodeContext context, PythonDictionary dict, object? item) {
             // call dict.keys()
             if (!PythonTypeOps.TryInvokeUnaryOperator(context, item, "keys", out object keys)) {
-                throw TypeError($"'{PythonTypeOps.GetName(item)}' object is not a mapping");
+                throw TypeError($"'{PythonOps.GetPythonTypeName(item)}' object is not a mapping");
             }
 
             // enumerate the keys getting their values
@@ -1575,7 +1575,7 @@ namespace IronPython.Runtime.Operations {
         public static void DictUpdate(CodeContext context, PythonDictionary dict, object? item) {
             // call dict.keys()
             if (!PythonTypeOps.TryInvokeUnaryOperator(context, item, "keys", out object keys)) {
-                throw TypeError($"'{PythonTypeOps.GetName(item)}' object is not a mapping");
+                throw TypeError($"'{PythonOps.GetPythonTypeName(item)}' object is not a mapping");
             }
 
             // enumerate the keys getting their values
@@ -1995,7 +1995,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static Exception TypeErrorForNotAnIterator(object? enumerable) {
-            return PythonOps.TypeError("'{0}' object is not an iterator", PythonTypeOps.GetName(enumerable));
+            return PythonOps.TypeError("'{0}' object is not an iterator", PythonOps.GetPythonTypeName(enumerable));
         }
 
         // Lack of type restrictions allows this method to return the direct result of __iter__ without
@@ -2018,7 +2018,7 @@ namespace IronPython.Runtime.Operations {
             if (PythonTypeOps.TryGetOperator(context, o, "__iter__", out object? iterFunc) && iterFunc != null) {
                 var iter = PythonCalls.Call(context, iterFunc);
                 if (!PythonTypeOps.TryGetOperator(context, iter, "__next__", out _)) {
-                    throw TypeError("iter() returned non-iterator of type '{0}'", PythonTypeOps.GetName(iter));
+                    throw TypeError("iter() returned non-iterator of type '{0}'", PythonOps.GetPythonTypeName(iter));
                 }
                 enumerator = iter!;
                 return true;
@@ -2034,11 +2034,11 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static Exception TypeErrorForNotIterable(object? enumerable) {
-            return PythonOps.TypeError("'{0}' object is not iterable", PythonTypeOps.GetName(enumerable));
+            return PythonOps.TypeError("'{0}' object is not iterable", PythonOps.GetPythonTypeName(enumerable));
         }
 
         public static KeyValuePair<IEnumerator, IDisposable> ThrowTypeErrorForBadIteration(CodeContext/*!*/ context, object enumerable) {
-            throw PythonOps.TypeError("iteration over non-sequence of type {0}", PythonTypeOps.GetName(enumerable));
+            throw PythonOps.TypeError("iteration over non-sequence of type {0}", PythonOps.GetPythonTypeName(enumerable));
         }
 
         internal static bool TryGetEnumerator(CodeContext/*!*/ context, [NotNullWhen(true)]object? enumerable, [NotNullWhen(true)]out IEnumerator? enumerator) {
@@ -2402,7 +2402,7 @@ namespace IronPython.Runtime.Operations {
             if (!PythonTypeOps.TryInvokeUnaryOperator(context, dict, "keys", out object keys)) {
                 throw TypeError("{0}() argument after ** must be a mapping, not {1}",
                     funcName,
-                    PythonTypeOps.GetName(dict));
+                    PythonOps.GetPythonTypeName(dict));
             }
 
             PythonDictionary res = new PythonDictionary();
@@ -2414,7 +2414,7 @@ namespace IronPython.Runtime.Operations {
                 if (!(o is string) && !(o is Extensible<string>)) {
                     throw TypeError("{0}() keywords must be strings, not {1}",
                         funcName,
-                        PythonTypeOps.GetName(o));
+                        PythonOps.GetPythonTypeName(o));
                 }
                 res[o] = PythonOps.GetIndex(context, dict, o);
             }
@@ -2470,7 +2470,7 @@ namespace IronPython.Runtime.Operations {
         public static PythonTuple UserMappingToPythonTuple(CodeContext/*!*/ context, object list, string funcName) {
             if (!TryGetEnumeratorObject(context, list, out object? enumerator)) {
                 // TODO: CPython 3.5 uses "an iterable" in the error message instead of "a sequence"
-                throw TypeError($"{funcName}() argument after * must be a sequence, not {PythonTypeOps.GetName(list)}");
+                throw TypeError($"{funcName}() argument after * must be a sequence, not {PythonOps.GetPythonTypeName(list)}");
             }
 
             return PythonTuple.Make(enumerator);
@@ -2834,32 +2834,32 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object ThrowingConvertToInt(object value) {
-            if (!CheckingConvertToInt(value)) throw TypeError(" __int__ returned non-int (type {0})", PythonTypeOps.GetName(value));
+            if (!CheckingConvertToInt(value)) throw TypeError(" __int__ returned non-int (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 
         public static object ThrowingConvertToFloat(object value) {
-            if (!CheckingConvertToFloat(value)) throw TypeError(" __float__ returned non-float (type {0})", PythonTypeOps.GetName(value));
+            if (!CheckingConvertToFloat(value)) throw TypeError(" __float__ returned non-float (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 
         public static object ThrowingConvertToComplex(object value) {
-            if (!CheckingConvertToComplex(value)) throw TypeError(" __complex__ returned non-complex (type {0})", PythonTypeOps.GetName(value));
+            if (!CheckingConvertToComplex(value)) throw TypeError(" __complex__ returned non-complex (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 
         public static object ThrowingConvertToLong(object value) {
-            if (!CheckingConvertToComplex(value)) throw TypeError(" __long__ returned non-long (type {0})", PythonTypeOps.GetName(value));
+            if (!CheckingConvertToComplex(value)) throw TypeError(" __long__ returned non-long (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 
         public static object ThrowingConvertToString(object value) {
-            if (!CheckingConvertToString(value)) throw TypeError(" __str__ returned non-str (type {0})", PythonTypeOps.GetName(value));
+            if (!CheckingConvertToString(value)) throw TypeError(" __str__ returned non-str (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 
         public static bool ThrowingConvertToBool(object value) {
-            if (!CheckingConvertToBool(value)) throw TypeError("__bool__ should return bool, returned {0}", PythonTypeOps.GetName(value));
+            if (!CheckingConvertToBool(value)) throw TypeError("__bool__ should return bool, returned {0}", PythonOps.GetPythonTypeName(value));
             return (bool)value;
         }
 
@@ -3670,10 +3670,10 @@ namespace IronPython.Runtime.Operations {
             if (o is PythonType dt) {
                 return PythonOps.AttributeErrorForMissingAttribute(dt.Name, name);
             } else if (o is NamespaceTracker) {
-                return PythonOps.AttributeErrorForMissingAttribute(PythonTypeOps.GetName(o), name);
+                return PythonOps.AttributeErrorForMissingAttribute(PythonOps.GetPythonTypeName(o), name);
             }
 
-            return AttributeErrorForReadonlyAttribute(PythonTypeOps.GetName(o), name);
+            return AttributeErrorForReadonlyAttribute(PythonOps.GetPythonTypeName(o), name);
         }
 
 
@@ -3877,7 +3877,7 @@ namespace IronPython.Runtime.Operations {
 
         public static Exception TypeErrorForUnboundMethodCall(string methodName, PythonType methodType, object instance) {
             string message = string.Format("unbound method {0}() must be called with {1} instance as first argument (got {2} instead)",
-                                           methodName, methodType.Name, PythonTypeOps.GetName(instance));
+                                           methodName, methodType.Name, PythonOps.GetPythonTypeName(instance));
             return TypeError(message);
         }
 
@@ -3914,7 +3914,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static Exception TypeErrorForUnhashableObject(object? obj) {
-            return TypeErrorForUnhashableType(PythonTypeOps.GetName(obj));
+            return TypeErrorForUnhashableType(PythonOps.GetPythonTypeName(obj));
         }
 
         internal static Exception TypeErrorForIncompatibleObjectLayout(string prefix, PythonType type, Type newType) {
@@ -3942,7 +3942,7 @@ namespace IronPython.Runtime.Operations {
         public static Exception TypeErrorForNonIterableObject(object? o) {
             return PythonOps.TypeError(
                 "argument of type '{0}' is not iterable",
-                PythonTypeOps.GetName(o)
+                PythonOps.GetPythonTypeName(o)
             );
         }
 
@@ -3967,7 +3967,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static Exception AttributeErrorForObjectMissingAttribute(object obj, string attributeName) {
-            return AttributeErrorForMissingAttribute(PythonTypeOps.GetName(obj), attributeName);
+            return AttributeErrorForMissingAttribute(PythonOps.GetPythonTypeName(obj), attributeName);
         }
 
         public static Exception AttributeErrorForMissingAttribute(string typeName, string attributeName) {
@@ -3983,7 +3983,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static Exception UncallableError(object? func) {
-            return PythonOps.TypeError("'{0}' object is not callable", PythonTypeOps.GetName(func));
+            return PythonOps.TypeError("'{0}' object is not callable", PythonOps.GetPythonTypeName(func));
         }
 
         public static Exception TypeErrorForProtectedMember(Type/*!*/ type, string/*!*/ name) {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3995,7 +3995,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static Exception TypeErrorForUnIndexableObject(object? o) {
-            return TypeError("'{0}' object cannot be interpreted as an integer", DynamicHelpers.GetPythonType(o).Name);
+            return TypeError("'{0}' object cannot be interpreted as an integer", PythonOps.GetPythonTypeName(o));
         }
 
         public static T TypeErrorForBadEnumConversion<T>(object? value) {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -206,7 +206,9 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static string GetPythonTypeName(object? obj) {
+#pragma warning disable IPY04 // Direct call to PythonTypeOps.GetName
             return PythonTypeOps.GetName(obj);
+#pragma warning restore IPY04
         }
 
         public static string Ascii(CodeContext/*!*/ context, object? o) {

--- a/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
@@ -176,7 +176,7 @@ namespace IronPython.Runtime.Operations {
 
         internal static string GetName(object o) {
             // Resolve Namespace-Tracker name, which would end in `namespace#` if 
-            // it is not handled indivdualy
+            // it is not handled individually
             if (o is NamespaceTracker nt)
                 return nt.Name;
 

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1230,7 +1230,7 @@ namespace IronPython.Runtime.Operations {
             }
 
             if (!PythonTypeOps.TryGetOperator(context, table, "__getitem__", out object getitem)) {
-                throw PythonOps.TypeError($"'{PythonTypeOps.GetName(table)}' object is not subscriptable");
+                throw PythonOps.TypeError($"'{PythonOps.GetPythonTypeName(table)}' object is not subscriptable");
             }
 
             StringBuilder ret = new StringBuilder();

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -174,7 +174,7 @@ namespace IronPython.Runtime.Operations {
                 return value;
             }
 
-            throw PythonOps.TypeError("expected str, got {0} from __str__", DynamicHelpers.GetPythonType(value).Name);
+            throw PythonOps.TypeError("expected str, got {0} from __str__", PythonOps.GetPythonTypeName(value));
         }
 
         #region Python Constructors
@@ -1949,7 +1949,7 @@ namespace IronPython.Runtime.Operations {
         private static Bytes UserEncode(CodeContext context, string encoding, PythonTuple codecInfo, string data, string? errors) {
             var res = CallUserDecodeOrEncode(context, codecInfo[0], data, errors);
             if (res[0] is Bytes b) return b;
-            throw PythonOps.TypeError("'{0}' encoder returned '{1}' instead of 'bytes'; use codecs.encode() to encode to arbitrary types", encoding, DynamicHelpers.GetPythonType(res[0]).Name);
+            throw PythonOps.TypeError("'{0}' encoder returned '{1}' instead of 'bytes'; use codecs.encode() to encode to arbitrary types", encoding, PythonOps.GetPythonTypeName(res[0]));
         }
 
         private static string UserDecode(CodeContext context, PythonTuple codecInfo, object data, string? errors) {
@@ -2144,14 +2144,14 @@ namespace IronPython.Runtime.Operations {
                 throw PythonOps.TypeError("expected string or tuple, got NoneType");
             }
             if (!(prefix is string) && !(prefix is PythonTuple) && !(prefix is Extensible<string>)) {
-                throw PythonOps.TypeError("expected string or tuple, got {0}", DynamicHelpers.GetPythonType(prefix).Name);
+                throw PythonOps.TypeError("expected string or tuple, got {0}", PythonOps.GetPythonTypeName(prefix));
             }
         }
 
         private static string GetString(object? obj) {
             string? ret = AsString(obj);
             if (ret == null) {
-                throw PythonOps.TypeError("expected string, got {0}", DynamicHelpers.GetPythonType(obj).Name);
+                throw PythonOps.TypeError("expected string, got {0}", PythonOps.GetPythonTypeName(obj));
             }
             return ret;
         }

--- a/Src/IronPython/Runtime/Operations/UserTypeOps.cs
+++ b/Src/IronPython/Runtime/Operations/UserTypeOps.cs
@@ -25,7 +25,7 @@ namespace IronPython.Runtime.Operations {
             if (o is string && o != null) {
                 return (string)o;
             }
-            throw PythonOps.TypeError("__str__ returned non-string type ({0})", PythonTypeOps.GetName(o));
+            throw PythonOps.TypeError("__str__ returned non-string type ({0})", PythonOps.GetPythonTypeName(o));
         }
 
         public static PythonDictionary SetDictHelper(ref PythonDictionary dict, PythonDictionary value) {
@@ -100,7 +100,7 @@ namespace IronPython.Runtime.Operations {
 
             if (!PythonOps.IsCallable(DefaultContext.Default, callable)) {
                 throw PythonOps.TypeError("Expected callable value for {0}, but found {1}", name.ToString(),
-                    PythonTypeOps.GetName(method));
+                    PythonOps.GetPythonTypeName(method));
             }
 
             PythonCalls.Call(callable, eventValue);

--- a/Src/IronPython/Runtime/Operations/UserTypeOps.cs
+++ b/Src/IronPython/Runtime/Operations/UserTypeOps.cs
@@ -37,7 +37,7 @@ namespace IronPython.Runtime.Operations {
         public static object GetPropertyHelper(object prop, object instance, string name) {
             if (!(prop is PythonTypeSlot desc)) {
                 throw PythonOps.TypeError("Expected property for {0}, but found {1}",
-                    name.ToString(), DynamicHelpers.GetPythonType(prop).Name);
+                    name.ToString(), PythonOps.GetPythonTypeName(prop));
             }
             object value;
             desc.TryGetValue(DefaultContext.Default, instance, DynamicHelpers.GetPythonType(instance), out value);
@@ -47,7 +47,7 @@ namespace IronPython.Runtime.Operations {
         public static void SetPropertyHelper(object prop, object instance, object newValue, string name) {
             if (!(prop is PythonTypeSlot desc)) {
                 throw PythonOps.TypeError("Expected settable property for {0}, but found {1}",
-                    name.ToString(), DynamicHelpers.GetPythonType(prop).Name);
+                    name.ToString(), PythonOps.GetPythonTypeName(prop));
             }
             desc.TrySetValue(DefaultContext.Default, instance, DynamicHelpers.GetPythonType(instance), newValue);
         }

--- a/Src/IronPython/Runtime/PythonDictionary.cs
+++ b/Src/IronPython/Runtime/PythonDictionary.cs
@@ -716,7 +716,9 @@ namespace IronPython.Runtime {
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public string TypeInfo {
                 get {
+#pragma warning disable IPY04 // Direct call to PythonTypeOps.GetName
                     return "Key: " + PythonTypeOps.GetName(Key) + ", " + "Value: " + PythonTypeOps.GetName(Value);
+#pragma warning restore IPY04
                 }
             }
         }

--- a/Src/IronPython/Runtime/PythonFunction.cs
+++ b/Src/IronPython/Runtime/PythonFunction.cs
@@ -188,7 +188,7 @@ namespace IronPython.Runtime {
         public PythonDictionary/*!*/ __dict__ {
             get { return EnsureDict(); }
             set {
-                _dict = value ?? throw PythonOps.TypeError("__dict__ must be set to a dictionary, not a '{0}'", PythonTypeOps.GetName(value));
+                _dict = value ?? throw PythonOps.TypeError("__dict__ must be set to a dictionary, not a '{0}'", PythonOps.GetPythonTypeName(value));
             }
         }
 
@@ -537,7 +537,7 @@ namespace IronPython.Runtime {
                 return "empty";
             }
 
-            return $"{PythonTypeOps.GetName(Value)} object at 0x{IdDispenser.GetId(Value):X}";
+            return $"{PythonOps.GetPythonTypeName(Value)} object at 0x{IdDispenser.GetId(Value):X}";
         }
 
         #endregion

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -564,7 +564,7 @@ namespace IronPython.Runtime {
 
         public virtual void __delitem__(object? index) {
             if (!Converter.TryConvertToIndex(index, out int idx))
-                throw PythonOps.TypeError("list indices must be integers or slices, not {0}", PythonTypeOps.GetName(index));
+                throw PythonOps.TypeError("list indices must be integers or slices, not {0}", PythonOps.GetPythonTypeName(index));
 
             __delitem__(idx);
         }
@@ -1120,7 +1120,7 @@ namespace IronPython.Runtime {
                 if (Converter.TryConvertToIndex(index, out int idx))
                     return this[idx];
 
-                throw PythonOps.TypeError("list indices must be integers or slices, not {0}", PythonTypeOps.GetName(index));
+                throw PythonOps.TypeError("list indices must be integers or slices, not {0}", PythonOps.GetPythonTypeName(index));
             }
             set {
                 this[Converter.ConvertToIndex(index)] = value;

--- a/Src/IronPython/Runtime/PythonTuple.cs
+++ b/Src/IronPython/Runtime/PythonTuple.cs
@@ -203,7 +203,7 @@ namespace IronPython.Runtime {
 
         public static PythonTuple operator +([NotNull]PythonTuple x, object? y) {
             if (y is PythonTuple t) return x + t;
-            throw PythonOps.TypeError($"can only concatenate tuple (not \"{PythonTypeOps.GetName(y)}\") to tuple");
+            throw PythonOps.TypeError($"can only concatenate tuple (not \"{PythonOps.GetPythonTypeName(y)}\") to tuple");
         }
 
         public static PythonTuple operator +([NotNull]PythonTuple x, [NotNull]PythonTuple y) {

--- a/Src/IronPython/Runtime/PythonTuple.cs
+++ b/Src/IronPython/Runtime/PythonTuple.cs
@@ -141,7 +141,7 @@ namespace IronPython.Runtime {
             } else if (o is object[] arr) {
                 return ArrayOps.CopyArray(arr, arr.Length);
             } else {
-                PerfTrack.NoteEvent(PerfTrack.Categories.OverAllocate, "TupleOA: " + PythonTypeOps.GetName(o));
+                PerfTrack.NoteEvent(PerfTrack.Categories.OverAllocate, "TupleOA: " + PythonOps.GetPythonTypeName(o));
 
                 var l = new List<object?>();
                 IEnumerator i = PythonOps.GetEnumerator(o);

--- a/Src/IronPython/Runtime/Reversed.cs
+++ b/Src/IronPython/Runtime/Reversed.cs
@@ -47,7 +47,7 @@ namespace IronPython.Runtime {
 
             int length;
             if (!DynamicHelpers.GetPythonType(o).TryGetLength(context, o, out length)) {
-                throw PythonOps.TypeError("object of type '{0}' has no len()", DynamicHelpers.GetPythonType(o).Name);
+                throw PythonOps.TypeError("object of type '{0}' has no len()", PythonOps.GetPythonTypeName(o));
             }
 
             if (type.UnderlyingSystemType == typeof(ReversedEnumerator)) {

--- a/Src/IronPython/Runtime/Set.cs
+++ b/Src/IronPython/Runtime/Set.cs
@@ -612,7 +612,7 @@ namespace IronPython.Runtime {
 
             throw PythonOps.TypeError(
                 "unsupported operand type(s) for |=: '{0}' and '{1}'",
-                PythonTypeOps.GetName(this), PythonTypeOps.GetName(set)
+                PythonOps.GetPythonTypeName(this), PythonOps.GetPythonTypeName(set)
             );
         }
 
@@ -637,7 +637,7 @@ namespace IronPython.Runtime {
 
             throw PythonOps.TypeError(
                 "unsupported operand type(s) for &=: '{0}' and '{1}'",
-                PythonTypeOps.GetName(this), PythonTypeOps.GetName(set)
+                PythonOps.GetPythonTypeName(this), PythonOps.GetPythonTypeName(set)
             );
         }
 
@@ -662,7 +662,7 @@ namespace IronPython.Runtime {
 
             throw PythonOps.TypeError(
                 "unsupported operand type(s) for ^=: '{0}' and '{1}'",
-                PythonTypeOps.GetName(this), PythonTypeOps.GetName(set)
+                PythonOps.GetPythonTypeName(this), PythonOps.GetPythonTypeName(set)
             );
         }
 
@@ -687,7 +687,7 @@ namespace IronPython.Runtime {
 
             throw PythonOps.TypeError(
                 "unsupported operand type(s) for -=: '{0}' and '{1}'",
-                PythonTypeOps.GetName(this), PythonTypeOps.GetName(set)
+                PythonOps.GetPythonTypeName(this), PythonOps.GetPythonTypeName(set)
             );
         }
 

--- a/Src/IronPython/Runtime/SetStorage.cs
+++ b/Src/IronPython/Runtime/SetStorage.cs
@@ -1272,7 +1272,7 @@ namespace IronPython.Runtime {
             } else if (setType == typeof(FrozenSetCollection)) {
                 setTypeStr = "frozenset";
             } else {
-                setTypeStr = PythonTypeOps.GetName(set);
+                setTypeStr = PythonOps.GetPythonTypeName(set);
             }
 
             StringBuilder sb = new StringBuilder();

--- a/Src/IronPython/Runtime/Super.cs
+++ b/Src/IronPython/Runtime/Super.cs
@@ -43,7 +43,7 @@ namespace IronPython.Runtime {
                     _selfClass = obj;
                     _self = obj;
                 } else {
-                    throw PythonOps.TypeError("super(type, obj): obj must be an instance or subtype of type {1}, not {0}", PythonTypeOps.GetName(obj), type.Name);
+                    throw PythonOps.TypeError("super(type, obj): obj must be an instance or subtype of type {1}, not {0}", PythonOps.GetPythonTypeName(obj), type.Name);
                 }
             } else {
                 _thisClass = type;
@@ -192,7 +192,7 @@ namespace IronPython.Runtime {
                 selfRepr = "<super object>";
             else
                 selfRepr = PythonOps.Repr(context, _self);
-            return string.Format("<{0}: {1}, {2}>", PythonTypeOps.GetName(this), PythonOps.Repr(context, _thisClass), selfRepr);
+            return string.Format("<{0}: {1}, {2}>", PythonOps.GetPythonTypeName(this), PythonOps.Repr(context, _thisClass), selfRepr);
         }
 
         #endregion

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -433,7 +433,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 if (s == null) {
                     return string.Format(
                         "sequence item {0}: expected string, {1} found",
-                        i, PythonTypeOps.GetName(en.Current)
+                        i, PythonOps.GetPythonTypeName(en.Current)
                     );
                 }
 
@@ -460,14 +460,14 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         [SpecialName, PropertyMethod, WrapperDescriptor]
         public static void Set__bases__(CodeContext/*!*/ context, PythonType/*!*/ type, object value) {
             // validate we got a tuple...
-            if (!(value is PythonTuple t)) throw PythonOps.TypeError("expected tuple of types or old-classes, got '{0}'", PythonTypeOps.GetName(value));
+            if (!(value is PythonTuple t)) throw PythonOps.TypeError("expected tuple of types or old-classes, got '{0}'", PythonOps.GetPythonTypeName(value));
 
             List<PythonType> ldt = new List<PythonType>();
 
             foreach (object o in t) {
                 // gather all the type objects...
                 if (!(o is PythonType adt)) {
-                    throw PythonOps.TypeError("expected tuple of types, got '{0}'", PythonTypeOps.GetName(o));
+                    throw PythonOps.TypeError("expected tuple of types, got '{0}'", PythonOps.GetPythonTypeName(o));
                 }
                 ldt.Add(adt);
             }

--- a/Src/IronPython/Runtime/Types/PythonTypeTypeSlot.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeTypeSlot.cs
@@ -46,7 +46,7 @@ namespace IronPython.Runtime.Types {
         }
 
         internal override bool TryDeleteValue(CodeContext context, object instance, PythonType owner) {
-            throw PythonOps.AttributeErrorForReadonlyAttribute(PythonTypeOps.GetName(instance), "__class__");
+            throw PythonOps.AttributeErrorForReadonlyAttribute(PythonOps.GetPythonTypeName(instance), "__class__");
         }
     }
 }

--- a/Src/IronPython/Runtime/Types/PythonTypeTypeSlot.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeTypeSlot.cs
@@ -36,7 +36,7 @@ namespace IronPython.Runtime.Types {
                 throw PythonOps.TypeError("__class__ assignment: only for user defined types");
             }
 
-            if (!(value is PythonType dt)) throw PythonOps.TypeError("__class__ must be set to new-style class, not '{0}' object", DynamicHelpers.GetPythonType(value).Name);
+            if (!(value is PythonType dt)) throw PythonOps.TypeError("__class__ must be set to new-style class, not '{0}' object", PythonOps.GetPythonTypeName(value));
 
             if(dt.UnderlyingSystemType != DynamicHelpers.GetPythonType(instance).UnderlyingSystemType)
                 throw PythonOps.TypeErrorForIncompatibleObjectLayout("__class__ assignment", DynamicHelpers.GetPythonType(instance), dt.UnderlyingSystemType);

--- a/Src/IronPython/Runtime/Types/ReflectedEvent.cs
+++ b/Src/IronPython/Runtime/Types/ReflectedEvent.cs
@@ -146,7 +146,7 @@ namespace IronPython.Runtime.Types {
             [SpecialName]
             public object InPlaceAdd(CodeContext/*!*/ context, object func) {
                 if (func == null || !PythonOps.IsCallable(context, func)) {
-                    throw PythonOps.TypeError("event addition expected callable object, got {0}", PythonTypeOps.GetName(func));
+                    throw PythonOps.TypeError("event addition expected callable object, got {0}", PythonOps.GetPythonTypeName(func));
                 }
 
                 if (_event.Tracker.IsStatic) {

--- a/Src/Scripts/generate_set.py
+++ b/Src/Scripts/generate_set.py
@@ -279,7 +279,7 @@ def gen_mutating_op(cw, t, arg_t, symbol, upname, clrname):
             '''"unsupported operand type(s) for %s=: '{0}' and '{1}'",''' %
             symbol
         )
-        cw.writeline('%s(this), %s(set)' % (('PythonTypeOps.GetName',) * 2))
+        cw.writeline('%s(this), %s(set)' % (('PythonOps.GetPythonTypeName',) * 2))
         cw.dedent()
         cw.writeline(');')
 


### PR DESCRIPTION
Prepares the ground for #52.

A handful of calls to `PythonTypeOps.GetName` remain where they are used for debugging purposes.

I also have left a few calls to `DynamicHelpers.GetPythonType(o).Name` in `ctypes`. I don't know that code well enough to judge whether the change would be justified, and since it is `ctypes` I thought it might be better to keep using the actual type name there.