### PR TITLE
Support large enums in int constructor

### DIFF
--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -55,7 +55,22 @@ namespace IronPython.Runtime.Operations {
                 case decimal val:
                     return int.MinValue <= val && val <= int.MaxValue ? (object)(int)val : (BigInteger)val;
                 case Enum e:
-                    return ((IConvertible)e).ToInt32(null);  // TODO: check long enums
+                    var ic = (IConvertible)e;
+                    switch (ic.GetTypeCode()) {
+                        case TypeCode.Byte:
+                        case TypeCode.SByte:
+                        case TypeCode.Int16:
+                        case TypeCode.UInt16:
+                        case TypeCode.Int32:
+                            return ic.ToInt32(null);
+                        case TypeCode.Int64:
+                            return (BigInteger)ic.ToInt64(null);
+                        case TypeCode.UInt32:
+                        case TypeCode.UInt64:
+                            return (BigInteger)ic.ToUInt64(null);
+                        default:
+                            throw new InvalidOperationException(); // unreachable
+                    }
                 case string s:
                     return LiteralParser.ParseIntegerSign(s, @base, FindStart(s, @base));
                 case Extensible<string> es:

--- a/Tests/test_ironmath.py
+++ b/Tests/test_ironmath.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-from iptest import IronPythonTestCase, big, is_mono, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, big, is_mono, is_netcoreapp, run_test, skipUnlessIronPython
 
 @skipUnlessIronPython()
 class IronMathTest(IronPythonTestCase):
@@ -304,6 +304,12 @@ class IronMathTest(IronPythonTestCase):
 
         self.assertEqual(big(1).CompareTo(None), 1)
         self.assertEqual(big(1).CompareTo(True), 0)
+
+        if is_netcoreapp:
+            import clr
+            clr.AddReference("System.Net.Sockets")
+        from System.Net.Sockets import IOControlCode
+        self.assertEqual(int(IOControlCode.TranslateHandle), 0xc800000D)
 
     def test_rightshiftby32_negative_bug(self):
         # test workaround for https://github.com/dotnet/runtime/issues/43396


### PR DESCRIPTION
Follow-up on https://github.com/IronLanguages/ironpython3/pull/1347 and https://github.com/IronLanguages/ironpython3/pull/1329 (issue https://github.com/IronLanguages/ironpython3/issues/52).