### PR TITLE
Mimic BigInteger members on Int32

### DIFF
--- a/Src/IronPython/Lib/iptest/test_env.py
+++ b/Src/IronPython/Lib/iptest/test_env.py
@@ -22,6 +22,7 @@ is_netcoreapp31 = False
 is_net50 = False
 is_net60 = False
 is_mono = False
+is_netstandard = False
 if is_ironpython:
     import clr
     is_netcoreapp = clr.IsNetCoreApp
@@ -30,10 +31,11 @@ if is_ironpython:
     is_net50 = clr.FrameworkDescription.startswith(".NET 5.0")
     is_net60 = clr.FrameworkDescription.startswith(".NET 6.0")
     is_mono = clr.IsMono
+    is_netstandard = clr.TargetFramework.startswith(".NETStandard")
 
 #--The bittedness of the Python implementation
 is_cli32, is_cli64 = False, False
-if is_ironpython: 
+if is_ironpython:
     import System
     is_cli32, is_cli64 = (System.IntPtr.Size == 4), (System.IntPtr.Size == 8)
 

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -231,8 +231,7 @@ namespace IronPython.Runtime.Operations {
                     // So use FormattingHelper.ToCultureString for that support.
                     if (spec.Fill.HasValue && spec.Fill.Value == '0' && width > 1) {
                         digits = FormattingHelper.ToCultureString(self, culture.NumberFormat, spec);
-                    }
-                    else {
+                    } else {
                         digits = self.ToString("N0", culture);
                     }
                     break;
@@ -246,8 +245,7 @@ namespace IronPython.Runtime.Operations {
                         // so use FormattingHelper.ToCultureString for that support.
                         if (spec.Fill.HasValue && spec.Fill.Value == '0' && width > 1) {
                             digits = FormattingHelper.ToCultureString(self, FormattingHelper.InvariantCommaNumberInfo, spec);
-                        }
-                        else {
+                        } else {
                             digits = self.ToString("#,0", CultureInfo.InvariantCulture);
                         }
                     } else {
@@ -299,8 +297,7 @@ namespace IronPython.Runtime.Operations {
                     } else if (spec.ThousandsComma) {
                         // Handle the common case in 'd'.
                         goto case 'd';
-                    }
-                    else {
+                    } else {
                         digits = self.ToString(CultureInfo.InvariantCulture);
                     }
                     break;
@@ -391,7 +388,7 @@ namespace IronPython.Runtime.Operations {
             if (self == Int32.MinValue) {
                 return "-0b10000000000000000000000000000000";
             }
-            
+
             string res = ToBinary(self, true);
             if (self < 0) {
                 res = "-" + res;
@@ -422,12 +419,121 @@ namespace IronPython.Runtime.Operations {
             } else {
                 digits = "10000000000000000000000000000000";
             }
-            
+
             if (includeType) {
                 digits = "0b" + digits;
             }
             return digits;
         }
+
+        #endregion
+
+        #region Mimic BigInteger members
+        // Ideally only on instances
+
+        #region Properties
+
+        [SpecialName, PropertyMethod, PythonHidden]
+        public static bool GetIsEven(int self) => (self & 1) == 0;
+
+        [SpecialName, PropertyMethod, PythonHidden]
+        public static bool GetIsOne(int self) => self == 1;
+
+        [SpecialName, PropertyMethod, PythonHidden]
+        public static bool GetIsPowerOfTwo(int self) => self > 0 && (self & (self - 1)) == 0;
+
+        [SpecialName, PropertyMethod, PythonHidden]
+        public static bool GetIsZero(int self) => self == 0;
+
+        [SpecialName, PropertyMethod, PythonHidden]
+        public static int GetSign(int self) => self == 0 ? 0 : self > 0 ? 1 : -1;
+
+        [PythonHidden]
+        public static object Zero => ScriptingRuntimeHelpers.Int32ToObject(0);
+
+        [PythonHidden]
+        public static object One => ScriptingRuntimeHelpers.Int32ToObject(1);
+
+        [PythonHidden]
+        public static object MinusOne => ScriptingRuntimeHelpers.Int32ToObject(-1);
+
+        #endregion
+
+        #region Methods
+
+        [PythonHidden]
+        public static byte[] ToByteArray(int self) => new BigInteger(self).ToByteArray();
+
+#if NETCOREAPP
+        [PythonHidden]
+        public static int GetByteCount(int self, bool isUnsigned = false) => new BigInteger(self).GetByteCount(isUnsigned);
+
+        [PythonHidden]
+        public static bool TryWriteBytes(int self, Span<byte> destination, out int bytesWritten, bool isUnsigned = false, bool isBigEndian = false)
+            => new BigInteger(self).TryWriteBytes(destination, out bytesWritten, isUnsigned, isBigEndian);
+#endif
+
+#if NET
+        [PythonHidden]
+        public static long GetBitLength(int self) => new BigInteger(self).GetBitLength();
+#endif
+
+        #endregion
+
+        #region Static Extension Methods
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Compare(BigInteger left, BigInteger right) => BigInteger.Compare(left, right);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Min(BigInteger left, BigInteger right) => BigInteger.Min(left, right);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Max(BigInteger left, BigInteger right) => BigInteger.Max(left, right);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static double Log(BigInteger value) => BigInteger.Log(value);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static double Log(BigInteger value, double baseValue) => BigInteger.Log(value, baseValue);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static double Log10(BigInteger value) => BigInteger.Log10(value);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static object Pow(BigInteger value, int exponent) => BigInteger.Pow(value, exponent);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static object ModPow(BigInteger value, BigInteger exponent, BigInteger modulus) => BigInteger.ModPow(value, exponent, modulus);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Negate(BigInteger value) => BigInteger.Negate(value);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Abs(BigInteger value) => BigInteger.Abs(value);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Add(BigInteger left, BigInteger right) => BigInteger.Add(left, right);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Subtract(BigInteger left, BigInteger right) => BigInteger.Subtract(left, right);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Multiply(BigInteger left, BigInteger right) => BigInteger.Multiply(left, right);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Divide(BigInteger left, BigInteger right) => BigInteger.Divide(left, right);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger Remainder(BigInteger dividend, BigInteger divisor) => BigInteger.Remainder(dividend, divisor);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger DivRem(BigInteger dividend, BigInteger divisor, out BigInteger remainder) => BigInteger.DivRem(dividend, divisor, out remainder);
+
+        [StaticExtensionMethod, PythonHidden]
+        public static BigInteger GreatestCommonDivisor(BigInteger left, BigInteger right) => BigInteger.GreatestCommonDivisor(left, right);
+
+        #endregion
 
         #endregion
     }

--- a/Tests/test_cliclass.py
+++ b/Tests/test_cliclass.py
@@ -1443,9 +1443,9 @@ if not hasattr(A, 'Rank'):
                 ii = int(i2) # convert to Int32 if possible
                 bi = big(i2)
                 self.assertEqual(ii.ToByteArray(), bi.ToByteArray())
-                if hasattr(int, 'GetByteCount') and not is_mono:
+                if hasattr(ii, 'GetByteCount') and hasattr(bi, 'GetByteCount'):
                     self.assertEqual(ii.GetByteCount(), bi.GetByteCount())
-                if hasattr(int, 'GetBitLength') and not is_mono:
+                if hasattr(ii, 'GetBitLength') and hasattr(bi, 'GetBitLength'):
                     self.assertEqual(ii.GetBitLength(), bi.GetBitLength())
 
         # static methods

--- a/Tests/test_cliclass.py
+++ b/Tests/test_cliclass.py
@@ -1420,6 +1420,68 @@ if not hasattr(A, 'Rank'):
         self.assertTrue('IndexOf' not in clr.Dir('abc'))
         self.assertTrue('IndexOf' in clr.DirClr('abc'))
 
+    def test_int32_bigint_equivalence(self):
+        import math
+
+        # properties
+        for i in range(-10, 10):
+            bi = big(i)
+            self.assertEqual(i.IsEven, bi.IsEven)
+            self.assertEqual(i.IsOne, bi.IsOne)
+            self.assertEqual(i.IsPowerOfTwo, bi.IsPowerOfTwo)
+            self.assertEqual(i.IsZero, bi.IsZero)
+            self.assertEqual(i.Sign, bi.Sign)
+            # static properties
+            self.assertEqual(i.Zero, bi.Zero)
+            self.assertEqual(i.One, bi.One)
+            self.assertEqual(i.MinusOne, bi.MinusOne)
+
+        # methods
+        i = System.Int32(1234567890)
+        bi = big(i)
+        self.assertEqual(i.ToByteArray(), bi.ToByteArray())
+        if hasattr(int, 'GetByteCount'):
+            self.assertEqual(i.GetByteCount(), bi.GetByteCount())
+        if hasattr(int, 'GetBitLength'):
+            self.assertEqual(i.GetBitLength(), bi.GetBitLength())
+
+        # static methods
+        for i in [0, 1, 2, 7<<30, 1<<32, (1<<32)-1, (1<<32)+1]:
+            for i2 in [i, -i]:
+                ii = int(i2) # convert to Int32 if possible
+                bi = big(i2)
+                self.assertEqual((1).Negate(ii), int.Negate(bi))
+                self.assertEqual((1).Abs(ii), int.Abs(bi))
+                self.assertEqual((1).Pow(ii, 5), int.Pow(bi, 5))
+                self.assertEqual((1).ModPow(ii, 5, 3), int.ModPow(bi, 5, 3))
+                if ii >= 0:
+                    self.assertEqual((1).Log(ii), int.Log(bi))
+                    self.assertEqual((1).Log10(ii), int.Log10(bi))
+                    self.assertEqual((1).Log(ii, 7.2), int.Log(bi, 7.2))
+                else:
+                    self.assertTrue(math.isnan((1).Log(ii)))
+                    self.assertTrue(math.isnan(int.Log(bi)))
+                    self.assertTrue(math.isnan((1).Log10(ii)))
+                    self.assertTrue(math.isnan(int.Log10(bi)))
+                    self.assertTrue(math.isnan((1).Log(ii, 7.2)))
+                    self.assertTrue(math.isnan(int.Log(bi, 7.2)))
+
+                for j in [0, 1, 2, 7<<30, 1<<32, (1<<32)-1, (1<<32)+1]:
+                    for j2 in [j, -j]:
+                        jj = int(j2) # convert to Int32 if possible
+                        bj = big(j2)
+                        self.assertEqual((1).Compare(ii, jj), int.Compare(bi, bj))
+                        self.assertEqual((1).Min(ii, jj), int.Min(bi, bj))
+                        self.assertEqual((1).Max(ii, jj), int.Max(bi, bj))
+                        self.assertEqual((1).Add(ii, jj), int.Add(bi, bj))
+                        self.assertEqual((1).Subtract(ii, jj), int.Subtract(bi, bj))
+                        self.assertEqual((1).Multiply(ii, jj), int.Multiply(bi, bj))
+                        self.assertEqual((1).GreatestCommonDivisor(ii, jj), int.GreatestCommonDivisor(bi, bj))
+                        if jj != 0:
+                            self.assertEqual((1).Divide(ii, jj), int.Divide(bi, bj))
+                            self.assertEqual((1).DivRem(ii, jj), int.DivRem(bi, bj))
+                            self.assertEqual((1).Remainder(ii, jj), int.Remainder(bi, bj))
+
     def test_array_contains(self):
         if is_mono: # for whatever reason this is defined on Mono
             System.Array[str].__dict__['__contains__']

--- a/Tests/test_cliclass.py
+++ b/Tests/test_cliclass.py
@@ -1436,17 +1436,20 @@ if not hasattr(A, 'Rank'):
             self.assertEqual(i.One, bi.One)
             self.assertEqual(i.MinusOne, bi.MinusOne)
 
+        test_values = [0, 1, 2, 4, 8, 10, 255, 256, 7<<30, 1<<31, (1<<31)-1, (1<<31)+1, 1<<32, (1<<32)-1, (1<<32)+1]
         # methods
-        i = System.Int32(1234567890)
-        bi = big(i)
-        self.assertEqual(i.ToByteArray(), bi.ToByteArray())
-        if hasattr(int, 'GetByteCount'):
-            self.assertEqual(i.GetByteCount(), bi.GetByteCount())
-        if hasattr(int, 'GetBitLength'):
-            self.assertEqual(i.GetBitLength(), bi.GetBitLength())
+        for i in test_values:
+            for i2 in [i, -i]:
+                ii = int(i2) # convert to Int32 if possible
+                bi = big(i2)
+                self.assertEqual(ii.ToByteArray(), bi.ToByteArray())
+                if hasattr(int, 'GetByteCount'):
+                    self.assertEqual(ii.GetByteCount(), bi.GetByteCount())
+                if hasattr(int, 'GetBitLength'):
+                    self.assertEqual(ii.GetBitLength(), bi.GetBitLength())
 
         # static methods
-        for i in [0, 1, 2, 7<<30, 1<<32, (1<<32)-1, (1<<32)+1]:
+        for i in test_values:
             for i2 in [i, -i]:
                 ii = int(i2) # convert to Int32 if possible
                 bi = big(i2)
@@ -1466,7 +1469,7 @@ if not hasattr(A, 'Rank'):
                     self.assertTrue(math.isnan((1).Log(ii, 7.2)))
                     self.assertTrue(math.isnan(int.Log(bi, 7.2)))
 
-                for j in [0, 1, 2, 7<<30, 1<<32, (1<<32)-1, (1<<32)+1]:
+                for j in test_values:
                     for j2 in [j, -j]:
                         jj = int(j2) # convert to Int32 if possible
                         bj = big(j2)

--- a/Tests/test_cliclass.py
+++ b/Tests/test_cliclass.py
@@ -1443,9 +1443,9 @@ if not hasattr(A, 'Rank'):
                 ii = int(i2) # convert to Int32 if possible
                 bi = big(i2)
                 self.assertEqual(ii.ToByteArray(), bi.ToByteArray())
-                if hasattr(int, 'GetByteCount'):
+                if hasattr(int, 'GetByteCount') and not is_mono:
                     self.assertEqual(ii.GetByteCount(), bi.GetByteCount())
-                if hasattr(int, 'GetBitLength'):
+                if hasattr(int, 'GetBitLength') and not is_mono:
                     self.assertEqual(ii.GetBitLength(), bi.GetBitLength())
 
         # static methods

--- a/Tests/test_int.py
+++ b/Tests/test_int.py
@@ -4,7 +4,7 @@
 
 import sys
 
-from iptest import IronPythonTestCase, is_cli, is_netcoreapp21, is_mono, big, myint, skipUnlessIronPython, run_test
+from iptest import IronPythonTestCase, is_cli, is_netstandard, is_mono, big, myint, skipUnlessIronPython, run_test
 
 class IntNoClrTest(IronPythonTestCase):
     """Must be run before IntTest because it depends on CLR API not being visible."""
@@ -28,10 +28,9 @@ class IntTest(IronPythonTestCase):
             self.assertSetEqual(set(dir(int)) - set(dir(Int32)), {'GetByteCount', 'TryWriteBytes'})
 
         # these two assertions fail on IronPython compiled for .NET Standard
-        # if not iptest.is_netstandard: # no such check possible
-        if not is_netcoreapp21: # assuming that .NET Standard build is tested by .NET Core 2.1 runtime
-             self.assertSetEqual(set(dir(i)) - set(dir(j)), {'MaxValue', 'MinValue'})
-             self.assertSetEqual(set(dir(Int32)) - set(dir(int)), {'MaxValue', 'MinValue'})
+        if not is_netstandard:
+            self.assertSetEqual(set(dir(i)) - set(dir(j)), {'MaxValue', 'MinValue'})
+            self.assertSetEqual(set(dir(Int32)) - set(dir(int)), {'MaxValue', 'MinValue'})
 
         # weaker assertions that should always hold
         self.assertTrue((set(dir(i)) - set(dir(j))).issubset({'MaxValue', 'MinValue', 'GetByteCount', 'TryWriteBytes', 'GetBitLength'}))

--- a/Tests/test_int.py
+++ b/Tests/test_int.py
@@ -4,7 +4,7 @@
 
 import sys
 
-from iptest import IronPythonTestCase, is_cli, is_netcoreapp21, big, myint, skipUnlessIronPython, run_test
+from iptest import IronPythonTestCase, is_cli, is_netcoreapp21, is_mono, big, myint, skipUnlessIronPython, run_test
 
 class IntNoClrTest(IronPythonTestCase):
     """Must be run before IntTest because it depends on CLR API not being visible."""
@@ -20,8 +20,12 @@ class IntTest(IronPythonTestCase):
         j = big(1)
         from System import Int32
 
-        self.assertSetEqual(set(dir(j)) - set(dir(i)), set())
-        self.assertSetEqual(set(dir(int)) - set(dir(Int32)), set())
+        if not is_mono:
+            self.assertSetEqual(set(dir(j)) - set(dir(i)), set())
+            self.assertSetEqual(set(dir(int)) - set(dir(Int32)), set())
+        else:
+            self.assertSetEqual(set(dir(j)) - set(dir(i)), {'GetByteCount', 'TryWriteBytes'})
+            self.assertSetEqual(set(dir(int)) - set(dir(Int32)), {'GetByteCount', 'TryWriteBytes'})
 
         # these two assertions fail on IronPython compiled for .NET Standard
         # if not iptest.is_netstandard: # no such check possible

--- a/Tests/test_int.py
+++ b/Tests/test_int.py
@@ -3,7 +3,6 @@
 # See the LICENSE file in the project root for more information.
 
 import sys
-import unittest
 
 from iptest import IronPythonTestCase, is_cli, big, myint, skipUnlessIronPython, run_test
 
@@ -23,12 +22,6 @@ class IntTest(IronPythonTestCase):
 
         self.assertSetEqual(set(dir(i)) - set(dir(j)), {'MaxValue', 'MinValue'})
         self.assertSetEqual(set(dir(Int32)) - set(dir(int)), {'MaxValue', 'MinValue'})
-
-    @unittest.expectedFailure
-    def test_instance_set_todo(self):
-        i = 1
-        j = big(1)
-        from System import Int32
 
         self.assertSetEqual(set(dir(j)) - set(dir(i)), set())
         self.assertSetEqual(set(dir(int)) - set(dir(Int32)), set())

--- a/Tests/test_int.py
+++ b/Tests/test_int.py
@@ -4,7 +4,7 @@
 
 import sys
 
-from iptest import IronPythonTestCase, is_cli, big, myint, skipUnlessIronPython, run_test
+from iptest import IronPythonTestCase, is_cli, is_netcoreapp21, big, myint, skipUnlessIronPython, run_test
 
 class IntNoClrTest(IronPythonTestCase):
     """Must be run before IntTest because it depends on CLR API not being visible."""
@@ -20,11 +20,18 @@ class IntTest(IronPythonTestCase):
         j = big(1)
         from System import Int32
 
-        self.assertSetEqual(set(dir(i)) - set(dir(j)), {'MaxValue', 'MinValue'})
-        self.assertSetEqual(set(dir(Int32)) - set(dir(int)), {'MaxValue', 'MinValue'})
-
         self.assertSetEqual(set(dir(j)) - set(dir(i)), set())
         self.assertSetEqual(set(dir(int)) - set(dir(Int32)), set())
+
+        # these two assertions fail on IronPython compiled for .NET Standard
+        # if not iptest.is_netstandard: # no such check possible
+        if not is_netcoreapp21: # assuming that .NET Standard build is tested by .NET Core 2.1 runtime
+             self.assertSetEqual(set(dir(i)) - set(dir(j)), {'MaxValue', 'MinValue'})
+             self.assertSetEqual(set(dir(Int32)) - set(dir(int)), {'MaxValue', 'MinValue'})
+
+        # weaker assertions that should always hold
+        self.assertTrue((set(dir(i)) - set(dir(j))).issubset({'MaxValue', 'MinValue', 'GetByteCount', 'TryWriteBytes', 'GetBitLength'}))
+        self.assertTrue((set(dir(Int32)) - set(dir(int))).issubset({'MaxValue', 'MinValue', 'GetByteCount', 'TryWriteBytes', 'GetBitLength'}))
 
     def test_from_bytes(self):
         self.assertEqual(type(int.from_bytes(b"abc", "big")), int)


### PR DESCRIPTION
Follow-up on https://github.com/IronLanguages/ironpython3/pull/1329 (issue https://github.com/IronLanguages/ironpython3/issues/52).

Instances of `Int32` behave as if being instances of an anonymous subtype of `int`. Therefore, for the sake of type system consistency, any attributes of `int` should be also present on instances of both `int` and `Int32`. This was already the case for regular Python attributes, but not for Python-hidden attributes. This PR sets it straight. Arguably, there is little chance that the static attributes are going to be accessed through an instance rather than the type, but here they are to avoid surprises. Who knows, maybe some code-generating use case assumes that it is possible, as it should be.

Ideally I would like to see those Python-hidden properties and method only on `Int32` instances and not pollute the namespace of the `Int32` type. However, the existing resolver mechanism does not support such distinction and I am not convinced it is worth extra complexity implementing an additional mechanism just for that.