### PR TITLE
Don't overflow on complex constructor

### DIFF
--- a/Src/IronPython/Runtime/LiteralParser.cs
+++ b/Src/IronPython/Runtime/LiteralParser.cs
@@ -1004,7 +1004,7 @@ namespace IronPython.Runtime {
                 int len = text.Length;
                 var idx = text.IndexOf('j');
                 if (idx == -1) {
-                    return MathUtils.MakeReal(ParseFloatNoCatch(text));
+                    return MathUtils.MakeReal(ParseFloat(text));
                 } else if (idx == len - 1) {
                     // last sign delimits real and imaginary...
                     int signPos = text.LastIndexOfAny(signs);
@@ -1019,7 +1019,7 @@ namespace IronPython.Runtime {
 
                     // no real component
                     if (signPos < 0) {
-                        return MathUtils.MakeImaginary((len == 1) ? 1 : ParseFloatNoCatch(text.Substring(0, len - 1)));
+                        return MathUtils.MakeImaginary((len == 1) ? 1 : ParseFloat(text.Substring(0, len - 1)));
                     }
 
                     string real = text.Substring(0, signPos);
@@ -1028,7 +1028,7 @@ namespace IronPython.Runtime {
                         imag += "1"; // convert +/- to +1/-1
                     }
 
-                    return new Complex(String.IsNullOrEmpty(real) ? 0 : ParseFloatNoCatch(real), ParseFloatNoCatch(imag));
+                    return new Complex(String.IsNullOrEmpty(real) ? 0 : ParseFloat(real), ParseFloat(imag));
                 } else {
                     throw ExnMalformed();
                 }

--- a/Tests/test_complex.py
+++ b/Tests/test_complex.py
@@ -2,8 +2,7 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-from iptest.type_util import *
-from iptest import IronPythonTestCase, run_test
+from iptest import big, IronPythonTestCase, mycomplex, run_test
 
 class ComplexTest(IronPythonTestCase):
 
@@ -156,6 +155,15 @@ class ComplexTest(IronPythonTestCase):
         self.assertEqual(complex(int_with_float(2)), 1+0j)
         self.assertEqual(complex(int_with_index(2)), 2+0j)
 
+        # .NET allows trailing null characters in its double.Parse but Python doesn't
+        self.assertRaisesMessage(ValueError, "complex() arg is a malformed string", complex, "\x00")
+        self.assertRaisesMessage(ValueError, "complex() arg is a malformed string", complex, "1\x00")
+        self.assertRaisesMessage(ValueError, "complex() arg is a malformed string", complex, "1\x00j")
+        self.assertRaisesMessage(ValueError, "complex() arg is a malformed string", complex, "1e1\x00")
+        self.assertRaisesMessage(ValueError, "complex() arg is a malformed string", complex, "1e1\x00j")
+        self.assertRaisesMessage(ValueError, "complex() arg is a malformed string", complex, "1\x00+1j")
+        self.assertRaisesMessage(ValueError, "complex() arg is a malformed string", complex, "1+1\x00j")
+
     def test_negative_zero_repr_str(self):
         # see also similar test in StdLib
 
@@ -237,16 +245,12 @@ class ComplexTest(IronPythonTestCase):
         self.assertEqual(complex(2), complex(2, 0))
 
     def test_inherit(self):
-        class mycomplex(complex): pass
-
         a = mycomplex(2+1j)
         self.assertEqual(a.real, 2)
         self.assertEqual(a.imag, 1)
 
-
     def test_repr(self):
         self.assertEqual(repr(1-6j), '(1-6j)')
-
 
     def test_infinite(self):
         self.assertEqual(repr(1.0e340j),  'infj')

--- a/Tests/test_complex_stdlib.py
+++ b/Tests/test_complex_stdlib.py
@@ -19,10 +19,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_complex.ComplexTest('test_abs'))
         suite.addTest(test.test_complex.ComplexTest('test_boolcontext'))
         suite.addTest(test.test_complex.ComplexTest('test_conjugate'))
-        if is_netcoreapp and not is_netcoreapp21:
-            suite.addTest(test.test_complex.ComplexTest('test_constructor'))
-        else:
-            suite.addTest(unittest.expectedFailure(test.test_complex.ComplexTest('test_constructor'))) # ValueError: complex() literal too large to convert
+        suite.addTest(test.test_complex.ComplexTest('test_constructor'))
         suite.addTest(test.test_complex.ComplexTest('test_divmod'))
         suite.addTest(test.test_complex.ComplexTest('test_file'))
         suite.addTest(test.test_complex.ComplexTest('test_floordiv'))
@@ -33,10 +30,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_complex.ComplexTest('test_neg'))
         suite.addTest(test.test_complex.ComplexTest('test_negated_imaginary_literal'))
         suite.addTest(test.test_complex.ComplexTest('test_negative_zero_repr_str'))
-        if is_netcoreapp and not is_netcoreapp21:
-            suite.addTest(test.test_complex.ComplexTest('test_overflow'))
-        else:
-            suite.addTest(unittest.expectedFailure(test.test_complex.ComplexTest('test_overflow'))) # ValueError: complex() literal too large to convert
+        suite.addTest(test.test_complex.ComplexTest('test_overflow'))
         suite.addTest(test.test_complex.ComplexTest('test_plus_minus_0j'))
         suite.addTest(test.test_complex.ComplexTest('test_pow'))
         suite.addTest(test.test_complex.ComplexTest('test_repr_roundtrip'))


### PR DESCRIPTION
Noticed this while reviewing https://github.com/IronLanguages/ironpython3/pull/1385