### PR TITLE
Allow NoImportLib in release mode

### DIFF
--- a/Src/IronPython/Runtime/PythonOptions.cs
+++ b/Src/IronPython/Runtime/PythonOptions.cs
@@ -145,9 +145,7 @@ namespace IronPython.Runtime {
             Tracing = GetOption(options, "Tracing", false);
             NoDebug = GetOption(options, "NoDebug", (Regex)null);
             Quiet = GetOption(options, "Quiet", false);
-#if DEBUG
             NoImportLib = GetOption(options, "NoImportLib", false);
-#endif
         }
 
         private static IDictionary<string, object> EnsureSearchPaths(IDictionary<string, object> options) {


### PR DESCRIPTION
Resolves https://github.com/IronLanguages/ironpython3/issues/1313

Sample usage:
```c#
var engine = Python.CreateEngine(new Dictionary<string, object> { {"NoImportLib", true } });
```