### PR TITLE
Remove obsolete BigIntegerV2 API from BigIntegerOps

### DIFF
--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -217,7 +217,6 @@ namespace IronPython.Runtime.Operations {
 
         #endregion
 
-
         #region Binary operators
 
         [SpecialName]
@@ -377,22 +376,9 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        [PythonHidden]
-        public static BigInteger Add(BigInteger x, BigInteger y) {
-            return x + y;
-        }
-        [PythonHidden]
-        public static BigInteger Subtract(BigInteger x, BigInteger y) {
-            return x - y;
-        }
-        [PythonHidden]
-        public static BigInteger Multiply(BigInteger x, BigInteger y) {
-            return x * y;
-        }
-
         [SpecialName]
         public static BigInteger FloorDivide([NotNull]BigInteger x, [NotNull]BigInteger y) {
-            return op_Division(x, y);
+            return DivMod(x, y, out _);
         }
 
         [SpecialName]
@@ -437,24 +423,15 @@ namespace IronPython.Runtime.Operations {
             throw PythonOps.OverflowError("integer division result too large for a float");
         }
 
-        // The op_* nomenclature is required here to avoid name collisions with the
-        // PythonHidden methods Divide, Mod, and [Left,Right]Shift.
-
         [SpecialName]
-        public static BigInteger op_Division(BigInteger x, BigInteger y) {
-            BigInteger r;
-            return DivMod(x, y, out r);
-        }
-
-        [SpecialName]
-        public static BigInteger op_Modulus(BigInteger x, BigInteger y) {
+        public static BigInteger Mod(BigInteger x, BigInteger y) {
             BigInteger r;
             DivMod(x, y, out r);
             return r;
         }
 
         [SpecialName]
-        public static BigInteger op_LeftShift(BigInteger x, int y) {
+        public static BigInteger LeftShift(BigInteger x, int y) {
             if (y < 0) {
                 throw PythonOps.ValueError("negative shift count");
             }
@@ -464,7 +441,7 @@ namespace IronPython.Runtime.Operations {
         private static readonly bool hasShiftBug = BigInteger.Parse("-18446744073709543424") >> 32 == 0; // https://github.com/dotnet/runtime/issues/43396
 
         [SpecialName]
-        public static BigInteger op_RightShift(BigInteger x, int y) {
+        public static BigInteger RightShift(BigInteger x, int y) {
             if (y < 0) {
                 throw PythonOps.ValueError("negative shift count");
             }
@@ -477,13 +454,13 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static BigInteger op_LeftShift(BigInteger x, BigInteger y) {
-            return op_LeftShift(x, (int)y);
+        public static BigInteger LeftShift(BigInteger x, BigInteger y) {
+            return LeftShift(x, (int)y);
         }
 
         [SpecialName]
-        public static BigInteger op_RightShift(BigInteger x, BigInteger y) {
-            return op_RightShift(x, (int)y);
+        public static BigInteger RightShift(BigInteger x, BigInteger y) {
+            return RightShift(x, (int)y);
         }
 
         #endregion
@@ -534,28 +511,24 @@ namespace IronPython.Runtime.Operations {
 
         #endregion
 
-        // These functions make the code generation of other types more regular
-        [PythonHidden]
-        public static BigInteger OnesComplement(BigInteger x) {
-            return ~x;
-        }
+        #region Code generation helpers
+        // These functions make the code generation of other integer types more regular.
 
-        internal static BigInteger FloorDivideImpl(BigInteger x, BigInteger y) {
-            return FloorDivide(x, y);
-        }
+        internal static BigInteger Add(BigInteger x, BigInteger y) => x + y;
 
-        [PythonHidden]
-        public static BigInteger BitwiseAnd(BigInteger x, BigInteger y) {
-            return x & y;
-        }
-        [PythonHidden]
-        public static BigInteger BitwiseOr(BigInteger x, BigInteger y) {
-            return x | y;
-        }
-        [PythonHidden]
-        public static BigInteger ExclusiveOr(BigInteger x, BigInteger y) {
-            return x ^ y;
-        }
+        internal static BigInteger Subtract(BigInteger x, BigInteger y) => x - y;
+
+        internal static BigInteger Multiply(BigInteger x, BigInteger y) => x * y;
+
+        internal static BigInteger OnesComplement(BigInteger x) => ~x;
+
+        internal static BigInteger BitwiseAnd(BigInteger x, BigInteger y) => x & y;
+
+        internal static BigInteger BitwiseOr(BigInteger x, BigInteger y) => x | y;
+
+        internal static BigInteger ExclusiveOr(BigInteger x, BigInteger y) => x ^ y;
+
+        #endregion
 
         [PropertyMethod, SpecialName]
         public static BigInteger Getreal(BigInteger self) {
@@ -673,278 +646,12 @@ namespace IronPython.Runtime.Operations {
             return self.ToString();
         }
 
-        #region Backwards compatibility with BigIntegerV2
-
-        [PythonHidden]
-        public static float ToFloat(BigInteger/*!*/ self) {
-            return checked((float)self.ToFloat64());
-        }
-
-        #region Binary Ops
-        
-        [PythonHidden]
-        public static BigInteger Xor(BigInteger x, BigInteger y) {
-            return x ^ y;
-        }
-
-        [PythonHidden]
-        public static BigInteger Mod(BigInteger x, BigInteger y) {
-            return op_Modulus(x, y);
-        }
-
-        [PythonHidden]
-        public static BigInteger LeftShift(BigInteger x, int y) {
-            return op_LeftShift(x, y);
-        }
-
-        [PythonHidden]
-        public static BigInteger RightShift(BigInteger x, int y) {
-            return op_RightShift(x, y);
-        }
-
-        [PythonHidden]
-        public static BigInteger LeftShift(BigInteger x, BigInteger y) {
-            return op_LeftShift(x, y);
-        }
-
-        [PythonHidden]
-        public static BigInteger RightShift(BigInteger x, BigInteger y) {
-            return op_RightShift(x, y);
-        }
-
-        #endregion
-
-        #region 'As' Conversions
-
-        [PythonHidden]
-        public static bool AsDecimal(BigInteger self, out decimal res) {
-            if (self <= (BigInteger)decimal.MaxValue && self >= (BigInteger)decimal.MinValue) {
-                res = (decimal)self;
-                return true;
-            }
-            res = default(decimal);
-            return false;
-        }
-
-        [PythonHidden]
-        public static bool AsInt32(BigInteger self, out int res) {
-            return self.AsInt32(out res);
-        }
-
-        [PythonHidden]
-        public static bool AsInt64(BigInteger self, out long res) {
-            return self.AsInt64(out res);
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static bool AsUInt32(BigInteger self, out uint res) {
-            return self.AsUInt32(out res);
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static bool AsUInt64(BigInteger self, out ulong res) {
-            return self.AsUInt64(out res);
-        }
-
-        #endregion
-
         #region Direct Conversions
-
-        [PythonHidden]
-        public static int ToInt32(BigInteger self) {
-            return (int)self;
-        }
-
-        [PythonHidden]
-        public static long ToInt64(BigInteger self) {
-            return (long)self;
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static uint ToUInt32(BigInteger self) {
-            return (uint)self;
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static ulong ToUInt64(BigInteger self) {
-            return (ulong)self;
-        }
 
         [PythonHidden]
         public static BigInteger ToBigInteger(BigInteger self) {
             return self;
         }
-
-        #endregion
-
-        #region Mimic some IConvertible members
-
-        [PythonHidden]
-        public static bool ToBoolean(BigInteger self, IFormatProvider provider) {
-            return !self.IsZero;
-        }
-
-        [PythonHidden]
-        public static byte ToByte(BigInteger self, IFormatProvider provider) {
-            return (byte)self;
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static sbyte ToSByte(BigInteger self, IFormatProvider provider) {
-            return (sbyte)self;
-        }
-
-        [PythonHidden]
-        public static char ToChar(BigInteger self, IFormatProvider provider) {
-            int res;
-            if (self.AsInt32(out res) && res <= Char.MaxValue && res >= Char.MinValue) {
-                return (char)res;
-            }
-            throw new OverflowException("big integer won't fit into char");
-        }
-
-        [PythonHidden]
-        public static decimal ToDecimal(BigInteger self, IFormatProvider provider) {
-            return (decimal)self;
-        }
-
-        [PythonHidden]
-        public static double ToDouble(BigInteger self, IFormatProvider provider) {
-            return ConvertToDouble(self);
-        }
-
-        [PythonHidden]
-        public static float ToSingle(BigInteger self, IFormatProvider provider) {
-            return ToFloat(self);
-        }
-
-        [PythonHidden]
-        public static short ToInt16(BigInteger self, IFormatProvider provider) {
-            return (short)self;
-        }
-
-        [PythonHidden]
-        public static int ToInt32(BigInteger self, IFormatProvider provider) {
-            return (int)self;
-        }
-
-        [PythonHidden]
-        public static long ToInt64(BigInteger self, IFormatProvider provider) {
-            return (long)self;
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static ushort ToUInt16(BigInteger self, IFormatProvider provider) {
-            return (ushort)self;
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static uint ToUInt32(BigInteger self, IFormatProvider provider) {
-            return (uint)self;
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static ulong ToUInt64(BigInteger self, IFormatProvider provider) {
-            return (ulong)self;
-        }
-
-        [PythonHidden]
-        public static object ToType(BigInteger self, Type conversionType, IFormatProvider provider) {
-            if (conversionType == typeof(BigInteger)) {
-                return self;
-            }
-            throw new NotImplementedException();
-        }
-
-        [PythonHidden]
-        public static TypeCode GetTypeCode(BigInteger self) {
-            return TypeCode.Object;
-        }
-
-        #endregion
-
-        [PythonHidden]
-        public static BigInteger Square(BigInteger self) {
-            return self * self;
-        }
-
-        [PythonHidden]
-        public static bool IsNegative(BigInteger self) {
-            return self.Sign < 0;
-        }
-
-        [PythonHidden]
-        public static bool IsPositive(BigInteger self) {
-            return self.Sign > 0;
-        }
-
-        [PythonHidden]
-        public static int GetBitCount(BigInteger self) {
-            return self.GetBitCount();
-        }
-
-        [PythonHidden]
-        public static int GetByteCount(BigInteger self) {
-            return self.GetByteCount();
-        }
-
-        #region 'Create' Methods
-
-        [PythonHidden]
-        public static BigInteger Create(byte[] v) {
-            return new BigInteger(v);
-        }
-
-        [PythonHidden]
-        public static BigInteger Create(int v) {
-            return new BigInteger(v);
-        }
-
-        [PythonHidden]
-        public static BigInteger Create(long v) {
-            return new BigInteger(v);
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static BigInteger Create(uint v) {
-            return new BigInteger(v);
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static BigInteger Create(ulong v) {
-            return (BigInteger)v;
-        }
-
-        [PythonHidden]
-        public static BigInteger Create(decimal v) {
-            return new BigInteger(v);
-        }
-
-        [PythonHidden]
-        public static BigInteger Create(double v) {
-            return new BigInteger(v);
-        }
-
-        #endregion
-
-        #region Expose BigIntegerV2-style uint data
-
-        [CLSCompliant(false), PythonHidden]
-        public static uint[] GetWords(BigInteger self) {
-            return self.GetWords();
-        }
-
-        [CLSCompliant(false), PythonHidden]
-        public static uint GetWord(BigInteger self, int index) {
-            return self.GetWord(index);
-        }
-
-        [PythonHidden]
-        public static int GetWordCount(BigInteger self) {
-            return self.GetWordCount();
-        }
-
-        #endregion
 
         #endregion
 

--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -653,6 +653,11 @@ namespace IronPython.Runtime.Operations {
             return self;
         }
 
+        [PythonHidden]
+        public static TypeCode GetTypeCode(BigInteger self) {
+            return TypeCode.Object;
+        }
+
         #endregion
 
         public static string/*!*/ __format__(CodeContext/*!*/ context, BigInteger/*!*/ self, [NotNull]string/*!*/ formatSpec) {

--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -653,6 +653,87 @@ namespace IronPython.Runtime.Operations {
             return self;
         }
 
+        #endregion
+
+        #region Mimic some IConvertible members
+
+        [PythonHidden]
+        public static bool ToBoolean(BigInteger self, IFormatProvider provider) {
+            return !self.IsZero;
+        }
+
+        [PythonHidden]
+        public static byte ToByte(BigInteger self, IFormatProvider provider) {
+            return (byte)self;
+        }
+
+        [CLSCompliant(false), PythonHidden]
+        public static sbyte ToSByte(BigInteger self, IFormatProvider provider) {
+            return (sbyte)self;
+        }
+
+        [PythonHidden]
+        public static char ToChar(BigInteger self, IFormatProvider provider) {
+            int res;
+            if (self.AsInt32(out res) && res <= Char.MaxValue && res >= Char.MinValue) {
+                return (char)res;
+            }
+            throw new OverflowException("big integer won't fit into char");
+        }
+
+        [PythonHidden]
+        public static decimal ToDecimal(BigInteger self, IFormatProvider provider) {
+            return (decimal)self;
+        }
+
+        [PythonHidden]
+        public static double ToDouble(BigInteger self, IFormatProvider provider) {
+            return ConvertToDouble(self);
+        }
+
+        [PythonHidden]
+        public static float ToSingle(BigInteger self, IFormatProvider provider) {
+            return checked((float)self.ToFloat64());
+        }
+
+        [PythonHidden]
+        public static short ToInt16(BigInteger self, IFormatProvider provider) {
+            return (short)self;
+        }
+
+        [PythonHidden]
+        public static int ToInt32(BigInteger self, IFormatProvider provider) {
+            return (int)self;
+        }
+
+        [PythonHidden]
+        public static long ToInt64(BigInteger self, IFormatProvider provider) {
+            return (long)self;
+        }
+
+        [CLSCompliant(false), PythonHidden]
+        public static ushort ToUInt16(BigInteger self, IFormatProvider provider) {
+            return (ushort)self;
+        }
+
+        [CLSCompliant(false), PythonHidden]
+        public static uint ToUInt32(BigInteger self, IFormatProvider provider) {
+            return (uint)self;
+        }
+
+        [CLSCompliant(false), PythonHidden]
+        public static ulong ToUInt64(BigInteger self, IFormatProvider provider) {
+            return (ulong)self;
+        }
+
+        [PythonHidden]
+        public static object ToType(BigInteger self, Type conversionType, IFormatProvider provider) {
+            if (conversionType == typeof(BigInteger)) {
+                return self;
+            }
+            throw new NotImplementedException();
+        }
+
         [PythonHidden]
         public static TypeCode GetTypeCode(BigInteger self) {
             return TypeCode.Object;

--- a/Tests/test_ironmath.py
+++ b/Tests/test_ironmath.py
@@ -26,38 +26,39 @@ class IronMathTest(IronPythonTestCase):
         self.load_iron_python_test()
 
     def test_bigint(self):
-        from System import Char, IConvertible
-        from System.Numerics import BigInteger, Complex
+        from System import Int64, Boolean, Char, Double, Single, IConvertible
+        from System.Numerics import BigInteger
         self.assertEqual(BigInteger.Add(big(1),99999999999999999999999999999999999999999999999999999999999) ,BigInteger.Subtract(100000000000000000000000000000000000000000000000000000000001,big(1)))
         self.assertEqual(BigInteger.Multiply(big(400),big(500)) , BigInteger.Divide(big(1000000),big(5)))
-        self.assertEqual(BigInteger.Multiply(big(400),big(8)) , BigInteger.LeftShift(big(400),big(3)))
-        self.assertEqual(BigInteger.Divide(big(400),big(8)) , BigInteger.RightShift(big(400),big(3)))
-        self.assertEqual(BigInteger.RightShift(BigInteger.LeftShift(big(400),big(100)),big(100)) , big(400))
-        self.assertEqual(BigInteger.RightShift(BigInteger.LeftShift(-12345678987654321,big(100)),big(100)) , -12345678987654321)
-        self.assertRaises(ValueError, BigInteger.RightShift, big(400), -big(100))
-        self.assertRaises(ValueError, BigInteger.LeftShift, big(400), -big(100))
-        self.assertRaises(ValueError, BigInteger.RightShift, -12345678987654321, -big(100))
-        self.assertRaises(ValueError, BigInteger.LeftShift, -12345678987654321, -big(100))
-        self.assertEqual(big(-123456781234567812345678123456781234567812345678123456781234567812345678).OnesComplement().OnesComplement() , -123456781234567812345678123456781234567812345678123456781234567812345678)
-        self.assertEqual(big(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678).OnesComplement() , -(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678 + big(1) ))
-        self.assertTrue(BigInteger.Xor(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678,big(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678).OnesComplement()) , -big(1))
-        self.assertEqual(BigInteger.BitwiseAnd(0xff00ff00,BigInteger.BitwiseOr(0x00ff00ff,0xaabbaabb)) , big(0xaa00aa00))
-        self.assertEqual(BigInteger.Mod(big(-9999999999999999999999999999999999999999),1000000000000000000) , -BigInteger.Mod(9999999999999999999999999999999999999999,big(-1000000000000000000)))
+        self.assertEqual(BigInteger.Multiply(big(400),big(8)) , big(400) <<big(3))
+        self.assertEqual(BigInteger.Divide(big(400),big(8)) , big(400) >>big(3))
+        self.assertEqual((big(400) << big(100)) >> big(100) , big(400))
+        self.assertEqual((-12345678987654321 << big(100)) >>big(100) , -12345678987654321)
+        self.assertRaises(ValueError, lambda x, y: x >> y, big(400), -big(100))
+        self.assertRaises(ValueError, lambda x, y: x << y, big(400), -big(100))
+        self.assertRaises(ValueError, lambda x, y: x >> y, -12345678987654321, -big(100))
+        self.assertRaises(ValueError, lambda x, y: x << y, -12345678987654321, -big(100))
+        self.assertEqual(~(~big(-123456781234567812345678123456781234567812345678123456781234567812345678)) , -123456781234567812345678123456781234567812345678123456781234567812345678)
+        self.assertEqual(~big(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678) , -(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678 + big(1) ))
+        self.assertTrue(big(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678) ^ (~big(-1234567812345678123456781234567812345678123456781234567812345678123456781234567812345678)) , -big(1))
+        self.assertEqual(big(0xff00ff00) & (big(0x00ff00ff) | big(0xaabbaabb)) , big(0xaa00aa00))
+        self.assertEqual(big(-9999999999999999999999999999999999999999) % 1000000000000000000 , -(9999999999999999999999999999999999999999 % big(-1000000000000000000)))
 
-        self.assertEqual(BigInteger.ToInt64(0x7fffffffffffffff) , 9223372036854775807)
-        self.assertRaises(OverflowError, BigInteger.ToInt64, 0x8000000000000000)
+        self.assertEqual(Int64(big(0x7fffffffffffffff)) , 9223372036854775807)
+        self.assertRaises(OverflowError, Int64, big(0x8000000000000000))
 
-        self.assertEqual(big(-0).ToBoolean(self.p) , False )
-        self.assertEqual(big(int(-1212321.3213)).ToBoolean(self.p) , True )
-        self.assertEqual(big(1212321384892342394723947).ToBoolean(self.p) , True )
+        self.assertEqual(Boolean(big(-0)) , False )
+        self.assertEqual(Boolean(big(int(-1212321.3213))) , True )
+        self.assertEqual(Boolean(big(1212321384892342394723947)) , True )
 
-        self.assertEqual(big(0).ToChar(self.p) , Char.MinValue)
-        self.assertEqual(big(65).ToChar(self.p) , IConvertible.ToChar('A', self.p))
-        self.assertEqual(big(0xffff).ToChar(self.p) , Char.MaxValue)
-        self.assertRaises(OverflowError, big(-1).ToChar, self.p)
+        self.assertEqual(Char(big(0)) , Char.MinValue)
+        self.assertEqual(Char(big(65)) , IConvertible.ToChar('A', self.p))
+        self.assertEqual(Char(big(0xffff)) , Char.MaxValue)
+        self.assertRaises(OverflowError, Char, big(-1))
 
-        self.assertEqual(big(100).ToDouble(self.p) , 100.0)
-        self.assertEqual(big(100).ToSingle(self.p) , big(int(100.1213123)).ToFloat())
+        self.assertEqual(Double(big(100)) , 100.0)
+        self.assertEqual(Single(big(100)) , 100.0)
+        self.assertEqual(Single(big(100)) , IConvertible.ToSingle(int(100.1213123), self.p))
 
         self.assertTrue(big(100) != 100.32)
         self.assertEqual(big(100) , 100.0)
@@ -66,36 +67,37 @@ class IronMathTest(IronPythonTestCase):
         self.assertEqual(100.0 , big(100) )
 
     def test_big_to_conversion(self):
-        from System import SByte, Byte, Int16, UInt16, Int32, UInt32, Int64, UInt64
-        from System.Numerics import BigInteger
-        for (a, m, t,x) in [
-                            (7, "ToSByte",  SByte,2),
-                            (8, "ToByte",   Byte, 0),
-                            (15, "ToInt16", Int16,2),
-                            (16, "ToUInt16", UInt16,0),
-                            (31, "ToInt32", Int32,2),
-                            (32, "ToUInt32", UInt32,0),
-                            (63, "ToInt64", Int64,2),
-                            (64, "ToUInt64", UInt64,0)
+        from System import SByte, Byte, Int16, UInt16, Int32, UInt32, Int64, UInt64, Char
+        for (a, t, x) in [
+                            (7,  SByte,  2),
+                            (8,  Byte,   0),
+                            (15, Int16,  2),
+                            (16, UInt16, 0),
+                            (16, Char,   0),
+                            (31, Int32,  2),
+                            (32, UInt32, 0),
+                            (63, Int64,  2),
+                            (64, UInt64, 0)
                         ]:
 
             b = big(-x ** a)
-            left = getattr(b, m)(self.p)
+            left = t(b)
             right = t.MinValue
             self.assertEqual(left, right)
 
             b = big(2 ** a -1)
-            left = getattr(b, m)(self.p)
+            left = t(b)
             right = t.MaxValue
             self.assertEqual(left, right)
 
-            b = big(0)
-            left = getattr(b, m)(self.p)
-            right = t.MaxValue - t.MaxValue
-            self.assertEqual(left, right)
+            if t is not Char:
+                b = big(0)
+                left = t(b)
+                right = t.MaxValue - t.MaxValue
+                self.assertEqual(left, right)
 
-            self.assertRaises(OverflowError,getattr(big(2 ** a), m),self.p)
-            self.assertRaises(OverflowError,getattr(big(-1 - x ** a), m),self.p)
+            self.assertRaises(OverflowError, t, big(2 ** a))
+            self.assertRaises(OverflowError, t, big(-1 - x ** a))
 
     def test_nobig_to_conversion(self):
         from System import SByte, Byte, Int16, UInt16, Int32, UInt32, Int64, UInt64
@@ -146,7 +148,7 @@ class IronMathTest(IronPythonTestCase):
                     test_extreme_values(a, t, x, wt)
 
     def test_complex(self):
-        from System.Numerics import BigInteger, Complex
+        from System.Numerics import Complex
         self.assertEqual(
             Complex.Add(
                 Complex(big(9999), -1234),
@@ -171,27 +173,25 @@ class IronMathTest(IronPythonTestCase):
 
         self.assertEqual(big(-1234).Sign, -1)
         self.assertEqual(is_zero(big(-1234)), False)
-        self.assertEqual(big(-1234).IsNegative(), True)
-        self.assertEqual(big(-1234).IsPositive(), False)
+        self.assertEqual(big(-1234) < 0, True)
+        self.assertEqual(big(-1234) > 0, False)
 
         self.assertEqual(big(0).Sign, 0)
         self.assertEqual(is_zero(big(0)), True)
-        self.assertEqual(big(0).IsNegative(), False)
-        self.assertEqual(big(0).IsPositive(), False)
+        self.assertEqual(big(0) < 0, False)
+        self.assertEqual(big(0) > 0, False)
 
         self.assertEqual(big(1234).Sign, 1)
         self.assertEqual(is_zero(big(1234)), False)
-        self.assertEqual(big(1234).IsNegative(), False)
-        self.assertEqual(big(1234).IsPositive(), True)
+        self.assertEqual(big(1234) < 0, False)
+        self.assertEqual(big(1234) > 0, True)
 
 
     def test_byte_conversions(self):
-        from System import Array, Byte
-        from System.Numerics import BigInteger
-
-        def CheckByteConversions(bigint, bytes):
-            self.assertSequenceEqual(bigint.ToByteArray(), bytes)
-            self.assertEqual(BigInteger.Create(Array[Byte](bytes)), bigint)
+        def CheckByteConversions(bigint, bytes_list):
+            self.assertSequenceEqual(bigint.ToByteArray(), bytes_list)
+            self.assertSequenceEqual(bigint.to_bytes(len(bytes_list), 'little', signed=True), bytes_list)
+            self.assertEqual(int.from_bytes(bytes(bytes_list), 'little', signed=True), bigint)
 
         CheckByteConversions(big(0x00), [0x00])
 
@@ -214,9 +214,13 @@ class IronMathTest(IronPythonTestCase):
         CheckByteConversions(big(0x080706050403020100), [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
 
     def test_dword_conversions(self):
+        import clr
         from System import Array, UInt32
         from System.Numerics import BigInteger
         from IronPythonTest import System_Scripting_Math
+        import Microsoft.Scripting.Utils.MathUtils
+        clr.ImportExtensions(Microsoft.Scripting.Utils.MathUtils)
+
         def CheckDwordConversions(bigint, dwords):
             self.assertSequenceEqual(bigint.GetWords(), dwords)
             if bigint == BigInteger.Zero:


### PR DESCRIPTION
Follow-up on #1347 and https://github.com/IronLanguages/ironpython3/pull/1329 (issue https://github.com/IronLanguages/ironpython3/issues/52).

Special point of interest: `op_Division`.