### PR TITLE
Disable warning about using end-of-life .NET Core 2.1

### DIFF
--- a/Src/IronPythonConsole/IronPythonConsole.csproj
+++ b/Src/IronPythonConsole/IronPythonConsole.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <!-- EOL netcoreapp2.1 is used to test netstandard2.0 assemblies -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>IronPythonConsole</RootNamespace>
     <AssemblyName>ipy</AssemblyName>

--- a/Src/IronPythonTest/IronPythonTest.csproj
+++ b/Src/IronPythonTest/IronPythonTest.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <!-- EOL netcoreapp2.1 is used to test netstandard2.0 assemblies -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET Core 2.1 is end of life but is used to test .NET Standard 2.0 assemblies.