### PR TITLE
Serialize Int32 directly

### DIFF
--- a/Src/IronPython/Runtime/ClrModule.cs
+++ b/Src/IronPython/Runtime/ClrModule.cs
@@ -1148,13 +1148,16 @@ import Namespace.")]
             string data, format;
             Type type = CompilerHelpers.GetType(self);
             switch (type.GetTypeCode()) {
-                // for the primitive non-python types just do a simple
-                // serialization
+                // For the primitive non-python types just do a simple serialization.
+                // Object of type Int32 normally do not go though this code path when pickled
+                // (that is, unless __reduce_ex__ is called directly), being handled as Python int
+                // through the pickle dispatch table. (GH #52)
                 case TypeCode.Byte:
                 case TypeCode.Char:
                 case TypeCode.DBNull:
                 case TypeCode.Decimal:
                 case TypeCode.Int16:
+                case TypeCode.Int32:
                 case TypeCode.Int64:
                 case TypeCode.SByte:
                 case TypeCode.Single:
@@ -1200,6 +1203,7 @@ import Namespace.")]
                     case "System.DBNull": return DBNull.Value;
                     case "System.Decimal": return Decimal.Parse(data);
                     case "System.Int16": return Int16.Parse(data);
+                    case "System.Int32": return Int32.Parse(data);
                     case "System.Int64": return Int64.Parse(data);
                     case "System.SByte": return SByte.Parse(data);
                     case "System.Single": return Single.Parse(data);


### PR DESCRIPTION
Now that all enums are serialized correctly, `clr.Serialize` can serialize `Int32` efficiently.