### PR TITLE
Fix sys.exit() with large negative exit code

### DIFF
--- a/Src/IronPython/Runtime/Exceptions/SystemExitException.cs
+++ b/Src/IronPython/Runtime/Exceptions/SystemExitException.cs
@@ -53,7 +53,7 @@ namespace IronPython.Runtime.Exceptions {
                 return Converter.ConvertToInt32(t[0]);
             } else if (Builtin.isinstance(t[0], TypeCache.BigInteger)) {
                 var b = Converter.ConvertToBigInteger(t[0]);
-                if(b > int.MaxValue) {
+                if (b > int.MaxValue || b < int.MinValue) {
                     return -1;
                 }
                 return (int)b;


### PR DESCRIPTION
This mimics CPython on Windows, when run directly from the shell prompt or with `os.system`. However, `test_stdconsole` fails when run under CPython because `os.spawnv` throws `OSError` when the process returns a negative value, rather than passing it as the return value (IronPython's `os.spawnv` passes it through, maybe a bug?). 

The story is different on Linux/maxOS. Here exit codes are always unsigned byte size and the lowest 8 bits from the `exit` argument, if it fits in 64 bits. Otherwise, CPython returns 255, (which is what -1 translates to). So to achieve CPython compatibility on Unix, `SystemExitException.GetExitCode`should return -1 only `if (b > long.MaxValue || b < long.MinValue)`, (maybe the story is different on 32-bit systems, I don't have any), otherwise just return the lowest 32-bits.

Anyway, since it is not wise on Unix to use exit codes outside 0-255 range anyway, I don't think it is worth the hassle to make `GetExitCode` platform-specific. 

Also, because the whole thing is such a fringe issue, I didn't add a regression test for the bug, `test_stdconsole` is already so slow.