### PR TITLE
Restore locale after testing

### DIFF
--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -145,9 +145,6 @@ IsolationLevel=PROCESS # causes failures in IronPython.test_ast and IronPython.s
 [IronPython.modules.misc.test__weakref]
 RetryCount=2
 
-[IronPython.modules.system_related.test__locale]
-IsolationLevel=PROCESS # changes the locale which can cause other tests to fail
-
 [IronPython.modules.system_related.test_nt]
 RunCondition=NOT $(IS_POSIX)
 NotParallelSafe=true # Uses fixed file, directory, and environment variable names

--- a/Tests/modules/system_related/test__locale.py
+++ b/Tests/modules/system_related/test__locale.py
@@ -10,6 +10,18 @@ from iptest import is_cli, is_netcoreapp, is_posix, run_test
 
 class _LocaleTest(unittest.TestCase):
 
+    def setUp(self):
+        super().setUp()
+        self.saved_lc = [(lc, _locale.setlocale(lc, 'C')) for lc in
+                            (getattr(_locale, lc_name) for lc_name in
+                                dir(_locale) if lc_name.startswith('LC_') and lc_name != 'LC_ALL')
+                        ]
+
+    def tearDown(self):
+        for lc, setting in self.saved_lc:
+            _locale.setlocale(lc, setting)
+        super().tearDown()
+
     def test_getdefaultlocale(self):
         result1 = _locale._getdefaultlocale()
         result2 = _locale._getdefaultlocale()

--- a/Tests/test_str.py
+++ b/Tests/test_str.py
@@ -5,7 +5,6 @@
 
 import os
 import sys
-import unittest
 import warnings
 
 from iptest import IronPythonTestCase, is_cli, big, run_test, skipUnlessIronPython
@@ -450,22 +449,24 @@ class StrTest(IronPythonTestCase):
         PERFECT_UNICODE_CASING = False
 
         import locale
-        lang,encoding = locale.getlocale()
+        lang, encoding = locale.getlocale(locale.LC_CTYPE)
 
-        if is_cli:
-            locale.setlocale(locale.LC_ALL, "tr_TR")
-        else:
-            locale.setlocale(locale.LC_ALL, "turkish")
+        try:
+            if is_cli or sys.version_info >= (3, 5):
+                locale.setlocale(locale.LC_CTYPE, "tr_TR")
+            else:
+                locale.setlocale(locale.LC_CTYPE, "turkish")
 
-        if PERFECT_UNICODE_CASING:
-            self.assertEqual(u"I".lower(),u"ı")
-            self.assertEqual(u"i".upper(),u"İ")
-        else:
-            # cpython compatibility
-            self.assertEqual(u"I".lower(),u"i")
-            self.assertEqual(u"i".upper(),u"I")
+            if PERFECT_UNICODE_CASING:
+                self.assertEqual(u"I".lower(),u"ı")
+                self.assertEqual(u"i".upper(),u"İ")
+            else:
+                # cpython compatibility
+                self.assertEqual(u"I".lower(),u"i")
+                self.assertEqual(u"i".upper(),u"I")
 
-        locale.setlocale(locale.LC_ALL, (lang,encoding))
+        finally:
+            locale.setlocale(locale.LC_CTYPE, (lang, encoding))
 
         # Note:
         # IronPython casing matches cpython implementation (linux and windows)

--- a/Tests/test_strformat.py
+++ b/Tests/test_strformat.py
@@ -4,7 +4,7 @@
 
 import _string
 import sys
-import unittest
+import _locale
 
 from iptest import IronPythonTestCase, is_cli, is_cpython, is_netcoreapp21, big, run_test, skipUnlessIronPython
 
@@ -19,6 +19,18 @@ class bad_str(object):
         raise TestException('booh')
 
 class StrFormatTest(IronPythonTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.saved_lc = [(lc, _locale.setlocale(lc, 'C')) for lc in
+                            (getattr(_locale, lc_name) for lc_name in
+                                dir(_locale) if lc_name.startswith('LC_') and lc_name != 'LC_ALL')
+                        ]
+
+    def tearDown(self):
+        for lc, setting in self.saved_lc:
+            _locale.setlocale(lc, setting)
+        super().tearDown()
 
     def test_formatter_parser_errors(self):
         errors = [ ("{0!",             "unmatched '{' in format spec" if is_cli else "end of string while looking for conversion specifier"),
@@ -554,7 +566,6 @@ class StrFormatTest(IronPythonTestCase):
         if is_netcoreapp21: return # https://github.com/IronLanguages/ironpython3/issues/751
 
         # check locale specific formatting
-        import _locale
         try:
             if is_cli:
                 _locale.setlocale(_locale.LC_ALL, 'en_US')
@@ -872,7 +883,6 @@ class StrFormatTest(IronPythonTestCase):
             self.assertEqual(value.__format__(spec), result)
 
         # check locale specific formatting
-        import _locale
         try:
             if is_cli:
                 _locale.setlocale(_locale.LC_ALL, 'en_US')
@@ -1174,7 +1184,6 @@ class StrFormatTest(IronPythonTestCase):
             self.assertEqual(value.__format__(spec), result)
 
         # check locale specific formatting
-        import _locale
         try:
             if is_cli:
                 _locale.setlocale(_locale.LC_ALL, 'en_US')


### PR DESCRIPTION
Prevents bogus test failures in subsequent tests under some circumstances (e.g. locale "en_CA" and .NET 6.0).