### PR TITLE
Disable parallel execution of test_traceback

### DIFF
--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -121,6 +121,7 @@ Ignore=true
 
 [IronPython.test_traceback]
 IsolationLevel=PROCESS
+NotParallelSafe=true # Creates temporary fixed-name modules
 
 [IronPython.test_weakref]
 RunCondition=NOT $(IS_MONO) # weakref failures


### PR DESCRIPTION
This test creates temporary fixed-name modules.