### PR TITLE
Implement to_bytes for all integer types

### DIFF
--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -749,7 +749,7 @@ namespace IronPython.Runtime.Operations {
                 val = -self;
             }
             string digits;
-            
+
             switch (spec.Type) {
                 case 'n':
                     CultureInfo culture = context.LanguageContext.NumericCulture;
@@ -932,9 +932,9 @@ namespace IronPython.Runtime.Operations {
             return __new__(context, type, val);
         }
 
-#endregion
+        #endregion
 
-#region Mimic IConvertible members
+        #region Mimic IConvertible members
 
         [PythonHidden]
         public static bool ToBoolean(BigInteger self, IFormatProvider? provider) {
@@ -1060,9 +1060,9 @@ namespace IronPython.Runtime.Operations {
             return TypeCode.Object;
         }
 
-#endregion
+        #endregion
 
-#region Helpers
+        #region Helpers
 
         internal static double ToDouble(BigInteger self) {
             // Unlike ConvertToDouble, this method produces a Python-specific overflow error messge.
@@ -1080,7 +1080,7 @@ namespace IronPython.Runtime.Operations {
             return ToDigits(val, 8, lowercase);
         }
 
-        internal static string ToBinary(BigInteger val) {            
+        internal static string ToBinary(BigInteger val) {
             string res = ToBinary(BigInteger.Abs(val), true, true);
             if (val.IsNegative()) {
                 res = "-" + res;
@@ -1092,7 +1092,7 @@ namespace IronPython.Runtime.Operations {
             Debug.Assert(!val.IsNegative());
 
             string digits = ToDigits(val, 2, lowercase);
-            
+
             if (includeType) {
                 digits = (lowercase ? "0b" : "0B") + digits;
             }
@@ -1119,10 +1119,10 @@ namespace IronPython.Runtime.Operations {
             for (int i = str.Length - 1; i >= 0; i--) {
                 res.Append(str[i]);
             }
-            
+
             return res.ToString();
         }
 
-#endregion
+        #endregion
     }
 }

--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -853,15 +853,14 @@ namespace IronPython.Runtime.Operations {
 
         public static Bytes to_bytes(BigInteger value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
             // TODO: signed should be a keyword only argument
-            // TODO: should probably be moved to IntOps.Generated and included in all types
+
+            bool isLittle = (byteorder == "little");
+            if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
 
             if (length < 0) throw PythonOps.ValueError("length argument must be non-negative");
             if (!signed && value < 0) throw PythonOps.OverflowError("can't convert negative int to unsigned");
 
-            bool isLittle = byteorder == "little";
-            if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
-
-            var reqLength = (bit_length(value) + (signed ? 1 : 0)) / 8;
+            var reqLength = (bit_length(value) + (signed ? 1 : 0) + 7) / 8;
             if (reqLength > length) throw PythonOps.OverflowError("int too big to convert");
 
             var bytes = value.ToByteArray();

--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -722,7 +722,7 @@ namespace IronPython.Runtime.Operations {
                 > 0 => self.GetBitLength(),
                 < 0 => BigInteger.Abs(self).GetBitLength(),
             };
-            return (length is >= int.MinValue and <= int.MaxValue) ? (int)length : (BigInteger)length;
+            return length <= int.MaxValue ? (int)length : (BigInteger)length;
 #else
             return MathUtils.BitLength(self);
 #endif

--- a/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
@@ -12,6 +12,8 @@ using Microsoft.Scripting.Utils;
 
 using IronPython.Runtime.Types;
 
+using NotDynamicNullAttribute = Microsoft.Scripting.Runtime.NotNullAttribute;
+
 #pragma warning disable 675
 
 namespace IronPython.Runtime.Operations {
@@ -292,6 +294,11 @@ namespace IronPython.Runtime.Operations {
 
         public static int bit_length(SByte value) {
             return MathUtils.BitLength((int)value);
+        }
+
+        public static Bytes to_bytes(SByte value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            // TODO: signed should be a keyword only argument
+            return Int64Ops.to_bytes(value, length, byteorder, signed);
         }
 
         #endregion
@@ -652,6 +659,11 @@ namespace IronPython.Runtime.Operations {
             return MathUtils.BitLength((int)value);
         }
 
+        public static Bytes to_bytes(Byte value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            // TODO: signed should be a keyword only argument
+            return UInt64Ops.to_bytes(value, length, byteorder, signed);
+        }
+
         #endregion
     }
 
@@ -931,6 +943,11 @@ namespace IronPython.Runtime.Operations {
 
         public static int bit_length(Int16 value) {
             return MathUtils.BitLength((int)value);
+        }
+
+        public static Bytes to_bytes(Int16 value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            // TODO: signed should be a keyword only argument
+            return Int64Ops.to_bytes(value, length, byteorder, signed);
         }
 
         #endregion
@@ -1301,6 +1318,11 @@ namespace IronPython.Runtime.Operations {
             return MathUtils.BitLength((int)value);
         }
 
+        public static Bytes to_bytes(UInt16 value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            // TODO: signed should be a keyword only argument
+            return UInt64Ops.to_bytes(value, length, byteorder, signed);
+        }
+
         #endregion
     }
 
@@ -1555,6 +1577,11 @@ namespace IronPython.Runtime.Operations {
 
         public static int bit_length(Int32 value) {
             return MathUtils.BitLength(value);
+        }
+
+        public static Bytes to_bytes(Int32 value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            // TODO: signed should be a keyword only argument
+            return Int64Ops.to_bytes(value, length, byteorder, signed);
         }
 
         #endregion
@@ -1923,6 +1950,11 @@ namespace IronPython.Runtime.Operations {
 
         public static int bit_length(UInt32 value) {
             return MathUtils.BitLengthUnsigned(value);
+        }
+
+        public static Bytes to_bytes(UInt32 value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            // TODO: signed should be a keyword only argument
+            return UInt64Ops.to_bytes(value, length, byteorder, signed);
         }
 
         #endregion

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -338,57 +338,10 @@ namespace IronPython.Runtime.Operations {
             return spec.AlignNumericText(digits, self == 0, self > 0);
         }
 
-        public static Bytes to_bytes(Int32 value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
-            // TODO: signed should be a keyword only argument
-            bool isLittle = (byteorder == "little");
-            if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
-
-            if (length < 0) throw PythonOps.ValueError("length argument must be non-negative");
-            if (!signed && value < 0) throw PythonOps.OverflowError("can't convert negative int to unsigned");
-
-            if (value == 0) return Bytes.Make(new byte[length]);
-
-            var bytes = new byte[length];
-            int cur, end, step;
-            if (isLittle) {
-                cur = 0; end = length; step = 1;
-            } else {
-                cur = length - 1; end = -1; step = -1;
-            }
-
-            if (!signed || value >= 0) {
-                UInt32 uvalue = unchecked((UInt32)value);
-                do {
-                    if (cur == end) ThrowOverflow();
-                    bytes[cur] = (byte)(uvalue & 0xFF);
-                    uvalue >>= 8;
-                    cur += step;
-                } while (uvalue != 0);
-            } else {
-                byte curbyte;
-                do {
-                    if (cur == end) ThrowOverflow();
-                    bytes[cur] = curbyte = (byte)(value & 0xFF);
-                    value >>= 8;
-                    cur += step;
-                } while (value != -1 || (curbyte & 0x80) == 0);
-
-                while (cur != end) {
-                    bytes[cur] = 0xFF;
-                    cur += step;
-                }
-            }
-
-            return Bytes.Make(bytes);
-
-            static void ThrowOverflow() => throw PythonOps.OverflowError("int too big to convert");
-        }
-
         [ClassMethod, StaticExtensionMethod]
         public static object from_bytes(CodeContext context, PythonType type, object bytes, [NotDynamicNull] string byteorder, bool signed = false)
             // TODO: signed should be a keyword only argument
             => BigIntegerOps.from_bytes(context, type, bytes, byteorder, signed);
-
 
         #endregion
 
@@ -474,6 +427,96 @@ namespace IronPython.Runtime.Operations {
                 digits = "0b" + digits;
             }
             return digits;
+        }
+
+        #endregion
+    }
+
+    public static partial class Int64Ops {
+
+        #region Public API - Bytes
+
+        public static Bytes to_bytes(Int64 value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            // TODO: signed should be a keyword only argument
+            bool isLittle = (byteorder == "little");
+            if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
+
+            if (length < 0) throw PythonOps.ValueError("length argument must be non-negative");
+            if (!signed && value < 0) throw PythonOps.OverflowError("can't convert negative int to unsigned");
+
+            if (value == 0) return Bytes.Make(new byte[length]);
+
+            var bytes = new byte[length];
+            int cur, end, step;
+            if (isLittle) {
+                cur = 0; end = length; step = 1;
+            } else {
+                cur = length - 1; end = -1; step = -1;
+            }
+
+            if (!signed || value >= 0) {
+                ulong uvalue = unchecked((ulong)value);
+                do {
+                    if (cur == end) ThrowOverflow();
+                    bytes[cur] = (byte)(uvalue & 0xFF);
+                    uvalue >>= 8;
+                    cur += step;
+                } while (uvalue != 0);
+            } else {
+                byte curbyte;
+                do {
+                    if (cur == end) ThrowOverflow();
+                    bytes[cur] = curbyte = (byte)(value & 0xFF);
+                    value >>= 8;
+                    cur += step;
+                } while (value != -1 || (curbyte & 0x80) == 0);
+
+                while (cur != end) {
+                    bytes[cur] = 0xFF;
+                    cur += step;
+                }
+            }
+
+            return Bytes.Make(bytes);
+
+            static void ThrowOverflow() => throw PythonOps.OverflowError("int too big to convert");
+        }
+
+        #endregion
+    }
+
+    public static partial class UInt64Ops {
+
+        #region Public API - Bytes
+
+        public static Bytes to_bytes(UInt64 value, int length, [NotDynamicNull] string byteorder, bool signed = false) {
+            bool isLittle = (byteorder == "little");
+            if (!isLittle && byteorder != "big") throw PythonOps.ValueError("byteorder must be either 'little' or 'big'");
+
+            if (length < 0) throw PythonOps.ValueError("length argument must be non-negative");
+
+            if (value == 0) return Bytes.Make(new byte[length]);
+
+            var bytes = new byte[length];
+            int cur, end, step;
+            if (isLittle) {
+                cur = 0; end = length; step = 1;
+            } else {
+                cur = length - 1; end = -1; step = -1;
+            }
+
+            do {
+                if (cur == end) ThrowOverflow();
+                bytes[cur] = (byte)(value & 0xFF);
+                value >>= 8;
+                cur += step;
+            } while (value != 0);
+
+            if (signed && (bytes[end - step] & 0x80) == 0x80) ThrowOverflow();
+
+            return Bytes.Make(bytes);
+
+            static void ThrowOverflow() => throw PythonOps.OverflowError("int too big to convert");
         }
 
         #endregion

--- a/Src/Scripts/generate_alltypes.py
+++ b/Src/Scripts/generate_alltypes.py
@@ -474,6 +474,13 @@ def gen_api(cw, ty):
         cw.write('return MathUtils.%s(%svalue);' % (counter, cast))
         cw.exit_block()
 
+        if ty.name not in ['Int64', 'UInt64']:
+            cw.writeline()
+            cw.enter_block('public static Bytes to_bytes(%s value, int length, [NotDynamicNull] string byteorder, bool signed = false)' % ty.name)
+            cw.write('// TODO: signed should be a keyword only argument')
+            cw.write('return %s.to_bytes(value, length, byteorder, signed);' % ("Int64Ops" if ty.is_signed else "UInt64Ops"))
+            cw.exit_block()
+
     cw.writeline()
     cw.writeline("#endregion")
 

--- a/Tests/test_int.py
+++ b/Tests/test_int.py
@@ -4,7 +4,7 @@
 
 import sys
 
-from iptest import IronPythonTestCase, is_cli, big, myint, clr_int_types, skipUnlessIronPython, run_test
+from iptest import IronPythonTestCase, is_cli, big, myint, skipUnlessIronPython, run_test
 
 class IntTest(IronPythonTestCase):
     def test_from_bytes(self):
@@ -33,11 +33,15 @@ class IntTest(IronPythonTestCase):
         self.assertRaisesMessage(ValueError, "length argument must be non-negative", (-1<<64).to_bytes, -1, 'little')
         self.assertRaisesMessage(OverflowError, "can't convert negative int to unsigned", (-1<<64).to_bytes, 0, 'little')
 
-    def test_to_bytes_int(self):
+    @skipUnlessIronPython()
+    def test_to_bytes_clrint(self):
+        from iptest import clr_int_types
+
         for t in clr_int_types:
             for v in (0, 1, -1, 2, -2, 127, -128, 128, -129, 255, 256, -256, 257, -257,
+                        2**15-1, -2**15, 2**15, -2**15-1, 2**16-1, -2**16, 2**16, -2**16-1,
                         2**31-1, -2**31, 2**31, -2**31-1, 2**32-1, -2**32, 2**32, -2**32-1,
-                        2**63-1, -2**63, 2**63, -2**63-1, 2**64-1, -2**64, 2**64, -2**64-1):
+                        2**63-1, -2**63, 2**63, -2**63-1, 2**64-1):
                 for byteorder in ('little', 'big'):
                     for signed in (True, False):
                         if signed and v < 0:


### PR DESCRIPTION
Normally I would not add a Python-specific method to a non-Python type (except for dunder methods), but this method can be quite useful on integral types.