### PR TITLE
Cleanup IntOps

### DIFF
--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -87,20 +87,19 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
 
         [Documentation("abs(number) -> number\n\nReturn the absolute value of the argument.")]
         public static object abs(CodeContext/*!*/ context, object? o) {
-            if (o is int) return Int32Ops.Abs((int)o);
-            if (o is long) return Int64Ops.Abs((long)o);
-            if (o is double) return DoubleOps.Abs((double)o);
-            if (o is bool) return (((bool)o) ? 1 : 0);
+            if (o is int i32) return Int32Ops.Abs(i32);
+            if (o is long i64) return Int64Ops.Abs(i64);
+            if (o is double d) return DoubleOps.Abs(d);
+            if (o is bool b) return (b ? 1 : 0);
 
-            if (o is BigInteger) return BigIntegerOps.__abs__((BigInteger)o);
-            if (o is Complex) return ComplexOps.Abs((Complex)o);
+            if (o is BigInteger bi) return BigIntegerOps.Abs(bi);
+            if (o is Complex z) return ComplexOps.Abs(z);
 
-            object value;
-            if (PythonTypeOps.TryInvokeUnaryOperator(context, o, "__abs__", out value)) {
+            if (PythonTypeOps.TryInvokeUnaryOperator(context, o, "__abs__", out object? value)) {
                 return value;
             }
 
-            throw PythonOps.TypeError("bad operand type for abs(): '{0}'", PythonOps.GetPythonTypeName(o));
+            throw PythonOps.TypeErrorForBadInstance("bad operand type for abs(): '{0}'", o);
         }
 
         public static bool all(CodeContext context, object? x) {

--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -251,11 +251,11 @@ namespace IronPython.Runtime.Operations {
 
         [SpecialName]
         public static object Abs(BigInteger x) {
-            return x.Abs();
+            return BigInteger.Abs(x);
         }
 
         public static bool __bool__(BigInteger x) {
-            return !x.IsZero();
+            return !x.IsZero;
         }
 
         public static BigInteger __trunc__(BigInteger self) {
@@ -502,7 +502,7 @@ namespace IronPython.Runtime.Operations {
                 throw PythonOps.ZeroDivisionError();
             }
 
-            BigInteger result = x.ModPow(y, z);
+            BigInteger result = BigInteger.ModPow(x, y, z);
 
             // fix the sign for negative moduli or negative mantissas
             if ((z < BigInteger.Zero && result > BigInteger.Zero)
@@ -521,7 +521,7 @@ namespace IronPython.Runtime.Operations {
                 throw PythonOps.ZeroDivisionError();
             }
 
-            BigInteger result = x.ModPow(y, z);
+            BigInteger result = BigInteger.ModPow(x, y, z);
 
             // fix the sign for negative moduli or negative mantissas
             if ((z < BigInteger.Zero && result > BigInteger.Zero)
@@ -848,7 +848,7 @@ namespace IronPython.Runtime.Operations {
 
             Debug.Assert(digits[0] != '-');
 
-            return spec.AlignNumericText(digits, self.IsZero(), self.IsPositive());
+            return spec.AlignNumericText(digits, self.IsZero, self.IsPositive());
         }
 
         public static Bytes to_bytes(BigInteger value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
@@ -1046,7 +1046,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static string ToBinary(BigInteger val) {            
-            string res = ToBinary(val.Abs(), true, true);
+            string res = ToBinary(BigInteger.Abs(val), true, true);
             if (val.IsNegative()) {
                 res = "-" + res;
             }
@@ -1065,7 +1065,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         private static string/*!*/ ToDigits(BigInteger/*!*/ val, int radix, bool lower) {
-            if (val.IsZero()) {
+            if (val.IsZero) {
                 return "0";
             }
 

--- a/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
@@ -23,6 +23,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class SByteOps {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(SByte));
@@ -62,6 +64,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to SByte", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -165,12 +169,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(SByte x, [NotNull]BigInteger y) {
+        public static object LeftShift(SByte x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static SByte RightShift(SByte x, [NotNull]BigInteger y) {
+        public static SByte RightShift(SByte x, BigInteger y) {
             return (SByte)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 
@@ -295,6 +299,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class ByteOps {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(Byte));
@@ -334,6 +340,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to Byte", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -492,12 +500,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(Byte x, [NotNull]BigInteger y) {
+        public static object LeftShift(Byte x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static Byte RightShift(Byte x, [NotNull]BigInteger y) {
+        public static Byte RightShift(Byte x, BigInteger y) {
             return (Byte)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 
@@ -649,6 +657,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class Int16Ops {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(Int16));
@@ -688,6 +698,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to Int16", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -791,12 +803,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(Int16 x, [NotNull]BigInteger y) {
+        public static object LeftShift(Int16 x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static Int16 RightShift(Int16 x, [NotNull]BigInteger y) {
+        public static Int16 RightShift(Int16 x, BigInteger y) {
             return (Int16)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 
@@ -926,6 +938,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class UInt16Ops {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(UInt16));
@@ -965,6 +979,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to UInt16", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -1123,12 +1139,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(UInt16 x, [NotNull]BigInteger y) {
+        public static object LeftShift(UInt16 x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static UInt16 RightShift(UInt16 x, [NotNull]BigInteger y) {
+        public static UInt16 RightShift(UInt16 x, BigInteger y) {
             return (UInt16)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 
@@ -1290,6 +1306,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class Int32Ops {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(Int32));
@@ -1329,6 +1347,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to Int32", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -1412,12 +1432,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(Int32 x, [NotNull]BigInteger y) {
+        public static object LeftShift(Int32 x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static Int32 RightShift(Int32 x, [NotNull]BigInteger y) {
+        public static Int32 RightShift(Int32 x, BigInteger y) {
             return (Int32)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 
@@ -1542,6 +1562,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class UInt32Ops {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(UInt32));
@@ -1581,6 +1603,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to UInt32", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -1739,12 +1763,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(UInt32 x, [NotNull]BigInteger y) {
+        public static object LeftShift(UInt32 x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static UInt32 RightShift(UInt32 x, [NotNull]BigInteger y) {
+        public static UInt32 RightShift(UInt32 x, BigInteger y) {
             return (UInt32)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 
@@ -1906,6 +1930,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class Int64Ops {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(Int64));
@@ -1945,6 +1971,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to Int64", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -2051,12 +2079,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(Int64 x, [NotNull]BigInteger y) {
+        public static object LeftShift(Int64 x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static Int64 RightShift(Int64 x, [NotNull]BigInteger y) {
+        public static Int64 RightShift(Int64 x, BigInteger y) {
             return (Int64)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 
@@ -2186,6 +2214,8 @@ namespace IronPython.Runtime.Operations {
 
     public static partial class UInt64Ops {
 
+        #region Constructors
+
         [StaticExtensionMethod]
         public static object __new__(PythonType cls) {
             return __new__(cls, default(UInt64));
@@ -2225,6 +2255,8 @@ namespace IronPython.Runtime.Operations {
             }
             throw PythonOps.TypeError("can't convert {0} to UInt64", PythonOps.GetPythonTypeName(value));
         }
+
+        #endregion
 
         #region Unary Operations
 
@@ -2380,12 +2412,12 @@ namespace IronPython.Runtime.Operations {
         #region Binary Operations - Bitwise
 
         [SpecialName]
-        public static object LeftShift(UInt64 x, [NotNull]BigInteger y) {
+        public static object LeftShift(UInt64 x, BigInteger y) {
             return BigIntegerOps.LeftShift((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static UInt64 RightShift(UInt64 x, [NotNull]BigInteger y) {
+        public static UInt64 RightShift(UInt64 x, BigInteger y) {
             return (UInt64)BigIntegerOps.RightShift((BigInteger)x, (BigInteger)y);
         }
 

--- a/Src/Scripts/generate_alltypes.py
+++ b/Src/Scripts/generate_alltypes.py
@@ -359,7 +359,7 @@ def gen_binaryops(cw, ty):
         cw.writeline("#region Binary Operations - Bitwise")
 
         if ty.name not in ["BigInteger"]:
-            ltypes = [('[NotNull]BigInteger', 'BigInteger')]
+            ltypes = [('BigInteger', 'BigInteger')]
             if ty.size < Int32.MaxValue:
                 ltypes.append( ('Int32', 'Int32') )
             for ltype, optype in ltypes:
@@ -478,6 +478,8 @@ def gen_api(cw, ty):
     cw.writeline("#endregion")
 
 type_header = """
+#region Constructors
+
 [StaticExtensionMethod]
 public static object __new__(PythonType cls) {
     return __new__(cls, default(%(type)s));
@@ -516,7 +518,9 @@ public static object __new__(PythonType cls, object value) {
         return checked((%(type)s)ed.Value);
     }
     throw PythonOps.TypeError("can't convert {0} to %(type)s", PythonOps.GetPythonTypeName(value));
-}"""
+}
+
+#endregion"""
 
 def gen_header(cw, ty):
     if ty.name not in ['Double', 'Single', 'BigInteger']:


### PR DESCRIPTION
Follow-up on #1347 and https://github.com/IronLanguages/ironpython3/pull/1329 (issue https://github.com/IronLanguages/ironpython3/issues/52).

There are many changes in this PR but most of them is just reordering of methods in `IntOps` and `BigIntegerOps` to align them with the order in `IntOps.Generated.cs`. Makes browsing, comparing, and reviewing easier.

From the functional changes:

* in `IntOps`:
  * `__abs__` removed (was erroneous)
  * `__float__` removed (was redundant)
* in `BigIntegerOps`, to align with the other numeric Ops:
  * `__pos__` renamed `Plus` (although actually it is redundant)
  * `__abs__` renamed `Abs` (could have been internal)

There are possibly more redundant methods or methods that could have been internal, but I am not going to hunt them down.