### PR TITLE
Define constructors for System.Char

### DIFF
--- a/Src/IronPython/Runtime/Operations/CharOps.cs
+++ b/Src/IronPython/Runtime/Operations/CharOps.cs
@@ -7,6 +7,8 @@
 using System.Runtime.CompilerServices;
 
 using Microsoft.Scripting.Runtime;
+using IronPython.Runtime.Types;
+
 
 namespace IronPython.Runtime.Operations {
     /// <summary>
@@ -16,6 +18,21 @@ namespace IronPython.Runtime.Operations {
     /// </summary>
 
     public static class CharOps {
+
+        [StaticExtensionMethod]
+        public static object __new__(PythonType cls) => __new__(cls, default(char));
+
+        [StaticExtensionMethod]
+        public static object __new__(PythonType cls, ushort value) => __new__(cls, (char)value);
+
+        [StaticExtensionMethod]
+        public static object __new__(PythonType cls, char value) {
+            if (cls != DynamicHelpers.GetPythonTypeFromType(typeof(char))) {
+                throw PythonOps.TypeError("Char.__new__: first argument must be Char type.");
+            }
+            return value;
+        }
+
         public static string __repr__(char self) => char.ToString(self);
 
         public static int __hash__(char self) => char.ToString(self).GetHashCode();

--- a/Tests/test_str.py
+++ b/Tests/test_str.py
@@ -503,4 +503,40 @@ class StrTest(IronPythonTestCase):
 
             self.assertEqual(u"abcd".translate(ThrowingIndexable(UserError(err))), u"abcd")
 
+class CharTest(IronPythonTestCase):
+
+    def test_char_new(self):
+        from System import Char, Int32, UInt16
+
+        self.assertEqual(Char(), '\x00')
+        self.assertEqual(Char('a'), 'a')
+        self.assertEqual(Char(ord('A')), 'A')
+        self.assertEqual(Char(chr(65)), 'A')
+        self.assertEqual(Char(UInt16(65)), 'A')
+        self.assertEqual(Char(Int32(65)), 'A')
+        self.assertEqual(Char(big(65)), 'A')
+        self.assertEqual(Char('€'), '€')
+
+        self.assertIsInstance(Char(), Char)
+        self.assertIsInstance(Char('a'), Char)
+        self.assertIsInstance(Char(65), Char)
+
+        self.assertRaises(TypeError, Char, 'a', 'b')
+        self.assertRaises(TypeError, Char, 'ab',)
+        self.assertRaises(TypeError, Char, '🐍') # surrogate pair
+        self.assertRaises(TypeError, Char, '\U0001F40D') # surrogate pair
+        self.assertEqual(Char('🐍'[0]), '\uD83D') # high surrogate
+
+        self.assertRaises(TypeError, Char.__new__, str)
+        self.assertRaises(TypeError, Char.__new__, str, 'a')
+        self.assertRaises(TypeError, Char.__new__, str, 65)
+        self.assertRaises(TypeError, Char.__new__, int)
+        self.assertRaises(TypeError, Char.__new__, int, 'a')
+        self.assertRaises(TypeError, Char.__new__, int, 65)
+
+        # ValueError would be OK too
+        self.assertRaises(OverflowError, Char, -1)
+        self.assertRaises(OverflowError, Char, 0x110000)
+        self.assertRaises(OverflowError, Char, 0x10000)
+
 run_test(__name__)

--- a/Tests/test_str.py
+++ b/Tests/test_str.py
@@ -505,6 +505,7 @@ class StrTest(IronPythonTestCase):
 
 class CharTest(IronPythonTestCase):
 
+    @skipUnlessIronPython()
     def test_char_new(self):
         from System import Char, Int32, UInt16
 


### PR DESCRIPTION
For some reasons, `System.Char` was lacking constructors. It made it convoluted to create instances of this type:

```pycon
>>> from System import Char, IConvertible
>>> Char()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Char() takes at least 2147483647 arguments (0 given)
>>> Char(65)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: cannot create instances of Char
>>> IConvertible.ToChar(65, None)   
A
>>> type(IConvertible.ToChar(65, None))
<class 'Char'>
```

The constructors bring `Char` more in line with other .NET primitive value types:

```pycon
>>> from System import Char
>>> Char('A')
A
>>> Char(65)
A
```
