### PR TITLE
Test cleanup

### DIFF
--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1192,7 +1192,7 @@ namespace IronPython.Runtime {
         }
 
         internal Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args) {
-            if (args.RequestingAssembly != null && !_loadedAssemblies.Contains(args.RequestingAssembly)) {
+            if (args.RequestingAssembly != null && !(args.RequestingAssembly == typeof(PythonContext).Assembly || _loadedAssemblies.Contains(args.RequestingAssembly))) {
                 return null;
             }
 

--- a/Tests/modules/io_related/test_codecs.py
+++ b/Tests/modules/io_related/test_codecs.py
@@ -2050,11 +2050,11 @@ class CodecTest(IronPythonTestCase):
             return ("", ex.end + 1)
 
         codecs.register_error("test_unicode_error1", handler1)
-        if is_cpython:
-            res = "+++\xac\u1234\u20ac\u8000---".encode("ptcp154", "test_unicode_error1")
-            self.assertEqual(res, b"+++\xac--")
-        else:
+        if is_cli:
             with self.assertRaises(NotImplementedError):
                 res = "+++\xac\u1234\u20ac\u8000---".encode("ptcp154", "test_unicode_error1")
+        else:
+            res = "+++\xac\u1234\u20ac\u8000---".encode("ptcp154", "test_unicode_error1")
+            self.assertEqual(res, b"+++\xac--")
 
 run_test(__name__)

--- a/Tests/modules/io_related/test_copyreg.py
+++ b/Tests/modules/io_related/test_copyreg.py
@@ -22,14 +22,14 @@ class CopyRegTest(unittest.TestCase):
     def test_constructor_neg(self):
         'https://github.com/IronLanguages/main/issues/443'
         class KOld: pass
-        
+
         self.assertRaises(TypeError, copyreg.constructor, KOld)
 
- 
+
     def test_constructor(self):
         #the argument can be callable
         copyreg.constructor(testclass)
-        
+
         #the argument can not be callable
         self.assertRaises(TypeError,copyreg.constructor,0)
         self.assertRaises(TypeError,copyreg.constructor,"Hello")
@@ -37,20 +37,20 @@ class CopyRegTest(unittest.TestCase):
 
 
     def test__newobj__(self):
-        
+
         #the second argument is omitted
         result = None
         result = copyreg.__newobj__(object)
         self.assertTrue(result != None,
             "The method __newobj__ did not return an object")
-                        
+
         #the second argument is an int object
         result = None
         a = 1
         result = copyreg.__newobj__(int,a)
         self.assertTrue(result != None,
             "The method __newobj__ did not return an object")
-            
+
         #the method accept multiple arguments
         reseult = None
         class customtype(object):
@@ -121,27 +121,27 @@ class CopyRegTest(unittest.TestCase):
         code = result[key]
         self.assertTrue(code == 123,
                 "The _extension_registry attribute did not return the correct value")
-                
+
         copyreg.add_extension('1','2',999)
         result = copyreg._extension_registry
         code = result[('1','2')]
         self.assertTrue(code == 999,
                 "The _extension_registry attribute did not return the correct value")
-        
+
         #general test, try to set the attribute then to get it
         myvalue = 3885
         copyreg._extension_registry["key"] = myvalue
         result = copyreg._extension_registry["key"]
         self.assertTrue(result == myvalue,
             "The set or the get of the attribute failed")
-    
+
     def test_inverted_registry(self):
         copyreg.add_extension('obj1','obj2',64)
         #get
         result = copyreg._inverted_registry[64]
         self.assertTrue(result == ('obj1','obj2'),
                 "The _inverted_registry attribute did not return the correct value")
-        
+
         #set
         value = ('newmodule','newobj')
         copyreg._inverted_registry[10001] = value
@@ -158,7 +158,7 @@ class CopyRegTest(unittest.TestCase):
         result = copyreg._extension_cache['cache1']
         self.assertTrue(result == value,
             "The get and set of the attribute failed")
-        
+
         value = rand.getrandbits(16)
         copyreg._extension_cache['cache2'] = value
         result = copyreg._extension_cache['cache2']
@@ -171,10 +171,10 @@ class CopyRegTest(unittest.TestCase):
         result = copyreg._extension_cache['cache1']
         self.assertTrue(result == value2,
             "The get and set of the attribute failed")
-        
+
         if 'cache1' not in copyreg._extension_cache or 'cache2' not in copyreg._extension_cache:
             Fail("Set of the attribute failed")
-            
+
         copyreg.clear_extension_cache()
         if 'cache1' in copyreg._extension_cache or 'cache2' in copyreg._extension_cache:
             Fail("The method clear_extension_cache did not work correctly ")
@@ -182,7 +182,7 @@ class CopyRegTest(unittest.TestCase):
     def test_reconstructor(self):
         reconstructor_copy = copyreg._reconstructor
         try:
-            obj = copyreg._reconstructor(object, object, None)   
+            obj = copyreg._reconstructor(object, object, None)
             self.assertTrue(type(obj) is object)
 
             #set,get, the value is a random int
@@ -192,35 +192,35 @@ class CopyRegTest(unittest.TestCase):
             result = copyreg._reconstructor
             self.assertTrue(result == value,
                 "set or get of the attribute failed!")
-        
+
             #the value is a string
             value2 = "value2"
             copyreg._reconstructor = value2
             result = copyreg._reconstructor
             self.assertTrue(result == value2,
                 "set or get of the attribute failed!")
-        
+
             #the value is a custom type object
             value3 = testclass()
             copyreg._reconstructor = value3
             result = copyreg._reconstructor
             self.assertTrue(result == value3,
                 "set or get of the attribute failed!")
-        finally:               
+        finally:
             copyreg._reconstructor = reconstructor_copy
-   
+
 
     def test_pickle(self):
         def testfun():
             return testclass()
-            
+
         # type is a custom type
         copyreg.pickle(type(testclass), testfun)
-        
+
         #type is a system type
         systype = type(random.Random())
         copyreg.pickle(systype,random.Random.random)
-        
+
         #function is not callable
         func = "hello"
         self.assertRaises(TypeError,copyreg.pickle,testclass,func)
@@ -228,12 +228,12 @@ class CopyRegTest(unittest.TestCase):
         self.assertRaises(TypeError,copyreg.pickle,testclass,func)
         func = random.Random()
         self.assertRaises(TypeError,copyreg.pickle,testclass,func)
-    
+
     def test_dispatch_table(self):
         result = copyreg.dispatch_table
         #CodePlex Work Item 8522
         #self.assertEqual(5,len(result))
-        
+
         temp = {
                 "abc":"abc123",
                 "def":"def123",
@@ -241,7 +241,7 @@ class CopyRegTest(unittest.TestCase):
             }
         copyreg.dispatch_table = temp
         self.assertEqual(temp,copyreg.dispatch_table)
-        
+
         temp = {
                 1:"abc123",
                 2:"def123",
@@ -249,7 +249,7 @@ class CopyRegTest(unittest.TestCase):
             }
         copyreg.dispatch_table = temp
         self.assertEqual(temp,copyreg.dispatch_table)
-        
+
         temp = {
                 1:123,
                 8:789,
@@ -257,7 +257,7 @@ class CopyRegTest(unittest.TestCase):
             }
         copyreg.dispatch_table = temp
         self.assertEqual(temp,copyreg.dispatch_table)
-        
+
         #set dispathc_table as empty
         temp ={}
         copyreg.dispatch_table = temp
@@ -265,9 +265,8 @@ class CopyRegTest(unittest.TestCase):
 
     def test_pickle_complex(self):
         #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21908
-        #if not is_cli:
         self.assertEqual(copyreg.pickle_complex(1), (complex, (1, 0)))
-        
+
         #negative tests
         self.assertRaises(AttributeError,copyreg.pickle_complex,"myargu")
         obj2 = myCustom2()

--- a/Tests/modules/network_related/test__socket.py
+++ b/Tests/modules/network_related/test__socket.py
@@ -186,28 +186,38 @@ class SocketTest(IronPythonTestCase):
         '''Tests _socket.getprotobyname'''
         #IP and CPython
         proto_map = {
-                    "icmp": _socket.IPPROTO_ICMP,
-                    "ip": _socket.IPPROTO_IP,
-                    "tcp": _socket.IPPROTO_TCP,
-                    "udp": _socket.IPPROTO_UDP,
+            "icmp": _socket.IPPROTO_ICMP,
+            "ip": _socket.IPPROTO_IP,
+            "tcp": _socket.IPPROTO_TCP,
+            "udp": _socket.IPPROTO_UDP,
         }
 
-        #supported only by IP
-        if is_cli:
-            proto_map.update(
-                {"dstopts": _socket.IPPROTO_DSTOPTS,
+        if is_cli or sys.version_info >= (3,8):
+            proto_map.update({
+                "ipv6": _socket.IPPROTO_IPV6,
+                "esp": _socket.IPPROTO_ESP,
+                "pup": _socket.IPPROTO_PUP, #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21918
+                "ggp": _socket.IPPROTO_GGP, #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21918
+            })
+
+            proto_map_cli_only = {
+                "dstopts": _socket.IPPROTO_DSTOPTS,
                 "none": _socket.IPPROTO_NONE,
                 "raw": _socket.IPPROTO_RAW,
                 "ipv4": _socket.IPPROTO_IPV4,
-                "ipv6": _socket.IPPROTO_IPV6,
-                "esp": _socket.IPPROTO_ESP,
                 "fragment": _socket.IPPROTO_FRAGMENT,
                 "nd": _socket.IPPROTO_ND,
                 "icmpv6": _socket.IPPROTO_ICMPV6,
                 "routing": _socket.IPPROTO_ROUTING,
-                "pup": _socket.IPPROTO_PUP, #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21918
-                "ggp": _socket.IPPROTO_GGP, #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21918
-                })
+            }
+
+            for proto_name, good_val in proto_map_cli_only.items():
+                if is_cli:
+                    temp_val = _socket.getprotobyname(proto_name)
+                    self.assertEqual(temp_val, good_val)
+                else:
+                    with self.assertRaises(OSError):
+                        _socket.getprotobyname(proto_name)
 
         for proto_name, good_val in proto_map.items():
             temp_val = _socket.getprotobyname(proto_name)

--- a/Tests/modules/network_related/test__ssl.py
+++ b/Tests/modules/network_related/test__ssl.py
@@ -94,11 +94,6 @@ class _SslTest(IronPythonTestCase):
 for documentation."""
         self.assertEqual(_ssl.__doc__, expected_doc)
 
-    def test__test_decode_cert(self):
-        if is_cli and hasattr(_ssl, "decode_cert"):
-            self.fail("Please add a test for _ssl.decode_cert")
-        print('TODO: no implementation to test yet.')
-
     def test_SSLType_ssl(self):
         '''
         Should be essentially the same as _ssl.sslwrap.  It's not though and will

--- a/Tests/modules/system_related/test_nt.py
+++ b/Tests/modules/system_related/test_nt.py
@@ -356,7 +356,7 @@ class NtTest(IronPythonTestCase):
         self.assertRaises(TypeError, nt.putenv, 1, "xyz")
         self.assertRaises(TypeError, nt.putenv, "ABC", 1)
 
-    @unittest.skipUnless(is_cli, "CPython has no nt.unsetenv function")
+    @unittest.skipUnless(is_cli or sys.version_info >= (3,9), "CPython has no nt.unsetenv function")
     def test_unsetenv(self):
         #simple sanity check
         nt.putenv("ipy_test_env_var", "xyz")
@@ -470,7 +470,7 @@ class NtTest(IronPythonTestCase):
         ping_cmd = os.path.join(os.environ["windir"], "system32", "ping")
         nt.spawnv(nt.P_WAIT, ping_cmd , ["ping"])
         nt.spawnv(nt.P_WAIT, ping_cmd , ["ping","127.0.0.1","-n","1"])
- 
+
     @unittest.skipUnless(sys.platform == "win32", 'windir is Windows specific')
     def test_spawnve(self):
         ping_cmd = os.path.join(os.environ["windir"], "system32", "ping")
@@ -946,7 +946,7 @@ class NtTest(IronPythonTestCase):
         p = subprocess.Popen("whoami", env=os.environ)
         self.assertTrue(p!=None)
         p.wait()
- 
+
     def test_fsync(self):
         fsync_file_name = 'text_fsync.txt'
         fd = nt.open(fsync_file_name, nt.O_WRONLY | nt.O_CREAT)

--- a/Tests/modules/system_related/test_thread.py
+++ b/Tests/modules/system_related/test_thread.py
@@ -7,7 +7,7 @@ import _thread as thread
 import time
 import unittest
 
-from iptest import is_cli, run_test, skipUnlessIronPython, is_netcoreapp
+from iptest import is_netcoreapp, run_test, skipUnlessIronPython
 
 if is_netcoreapp:
     import clr
@@ -71,28 +71,24 @@ class ThreadTest(unittest.TestCase):
         sys.stderr = se
 
     def test_stack_size(self):
-        import sys
-        if is_cli or (sys.version_info[0] == 2 and sys.version_info[1] > 4) or sys.version_info[0] > 2:
-            import _thread as thread
+        import _thread as thread
 
-            size = thread.stack_size()
-            self.assertTrue(size==0 or size>=32768)
+        size = thread.stack_size()
+        self.assertTrue(size==0 or size>=32768)
 
-            bad_size_list = [ 1, -1, -32768, -32769, -32767, -40000, 32767, 32766]
-            for bad_size in bad_size_list:
-                self.assertRaises(ValueError, thread.stack_size, bad_size)
+        bad_size_list = [ 1, -1, -32768, -32769, -32767, -40000, 32767, 32766]
+        for bad_size in bad_size_list:
+            self.assertRaises(ValueError, thread.stack_size, bad_size)
 
-            good_size_list = [4096*10, 4096*100, 4096*1000, 4096*10000]
-            for good_size in good_size_list:
-                #CodePlex Work Item 7827
-                if is_cli and good_size<=50000: print("Ignoring", good_size, "for CLI"); continue
-                temp = thread.stack_size(good_size)
-                self.assertTrue(temp>=32768 or temp==0)
-
-            def temp(): pass
-            thread.start_new_thread(temp, ())
-            temp = thread.stack_size(1024*1024)
+        good_size_list = [4096*10, 4096*100, 4096*1000, 4096*10000]
+        for good_size in good_size_list:
+            temp = thread.stack_size(good_size)
             self.assertTrue(temp>=32768 or temp==0)
+
+        def temp(): pass
+        thread.start_new_thread(temp, ())
+        temp = thread.stack_size(1024*1024)
+        self.assertTrue(temp>=32768 or temp==0)
 
     @skipUnlessIronPython()
     def test_new_thread_is_background(self):

--- a/Tests/modules/system_related/test_time.py
+++ b/Tests/modules/system_related/test_time.py
@@ -3,11 +3,10 @@
 # See the LICENSE file in the project root for more information.
 
 import time
-import unittest
 
-from iptest import is_cli, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, run_test
 
-class TimeTest(unittest.TestCase):
+class TimeTest(IronPythonTestCase):
     def test_strftime(self):
         t = time.localtime()
         x = time.strftime('%x %X', t)

--- a/Tests/modules/type_related/test__struct.py
+++ b/Tests/modules/type_related/test__struct.py
@@ -4,7 +4,6 @@
 
 import _struct
 import sys
-import unittest
 
 from iptest import IronPythonTestCase, is_64, is_cli, is_cpython, run_test
 

--- a/Tests/modules/type_related/test_array.py
+++ b/Tests/modules/type_related/test_array.py
@@ -8,11 +8,10 @@ Tests for CPython's array module.
 
 import array
 import sys
-import unittest
 
-from iptest import is_cli, is_mono, big, run_test
+from iptest import IronPythonTestCase, is_cli, is_mono, big, run_test
 
-class ArrayTest(unittest.TestCase):
+class ArrayTest(IronPythonTestCase):
     def test_ArrayType(self):
         self.assertEqual(array.ArrayType,
                 array.array)
@@ -458,12 +457,12 @@ class ArrayTest(unittest.TestCase):
                         ('l', b"\x12\x34\x45\x67") : "array('l', [1732588562])",
                         ('L', b"\x12\x34\x45\x67") : "array('L', [1732588562])",
                     }
-        if not is_cli: #https://github.com/IronLanguages/main/issues/861
-            test_cases[('d', b"\x12\x34\x45\x67\x12\x34\x45\x67")] = "array('d', [2.95224853258877e+189])"
-            test_cases[('f', b"\x12\x34\x45\x67")] = "array('f', [9.312667248538457e+23])"
-        else:
+        if is_cli: # https://github.com/IronLanguages/ironpython2/issues/102
             test_cases[('d', b"\x12\x34\x45\x67\x12\x34\x45\x67")] = "array('d', [2.9522485325887698e+189])"
             test_cases[('f', b"\x12\x34\x45\x67")] = "array('f', [9.3126672485384569e+23])"
+        else:
+            test_cases[('d', b"\x12\x34\x45\x67\x12\x34\x45\x67")] = "array('d', [2.95224853258877e+189])"
+            test_cases[('f', b"\x12\x34\x45\x67")] = "array('f', [9.312667248538457e+23])"
 
         for key in test_cases.keys():
             type_code, param = key

--- a/Tests/test_array.py
+++ b/Tests/test_array.py
@@ -6,16 +6,14 @@
 ## Test array support by IronPython (System.Array)
 ##
 
-import unittest
-
-from iptest import IronPythonTestCase, is_cli, is_posix, run_test
+from iptest import IronPythonTestCase, is_cli, run_test, skipUnlessIronPython
 
 if is_cli:
     import System
 
+@skipUnlessIronPython()
 class ArrayTest(IronPythonTestCase):
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_sanity(self):
         # 1-dimension array
         array1 = System.Array.CreateInstance(int, 2)
@@ -77,7 +75,6 @@ class ArrayTest(IronPythonTestCase):
             self.assertEqual([x for x in f(array1, 0)], [])
             self.assertEqual([x for x in f(array1, -10)], [])
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_invalid_index(self):
         ## types and messages follow memoryview behaviour
         rank3array = System.Array.CreateInstance(object, 2, 2, 2)
@@ -133,7 +130,6 @@ class ArrayTest(IronPythonTestCase):
         def f4(): rank3array[0, 0, -3] = 0
         self.assertRaisesMessage(IndexError, "index out of range: -3", f4)
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_slice(self):
         array1 = System.Array.CreateInstance(int, 20)
         for i in range(20): array1[i] = i * i
@@ -150,7 +146,6 @@ class ArrayTest(IronPythonTestCase):
         def f(): array1[::2] = [x * 2 for x in range(11)]
         self.assertRaises(ValueError, f)
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_creation(self):
         t = System.Array
         ti = type(System.Array.CreateInstance(int, 1))
@@ -161,7 +156,6 @@ class ArrayTest(IronPythonTestCase):
             t.Reverse(x)
             self.assertEqual([i for i in x], [2, 1])
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_constructor(self):
         array1 = System.Array[int](10)
         array2 = System.Array.CreateInstance(System.Int32, 10)
@@ -177,7 +171,6 @@ class ArrayTest(IronPythonTestCase):
             for y in range(array3.GetLength(1)):
                 self.assertEquals(array3[x, y], 0)
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_nonzero_lowerbound(self):
         a = System.Array.CreateInstance(int, (5,), (5,))
         for i in range(5): a[i] = i
@@ -225,7 +218,6 @@ class ArrayTest(IronPythonTestCase):
         self.assertRaises(NotImplementedError, sliceArrayAssign, a, -200, 1)
         self.assertRaises(NotImplementedError, sliceArrayAssign, a, 1, 1)
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_array_type(self):
 
         def type_helper(array_type, instance):
@@ -282,7 +274,6 @@ class ArrayTest(IronPythonTestCase):
         type_helper(str, " ")
         type_helper(str, "abc")
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
     def test_tuple_indexer(self):
         array1 = System.Array.CreateInstance(int, 20, 20)
         array1[0,0] = 5

--- a/Tests/test_attrinjector.py
+++ b/Tests/test_attrinjector.py
@@ -2,12 +2,9 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import sys
-import unittest
+from iptest import IronPythonTestCase, run_test, skipUnlessIronPython
 
-from iptest import IronPythonTestCase, is_cli, run_test
-
-@unittest.skipUnless(is_cli, 'IronPython specific test')
+@skipUnlessIronPython()
 class AttrInjectorTestCase(IronPythonTestCase):
     def setUp(self):
         super(AttrInjectorTestCase, self).setUp()
@@ -31,10 +28,10 @@ class AttrInjectorTestCase(IronPythonTestCase):
 
     def operator_test(self, a):
         self.assertEqual(a.doesnotexist, 42)
-        
+
         # GetBoundMember shouldn't be called for pre-existing attributes, and we verify the name we got before.
         self.assertEqual(a.Name, 'doesnotexist')
-        
+
         # SetMember should be called for sets
         a.somethingelse = 123
         self.assertEqual(a.Name, 'somethingelse')

--- a/Tests/test_bool.py
+++ b/Tests/test_bool.py
@@ -2,11 +2,9 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import unittest
+from iptest import big, myint, run_test, skipUnlessIronPython
 
-from iptest import is_cli, big, myint, run_test
-
-class BoolTest(unittest.TestCase):
+class BoolTest(IronPythonTestCase):
     def test_types(self):
         for x in [str, int, float, bool]:
             if not x:
@@ -48,11 +46,11 @@ class BoolTest(unittest.TestCase):
         self.assertRaises(ZeroDivisionError, divmod, True,  False)
         self.assertRaises(ZeroDivisionError, divmod, False, False)
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_decimal(self):
         import System
         if not System.Decimal:
-            Fail("should be true: %r", System.Decimal)
+            self.fail("should be true: %r", System.Decimal)
 
         self.assertEqual(bool(System.Decimal(0)), False)
         self.assertEqual(bool(System.Decimal(1)), True)

--- a/Tests/test_bool.py
+++ b/Tests/test_bool.py
@@ -2,7 +2,7 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-from iptest import big, myint, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, big, myint, run_test, skipUnlessIronPython
 
 class BoolTest(IronPythonTestCase):
     def test_types(self):

--- a/Tests/test_builtinfunc.py
+++ b/Tests/test_builtinfunc.py
@@ -858,7 +858,7 @@ class BuiltinsTest2(IronPythonTestCase):
         self.assertEqualAndCheckType(round(111111111111111111111111111250, -2), 111111111111111111111111111200, int)
         self.assertEqualAndCheckType(round(111111111111111111111111111251, -2), 111111111111111111111111111300, int)
 
-        if is_cli:
+        if is_cli: # blocking with CPython
             self.assertEqualAndCheckType(round(111111111111111111111111111111, -111111111111111111111111111111), 0, int)
             self.assertEqualAndCheckType(round(-111111111111111111111111111111, -111111111111111111111111111111), 0, int)
 
@@ -946,9 +946,9 @@ class BuiltinsTest2(IronPythonTestCase):
         actual = round(float('nan'), -354250895282439122322875506826024599142533926918074193061745122574500)
         self.assertTrue(math.isnan(actual))
 
-        self.assertEqual(round(3.55, self.IntIndex(1)), 3.6 if is_cli else 3.5)
+        self.assertEqual(round(3.55, self.IntIndex(1)), 3.6 if is_cli else 3.5) # https://github.com/IronLanguages/ironpython2/issues/517
         self.assertEqual(round(35, self.IntIndex(-1)), 40)
-        self.assertEqual(round(35.555, self.LongIndex(2)), 35.56 if is_cli else 35.55)
+        self.assertEqual(round(35.555, self.LongIndex(2)), 35.56 if is_cli else 35.55) # https://github.com/IronLanguages/ironpython2/issues/517
         self.assertEqual(round(355, self.LongIndex(-2)), 400)
 
         try:

--- a/Tests/test_bytes.py
+++ b/Tests/test_bytes.py
@@ -9,7 +9,7 @@ import sys
 import unittest
 import warnings
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, myint, myfloat, mycomplex, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cpython, myint, myfloat, mycomplex, run_test, skipUnlessIronPython
 
 types = [bytearray, bytes]
 
@@ -140,7 +140,7 @@ class BytesTest(IronPythonTestCase):
 
         del test_hint_called
 
-    @unittest.skipUnless(is_cli, "Interop with CLI")
+    @skipUnlessIronPython()
     def test_init_interop(self):
         import clr
         clr.AddReference("System.Memory")
@@ -547,7 +547,7 @@ class BytesTest(IronPythonTestCase):
                 [-1, -1, -1, -1, 1, 1, -1, 1, 1, 1, 1, 1], # start = 1
                 [-1, -1, -1, -1, -1, 2, -1, -1, 2, 2, 2, 2], # start = 2
                 [-1, -1, -1, -1, -1, -1, -1, -1, -1, 3, 3, 3], # start = 3
-                [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1], # start = 4                
+                [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1], # start = 4
             ]
             seq = testType(b"abc")
             for start in range(-5, 5):

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -7,7 +7,7 @@ import os
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_mono, myint, big, run_test
+from iptest import IronPythonTestCase, is_cli, is_mono, myint, big, run_test, skipUnlessIronPython
 
 GETATTRIBUTE_CALLED = False
 
@@ -37,7 +37,7 @@ class ClassTest(IronPythonTestCase):
             # Non-existent attribute
             self.assertRaises(AttributeError, i.__getattribute__, "foo")
 
-            if is_cli and not i: # !!! Need to expose __reduce__ on all types
+            if not i: # !!! Need to expose __reduce__ on all types
                 self.assertRaises(TypeError, i.__reduce__)
                 self.assertRaises(TypeError, i.__reduce_ex__)
 
@@ -45,8 +45,6 @@ class ClassTest(IronPythonTestCase):
             self.assertEqual(hash(i), i.__hash__())
 
         for i in builtin_types:
-            if is_cli and i == type(None):
-                continue
             # __init__ and __new__ are implemented by IronPython.Runtime.Operations.InstanceOps
             # We do repr to ensure that we can map back the functions properly
             repr(getattr(i, "__init__"))
@@ -1202,7 +1200,7 @@ class ClassTest(IronPythonTestCase):
         self.assertEqual(hasattr(B, 'c'), True)
 
         # slots & metaclass
-        if is_cli:          # INCOMPATBILE: __slots__ not supported for subtype of type
+        if is_cli:          # INCOMPATIBLE: __slots__ not supported for subtype of type
             class foo(type):
                 __slots__ = ['abc']
 
@@ -1265,8 +1263,8 @@ class ClassTest(IronPythonTestCase):
         # weird case, including __weakref__ and __dict__ and we allow
         # a subtype to inherit from both
 
-        if is_cli: types = [object, dict, tuple]    # INCOMPATBILE: __slots__ not supported for tuple
-        else: types = [object,dict]
+        if is_cli: types = [object, dict, tuple]    # INCOMPATIBLE: __slots__ not supported for tuple
+        else: types = [object, dict]
 
         for x in types:
             class A(x):
@@ -1703,7 +1701,7 @@ class ClassTest(IronPythonTestCase):
             with self.assertRaises(AttributeError):
                 prop.__doc__ = 'abc'
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_override_mro(self):
         with self.assertRaises(NotImplementedError):
             class C(object):

--- a/Tests/test_cliclass.py
+++ b/Tests/test_cliclass.py
@@ -1804,7 +1804,7 @@ if not hasattr(A, 'Rank'):
         finally:
             os.unlink(fname)
 
-    @unittest.skipIf(is_netcoreapp, "TODO: figure out")
+    @unittest.skipIf(is_netcoreapp, "https://github.com/IronLanguages/ironpython2/issues/810")
     def test_extension_methods(self):
         import clr, imp, os
         if is_netcoreapp:

--- a/Tests/test_clrexception.py
+++ b/Tests/test_clrexception.py
@@ -2,11 +2,10 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import unittest
-from iptest import skipUnlessIronPython, is_netcoreapp, is_cli, run_test
+from iptest import IronPythonTestCase, is_netcoreapp, run_test, skipUnlessIronPython
 
 @skipUnlessIronPython()
-class ClrExceptionTest(unittest.TestCase):
+class ClrExceptionTest(IronPythonTestCase):
 
     def clr_to_py_positive(self, clrExcep, pyExcep, excepMsg = None, msg = "CLR exception not mapped to specified Python exception"):
         try:

--- a/Tests/test_clrload.py
+++ b/Tests/test_clrload.py
@@ -225,6 +225,7 @@ class ClrLoadTest(IronPythonTestCase):
         copyfile(test1_dll, test1_dll_along_with_ipy)
 
     #TODO: @skip("multiple_execute")
+    @unittest.skipIf(is_mono, "mono may have a bug here...need to investigate https://github.com/IronLanguages/main/issues/1595")
     def test_assembly_resolve_isolation(self):
         import clr, os
         clr.AddReference("IronPython")

--- a/Tests/test_clrload.py
+++ b/Tests/test_clrload.py
@@ -6,7 +6,7 @@ import os
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_netcoreapp, is_netcoreapp21, is_mono, is_osx, is_posix, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_netcoreapp, is_netcoreapp21, is_mono, is_osx, is_posix, run_test, skipUnlessIronPython
 from shutil import copyfile
 
 @skipUnlessIronPython()
@@ -25,11 +25,11 @@ class ClrLoadTest(IronPythonTestCase):
 
     def test_negative_assembly_names(self):
         import clr
-        self.assertRaises(IOError, clr.AddReferenceToFileAndPath, os.path.join(self.test_dir, 'this_file_does_not_exist.dll'))
-        self.assertRaises(IOError, clr.AddReferenceToFileAndPath, os.path.join(self.test_dir, 'this_file_does_not_exist.dll'))
-        self.assertRaises(IOError, clr.AddReferenceToFileAndPath, os.path.join(self.test_dir, 'this_file_does_not_exist.dll'))
-        self.assertRaises(IOError, clr.AddReferenceByName, 'bad assembly name', 'WellFormed.But.Nonexistent, Version=9.9.9.9, Culture=neutral, PublicKeyToken=deadbeefdeadbeef, processorArchitecture=6502')
-        self.assertRaises(FileNotFoundError if is_netcoreapp21 else IOError, clr.AddReference, 'this_assembly_does_not_exist_neither_by_file_name_nor_by_strong_name')
+        self.assertRaises(OSError, clr.AddReferenceToFileAndPath, os.path.join(self.test_dir, 'this_file_does_not_exist.dll'))
+        self.assertRaises(OSError, clr.AddReferenceToFileAndPath, os.path.join(self.test_dir, 'this_file_does_not_exist.dll'))
+        self.assertRaises(OSError, clr.AddReferenceToFileAndPath, os.path.join(self.test_dir, 'this_file_does_not_exist.dll'))
+        self.assertRaises(FileNotFoundError, clr.AddReferenceByName, 'bad assembly name', 'WellFormed.But.Nonexistent, Version=9.9.9.9, Culture=neutral, PublicKeyToken=deadbeefdeadbeef, processorArchitecture=6502')
+        self.assertRaises(FileNotFoundError if is_netcoreapp21 else OSError, clr.AddReference, 'this_assembly_does_not_exist_neither_by_file_name_nor_by_strong_name')
 
         self.assertRaises(TypeError, clr.AddReference, 35)
 
@@ -225,8 +225,6 @@ class ClrLoadTest(IronPythonTestCase):
         copyfile(test1_dll, test1_dll_along_with_ipy)
 
     #TODO: @skip("multiple_execute")
-    @unittest.skipIf(is_mono, "mono may have a bug here...need to investigate https://github.com/IronLanguages/main/issues/1595")
-    @unittest.skipIf(is_netcoreapp, "TODO: figure out")
     def test_assembly_resolve_isolation(self):
         import clr, os
         clr.AddReference("IronPython")
@@ -389,7 +387,6 @@ result = Test()
         self.assertRaises(AttributeError, f)
 
     #TODO:@skip("multiple_execute")
-    @unittest.skipIf(is_netcoreapp, "TODO: figure out")
     def test_namespaceimport(self):
         import clr
         tmp = self.temporary_dir
@@ -443,7 +440,7 @@ result = Test()
         start = 0; end = 1
         while before[start] == after[start]: start += 1
         while before[-end] == after[-end]: end += 1
-        end -= 1;
+        end -= 1
 
         # what remains is an int - number of assemblies loaded.
         # The integer must have increased value by 1

--- a/Tests/test_clrload2.py
+++ b/Tests/test_clrload2.py
@@ -3,9 +3,8 @@
 # See the LICENSE file in the project root for more information.
 
 import sys
-import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_netcoreapp, is_mono, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_netcoreapp, is_mono, run_test, skipUnlessIronPython
 
 @skipUnlessIronPython()
 class ClrLoad2Test(IronPythonTestCase):
@@ -21,32 +20,32 @@ class ClrLoad2Test(IronPythonTestCase):
             UseCLI.Form().Controls.Add(UseCLI.Control())
 
         nc = UseCLI.NestedClass()
-        
+
         ic = UseCLI.NestedClass.InnerClass()
-        
+
         tc = UseCLI.NestedClass.InnerClass.TripleNested()
-        
+
         # This will use TypeCollision
         gc1 = UseCLI.NestedClass.InnerGenericClass[int]()
         gc2 = UseCLI.NestedClass.InnerGenericClass[int, int]()
-        
+
         # access methods, fields, and properties on the class w/ nesteds,
         # the nested class, and the triple nested class
         for x in ((nc, ''), (ic, 'Inner'), (tc, 'Triple'), (gc1, "InnerGeneric"), (gc2, "InnerGeneric")):
             obj, name = x[0], x[1]
-            
+
             self.assertEqual(getattr(obj, 'CallMe' + name)(), name + ' Hello World')
-            
+
             self.assertEqual(getattr(obj, name+'Field'), None)
-            
+
             self.assertEqual(getattr(obj, name+'Property'), None)
-            
+
             setattr(obj, name+'Property', name)
-            
+
             self.assertEqual(getattr(obj, name+'Field'), name)
-            
+
             self.assertEqual(getattr(obj, name+'Property'), name)
 
         sys.path = [x for x in old_path]
-        
+
 run_test(__name__)

--- a/Tests/test_clruse.py
+++ b/Tests/test_clruse.py
@@ -11,10 +11,9 @@ TODO:
 '''
 
 import os
-import sys
 import unittest
 
-from iptest import is_cli, stdout_trapper, path_modifier, run_test
+from iptest import IronPythonTestCase, stdout_trapper, path_modifier, run_test, skipUnlessIronPython
 
 #------------------------------------------------------------------------------
 #--GLOBALS
@@ -44,27 +43,27 @@ else:
 #--HELPERS
 SIMPLE_TEST_COUNT = 0
 
-@unittest.skipUnless(is_cli, 'IronPython specific test case')
-class ClrUseTest(unittest.TestCase):
+@skipUnlessIronPython()
+class ClrUseTest(IronPythonTestCase):
     def simpleTester(self, a, b, c):
         global SIMPLE_TEST_COUNT
 
         import clr
-        
+
         test_name = "clrusetest{}.py".format(SIMPLE_TEST_COUNT)
         SIMPLE_TEST_COUNT += 1
         expected_stdout = '''OK...'''
-        
+
         #create the file
         test_text = SIMPLE_TEST % (str(a), str(c))
         with open(test_name, "w") as f:
             f.writelines(test_text)
-        
+
         try:
             with path_modifier('.') as p:
                 with stdout_trapper() as output:
                     new_module = clr.Use(test_name.split(".py")[0])
-            
+
             #run a few easy checks
             self.assertEqual(len(output.messages), 3)
             self.assertEqual(output.messages[0], expected_stdout)
@@ -79,7 +78,7 @@ class ClrUseTest(unittest.TestCase):
             self.assertEqual(new_module.K.NewMember, 33)
             new_module.K = None
             self.assertEqual(new_module.K, None)
-            
+
             #negative checks
             self.assertRaises(TypeError, new_module.aFunc)
             self.assertRaises(TypeError, new_module.aFunc, 1, 2)
@@ -91,7 +90,7 @@ class ClrUseTest(unittest.TestCase):
                 self.fail("Should never get this far")
             except:
                 pass
-            
+
             #hard test
             real_module = __import__(test_name.split(".py")[0])
             #for key in dir(real_module): self.assertEqual(real_module.__dict__[key], new_module.__dict__[key])
@@ -119,7 +118,7 @@ class ClrUseTest(unittest.TestCase):
             #create the file
             with open(test_name, "w") as f:
                 f.writelines('''A=1; print "First Run"''')
-            
+
             with path_modifier('.') as p:
                 with stdout_trapper() as output:
                     new_module = clr.Use(test_name.split(".py")[0])
@@ -132,7 +131,7 @@ class ClrUseTest(unittest.TestCase):
             #recreate the file
             with open(test_name, "w") as f:
                 f.writelines('''A=2; print "Second Run"''')
-            
+
             with path_modifier('.') as p:
                 with stdout_trapper() as output:
                     new_module = clr.Use(test_name.split(".py")[0])
@@ -145,5 +144,5 @@ class ClrUseTest(unittest.TestCase):
             try:
                 os.remove(test_name)
             except: pass
-        
+
 run_test(__name__)

--- a/Tests/test_codecs.py
+++ b/Tests/test_codecs.py
@@ -6,10 +6,9 @@
 ## Test codecs, in addition to test_codecs from StdLib and from modules/io_related
 ##
 
-import unittest
 import codecs
 
-from iptest import run_test, is_cli
+from iptest import IronPythonTestCase, is_cli, run_test, skipUnlessIronPython
 
 if is_cli:
     import clr
@@ -17,9 +16,9 @@ if is_cli:
     import System.Text
     clr.AddReference("System.Memory")
 
-class CodecsTest(unittest.TestCase):
+class CodecsTest(IronPythonTestCase):
 
-    @unittest.skipUnless(is_cli, "Interop with CLI")
+    @skipUnlessIronPython()
     def test_interop_ascii(self):
         self.assertEqual("abc".encode(System.Text.Encoding.ASCII), b"abc")
         self.assertEqual(b"abc".decode(System.Text.Encoding.ASCII), "abc")
@@ -108,7 +107,7 @@ class CodecsTest(unittest.TestCase):
         self.assertEqual("abć".encode('utf_32_be'), b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07")
         self.assertEqual(b"\x00\x00\x00a\x00\x00\x00b\x00\x00\x01\x07".decode('utf_32_be'), "abć")
 
-    @unittest.skipUnless(is_cli, "Interop with CLI")
+    @skipUnlessIronPython()
     def test_interop_array(self):
         arr = System.Array[System.Byte](b"abc")
         ars = System.ArraySegment[System.Byte](arr)

--- a/Tests/test_dict.py
+++ b/Tests/test_dict.py
@@ -9,7 +9,6 @@ x = dir(dict.fromkeys)
 
 import collections
 import os
-import unittest
 import sys
 
 from iptest import IronPythonTestCase, is_cli, big, path_modifier, run_test, skipUnlessIronPython, source_root

--- a/Tests/test_dlrkwarg.py
+++ b/Tests/test_dlrkwarg.py
@@ -2,16 +2,13 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import unittest
-
-from iptest import IronPythonTestCase, is_cli, is_mono, is_netcoreapp, is_posix, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, run_test, skipUnlessIronPython
 
 if is_cli:
     import System
     from iptest.ipunittest import load_ironpython_test
     load_ironpython_test()
     from IronPythonTest import DefaultParams, Variadics
-
 
 @skipUnlessIronPython()
 class DlrKwargTest(IronPythonTestCase):

--- a/Tests/test_doc.py
+++ b/Tests/test_doc.py
@@ -4,8 +4,6 @@
 
 "module doc"
 
-import unittest
-
 from iptest import IronPythonTestCase, is_cli, path_modifier, retryOnFailure, run_test, skipUnlessIronPython
 
 class DocTest(IronPythonTestCase):

--- a/Tests/test_file.py
+++ b/Tests/test_file.py
@@ -9,7 +9,7 @@ import _thread
 
 CP16623_LOCK = _thread.allocate_lock()
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, is_netcoreapp, is_posix, run_test
+from iptest import IronPythonTestCase, is_cli, is_cpython, is_netcoreapp, is_posix, run_test, skipUnlessIronPython
 
 class FileTest(IronPythonTestCase):
 
@@ -133,7 +133,7 @@ class FileTest(IronPythonTestCase):
 
         self.assertEqual(data, 'a2\xa33\\u0163\x0f\x0fF\t\\\x0fF\x0fE\x00\x01\x7F\x7E\x80')
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_cp27179(self):
         # write() accepting Array[Byte]
         from System import Array, Byte
@@ -464,7 +464,7 @@ class FileTest(IronPythonTestCase):
             else:
                 f.write('\u6211')
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_net_stream(self):
         import System
         fs = System.IO.FileStream(self.temp_file, System.IO.FileMode.Create, System.IO.FileAccess.Write, System.IO.FileShare.ReadWrite)

--- a/Tests/test_generator.py
+++ b/Tests/test_generator.py
@@ -2,9 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import sys
-import unittest
-
 from iptest import IronPythonTestCase, is_cli, run_test
 
 def ifilter(iterable):
@@ -39,14 +36,14 @@ class GeneratorTest(IronPythonTestCase):
         self.assertEqual(list((i,j) for i in range(2) for j in range(3)), [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)])
         self.assertEqual(list((i,j) for i in range(2) for j in range(i+1)), [(0, 0), (1, 0), (1, 1)])
         self.assertEqual([x for x, in [(1,)]], [1])
-        
+
         i = 10
         self.assertEqual(sum(i+i for i in range(1000) if i < 50), 2450)
         self.assertEqual(i, 10)
-        
+
         g = (i+i for i in range(10))
         self.assertEqual(list(g), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18])
-        
+
         g = (i+i for i in range(3))
         self.assertEqual(next(g), 0)
         self.assertEqual(next(g), 2)
@@ -55,17 +52,17 @@ class GeneratorTest(IronPythonTestCase):
         self.assertRaises(StopIteration, g.__next__)
         self.assertRaises(StopIteration, g.__next__)
         self.assertEqual(list(g), [])
-        
+
         def f(n):
             return (i+i for i in range(n) if i < 50)
-        
+
         self.assertEqual(sum(f(100)), 2450)
         self.assertEqual(list(f(10)), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18])
         self.assertEqual(sum(f(10)), 90)
-        
+
         def f(n):
             return ((i,j) for i in range(n) for j in range(i))
-        
+
         self.assertEqual(list(f(3)), [(1, 0), (2, 0), (2, 1)])
 
 
@@ -77,18 +74,18 @@ class GeneratorTest(IronPythonTestCase):
                     yield j
             for i in range(10):
                 yield (i, innergen())
-        
+
         for a,b in outergen():
             self.assertEqual(a, next(b))
             self.assertEqual(list(range(a)), list(b))
-        
-        
+
+
         def f():
             yield "Import inside generator"
-        
+
         self.assertEqual(next(f()), "Import inside generator")
-        
-        
+
+
         def xgen():
             try:
                 yield 1
@@ -96,10 +93,10 @@ class GeneratorTest(IronPythonTestCase):
                 pass
             else:
                 yield 2
-        
+
         self.assertEqual([ i for i in xgen()], [1,2])
-        
-        
+
+
         def xgen2(x):
             yield "first"
             try:
@@ -118,17 +115,17 @@ class GeneratorTest(IronPythonTestCase):
                 yield "else"
                 yield "else 2"
             yield "last"
-        
+
         def testxgen2(x, r):
             self.assertEqual(list(xgen2(x)), r)
-        
+
         testxgen2(0, ['first', 'try', 'exc', 'exc 2', 'last'])
         testxgen2(1, ['first', 'try', 'try 2', 'else', 'else 2', 'last'])
         testxgen2(2, ['first', 'try', 'try 2', 'else', 'else 2', 'last'])
         testxgen2(3, ['first', 'try', 'try 2', 'else', 'else 2', 'last'])
         testxgen2(4, ['first', 'try', 'error', 'error 2', 'last'])
-        
-        
+
+
         def xgen3():
             yield "first"
             try:
@@ -137,9 +134,9 @@ class GeneratorTest(IronPythonTestCase):
                 yield "fin"
                 yield "fin 2"
             yield "last"
-        
+
         self.assertEqual(list(xgen3()), ['first', 'fin', 'fin 2', 'last'])
-        
+
         self.assertEqual(type(xgen), type(xgen2))
         self.assertEqual(type(ifilter), type(xgen3))
 
@@ -148,17 +145,17 @@ class GeneratorTest(IronPythonTestCase):
             def g():
                 def xx():
                     return x
-        
+
                 def yy():
                     return y
-        
+
                 def zz():
                     return z
-        
+
                 def ii():
                     return i
-        
-        
+
+
                 yield xx()
                 yield yy()
                 yield zz()
@@ -167,9 +164,9 @@ class GeneratorTest(IronPythonTestCase):
             x = 1
             y = 2
             z = 3
-        
+
             return g()
-        
+
         self.assertEqual(list(f()), [1, 2, 3, 11, 12, 13])
 
     def test_generator_finally(self):
@@ -180,13 +177,13 @@ class GeneratorTest(IronPythonTestCase):
                 yield 1
                 yield 2
                 yield 3
-        
+
         n = yield_in_finally_w_exception()
         self.assertEqual(next(n), 1)
         self.assertEqual(next(n), 2)
         self.assertEqual(next(n), 3)
         self.assertRaises(ZeroDivisionError, n.__next__)
-        
+
         def yield_in_finally_w_exception_2():
             try:
                 1/0
@@ -195,16 +192,16 @@ class GeneratorTest(IronPythonTestCase):
                 yield 2
                 raise AssertionError()
                 yield 3
-        
+
         n = yield_in_finally_w_exception_2()
         self.assertEqual(next(n), 1)
         self.assertEqual(next(n), 2)
         self.assertRaises(AssertionError, n.__next__)
-        
+
         def test_generator_exp():
             l = ((1,2),(3, 4))
             return (x for x,y in l)
-        
+
         self.assertEqual(list(test_generator_exp()), [1, 3])
 
 
@@ -256,9 +253,9 @@ class GeneratorTest(IronPythonTestCase):
                     yield 28
                 yield 29
             yield 33
-        
+
         self.assertEqual(list(nested_yield_1()), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 30, 23, 24, 25, 26, 27, 28, 29, 33])
-        
+
         def nested_yield_2():
             try:
                 pass
@@ -281,9 +278,9 @@ class GeneratorTest(IronPythonTestCase):
                 yield 8
                 yield 9
             yield 10
-            
+
         self.assertEqual(list(nested_yield_2()), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-        
+
         def nested_yield_3():
             yield 1
             try:
@@ -306,9 +303,9 @@ class GeneratorTest(IronPythonTestCase):
             except:
                 pass
             yield 9
-        
+
         self.assertEqual(list(nested_yield_3()), [1, 2, 3, 4, 5, 6, 7, 8, 9])
-        
+
         def nested_yield_4():
             yield 1
             try:
@@ -326,7 +323,7 @@ class GeneratorTest(IronPythonTestCase):
             else:
                 raise AssertionError()
             yield 5
-                
+
         self.assertEqual(list(nested_yield_4()), [1, 2, 3, 4, 5])
 
 
@@ -337,9 +334,9 @@ class GeneratorTest(IronPythonTestCase):
             for i in range(size-1):
                 args = args+('a%i, ' % i)
             args = args+('a%i' % (size-1))
-        
+
             func = """
-def fetest(%s):        
+def fetest(%s):
     ret = 0
     for i in range(%i):
         exec('a%%i = a%%i*a%%i' %% (i,i,i))
@@ -349,10 +346,10 @@ def fetest(%s):
             #print func
             d = {'assertEqual':self.assertEqual}
             exec(func, d, d)
-        
+
             args = list(range(size)) if is_cli else [0]*size
             exec("assertEqual(list(fetest(%s)),%s)" % (str(args)[1:-1], str([x*x for x in args])), d, d)
-        
+
         lstate(1)
         lstate(2)
         lstate(4)
@@ -377,27 +374,27 @@ def fetest(%s):
         # do any further execution of the generator. (See codeplex workitem 1402)
         #
         #
-        
-        
+
+
         # 1) Test exiting by normal return
         l=[0, 0]
         def f(l):
             l[0] += 1 # side effect
             yield 'a'
             l[1] += 1  # side effect statement
-        
+
         g=f(l)
         self.assertTrue(next(g) == 'a')
         self.assertTrue(l == [1,0]) # should not have executed past yield
         self.assertRaises(StopIteration, g.__next__)
         self.assertTrue(l == [1,1]) # now should have executed
-        
+
         # Generator is now closed, future calls should just keep throwing
         self.assertRaises(StopIteration, g.__next__)
         self.assertTrue(l == [1,1]) # verify that we didn't execute any more statements
-        
-        
-        
+
+
+
         # 2) Now test with exiting via StopIteration exception
         l = [0,0]
         def f(l):
@@ -405,47 +402,47 @@ def fetest(%s):
             l[0] += 1
             raise StopIteration
             l[1] += 1
-        
+
         g=f(l)
         self.assertTrue(next(g) == 'c')
         self.assertTrue(l == [0,0])
         self.assertRaises(StopIteration, g.__next__)
         self.assertTrue(l == [1,0])
-        
+
         # generator is now closed from unhandled exception. Future calls should throw StopIteration
         self.assertRaises(StopIteration, g.__next__)
         self.assertTrue(l == [1,0]) # verify that we didn't execute any more statements
-        
+
         # repeat enumeration in a comprehension.
         # This tests that StopIteration is properly caught and gracefully terminates the generator.
         l=[0,0]
         self.assertEqual([x for x in f(l)], ['c'])
         self.assertEqual(l,[1,0])
-        
-        
-        
+
+
+
         # 3) Now test with exiting via throwing an unhandled exception
         class MyError(Exception):
             pass
-        
+
         l=[0, 0]
         def f(l):
             l[0] += 1 # side effect
             yield 'b'
             l[1] += 1  # side effect statement
             raise MyError
-        
+
         g=f(l)
         self.assertTrue(next(g) == 'b')
         self.assertTrue(l == [1,0])
         self.assertRaises(MyError, g.__next__)
         self.assertTrue(l == [1,1])
-        
+
         # generator is now closed from unhandled exception. Future calls should throw StopIteration
         self.assertRaises(StopIteration, g.__next__)
         self.assertTrue(l == [1,1]) # verify that we didn't execute any more statements
-        
-        
+
+
         # repeat enumeration in a comprehension. Unlike case 2, this now fails since the exception
         # is MyError instead of StopIteration
         l=[0,0]
@@ -458,7 +455,7 @@ def fetest(%s):
         def f():
             yield ()
         self.assertEqual(list(f()), [()])
-    
+
     def test_generator_reentrancy(self):
         # Test that generator can't be called re-entrantly. This is explicitly called out in Pep 255.
         # Any operation should throw a ValueError if called.
@@ -471,7 +468,7 @@ def fetest(%s):
             # try again, should still throw
             me.send(None)
             self.assertTrue(False) # unreachable!
-        
+
         me = f()
         self.assertEqual(next(me), 7)
         # Generator should still be alive
@@ -482,7 +479,7 @@ def fetest(%s):
 
     def test_generator_expr_in(self):
         self.assertEqual('abc' in (x for x in ('abc', )), True)
-        
+
         def f(): yield 2
 
         self.assertEqual(2 in f(), True)
@@ -492,25 +489,25 @@ def fetest(%s):
         if not is_cli: expectedAttributes += ['__del__']
         expectedAttributes.sort()
         def f(): yield 2
-        
+
         got = set(dir(f())) - set(dir(object))
         got = list(got)
         got.sort()
         self.assertEqual(got, expectedAttributes)
-        
+
         temp_gen = f()
         self.assertEqual(f.__code__, temp_gen.gi_code)
-    
+
     def test_cp24031(self):
         def f(*args):
             return args
-        
+
         self.assertEqual(f(*(x for x in range(2))),
                 (0, 1))
-        
+
         class KNew(object):
             pass
-        
+
         self.assertRaisesMessage(TypeError, "object() takes no parameters",
                             lambda: KNew(*(i for i in range(10))) != None)
 

--- a/Tests/test_genericmeth.py
+++ b/Tests/test_genericmeth.py
@@ -3,9 +3,8 @@
 # See the LICENSE file in the project root for more information.
 
 import os
-import unittest
 
-from iptest import IronPythonTestCase, is_cli, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, run_test, skipUnlessIronPython
 
 @skipUnlessIronPython()
 class GenericMethTest(IronPythonTestCase):
@@ -43,22 +42,22 @@ class GenericMethTest(IronPythonTestCase):
             'InstMeth(self: GenMeth) -> str',
             'InstMeth(self: GenMeth, arg1: Int32) -> str',
             'InstMeth(self: GenMeth, arg1: str) -> str']) + os.linesep
-            
+
         self.assertDocEqual(gm.InstMeth.__doc__, expected)
 
         # And the same for the static methods.
         expected_static_methods = os.linesep.join([
-                'StaticMeth[T]() -> str' , 
-                'StaticMeth[(T, U)]() -> str' , 
-                'StaticMeth[T](arg1: Int32) -> str' , 
-                'StaticMeth[T](arg1: str) -> str' , 
-                'StaticMeth[(T, U)](arg1: Int32) -> str' , 
-                'StaticMeth[T](arg1: T) -> str' , 
-                'StaticMeth[(T, U)](arg1: T, arg2: U) -> str' , 
-                'StaticMeth() -> str' , 
-                'StaticMeth(arg1: Int32) -> str' , 
+                'StaticMeth[T]() -> str' ,
+                'StaticMeth[(T, U)]() -> str' ,
+                'StaticMeth[T](arg1: Int32) -> str' ,
+                'StaticMeth[T](arg1: str) -> str' ,
+                'StaticMeth[(T, U)](arg1: Int32) -> str' ,
+                'StaticMeth[T](arg1: T) -> str' ,
+                'StaticMeth[(T, U)](arg1: T, arg2: U) -> str' ,
+                'StaticMeth() -> str' ,
+                'StaticMeth(arg1: Int32) -> str' ,
                 'StaticMeth(arg1: str) -> str']) + os.linesep
-        
+
         self.assertDocEqual(GenMeth.StaticMeth.__doc__, expected_static_methods)
 
         # Check that we bind to the correct method based on type and call arguments for each of our instance methods. We can validate this

--- a/Tests/test_imp.py
+++ b/Tests/test_imp.py
@@ -3,12 +3,11 @@
 # See the LICENSE file in the project root for more information.
 
 import imp
-import operator
 import os
 import sys
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_posix, path_modifier, run_test
+from iptest import IronPythonTestCase, is_cli, is_posix, path_modifier, run_test, skipUnlessIronPython
 import collections
 
 def get_builtins_dict():
@@ -1077,7 +1076,7 @@ class Test(object):
         for x in dir(type(sys)):
             self.assertEqual(mymod.__getattribute__(x), getattr(mymod, x))
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_import_lookup_after(self):
         import os
         try:
@@ -1097,7 +1096,7 @@ sys.modules['y'] = newmod
             os.unlink(_x_mod)
             os.unlink(_y_mod)
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_imp_load_source(self):
         import os
         try:
@@ -1116,13 +1115,13 @@ X = 3.14
         finally:
             os.unlink(_x_mod)
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_imp_load_compiled(self):
         #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=17459
         with self.assertRaises(FileNotFoundError):
             imp.load_compiled("", "")
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_imp_load_dynamic(self):
         #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=17459
         self.assertEqual(imp.load_dynamic, None)
@@ -1240,7 +1239,7 @@ X = 3.14
     def test_import_string_from_list_cp26098(self):
         self.assertEqual(__import__('email.mime.application', globals(), locals(), 'MIMEApplication').__name__, 'email.mime.application')
 
-    @unittest.skipUnless(is_cli, 'IronPython specific test')
+    @skipUnlessIronPython()
     def test_new_builtin_modules(self):
         import clr
         clr.AddReference('IronPythonTest')

--- a/Tests/test_in.py
+++ b/Tests/test_in.py
@@ -2,9 +2,7 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import unittest
-
-from iptest import is_cli, run_test
+from iptest import IronPythonTestCase, is_cli, run_test
 
 if is_cli:
     import clr
@@ -12,15 +10,15 @@ if is_cli:
 class C:
     x = "Hello"
     def __contains__(self, y):
-        return self.x == y;
+        return self.x == y
 
 
 class D:
     x = (1,2,3,4,5,6,7,8,9,10)
     def __getitem__(self, y):
-        return self.x[y];
+        return self.x[y]
 
-class InTest(unittest.TestCase):
+class InTest(IronPythonTestCase):
     def test_basic(self):
         self.assertTrue('abc' in 'abcd')
 

--- a/Tests/test_index.py
+++ b/Tests/test_index.py
@@ -2,9 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import sys
-import unittest
-
 from iptest import IronPythonTestCase, is_cli, run_test, skipUnlessIronPython
 
 class IndexTest(IronPythonTestCase):
@@ -29,7 +26,7 @@ class IndexTest(IronPythonTestCase):
     def test_hashtable(self):
         import clr
         import System
-        hashtables = [System.Collections.Generic.Dictionary[object, object]()]    
+        hashtables = [System.Collections.Generic.Dictionary[object, object]()]
         hashtables.append(System.Collections.Hashtable())
 
         for x in hashtables:
@@ -38,20 +35,20 @@ class IndexTest(IronPythonTestCase):
             x[10,] = "Tuple Int"
             x["String",] = "Tuple String"
             x[2.4,] = "Tuple Double"
-            
+
             self.assertTrue(x["Hi"] == "Hello")
             self.assertTrue(x[1] == "Python")
             self.assertTrue(x[(10,)] == "Tuple Int")
             self.assertTrue(x[("String",)] == "Tuple String")
             self.assertTrue(x[(2.4,)] == "Tuple Double")
-            
+
             success=False
             try:
                 x[1,2] = 10
             except TypeError as e:
                 success=True
             self.assertTrue(success)
-            
+
             x[(1,2)] = "Tuple key in hashtable"
             self.assertTrue(x[1,2,] == "Tuple key in hashtable")
 
@@ -61,12 +58,12 @@ class IndexTest(IronPythonTestCase):
         import System
 
         md = System.Array.CreateInstance(System.Int32, 2, 2, 2)
-        
+
         for i in range(2):
             for j in range(2):
                 for k in range(2):
                     md[i,j,k] = i+j+k
-        
+
         for i in range(2):
             for j in range(2):
                 for k in range(2):
@@ -80,7 +77,7 @@ class IndexTest(IronPythonTestCase):
         # verify that slicing an array returns an array of the proper type
         from System import Array
         data = Array[int]( (2,3,4,5,6) )
-        
+
         self.assertEqual(type(data[:0]), Array[int])
         self.assertEqual(type(data[0:3:2]), Array[int])
 
@@ -90,7 +87,7 @@ class IndexTest(IronPythonTestCase):
         self.assertTrue(d[1,2,3,4,5] == d[(1,2,3,4,5)])
         self.assertTrue(d[1,2,3,4,5] == 12345)
         self.assertTrue(d[(1,2,3,4,5)] == 12345)
-        
+
         d = {None:23}
         del d[None]
         self.assertEqual(d, {})
@@ -99,15 +96,15 @@ class IndexTest(IronPythonTestCase):
     def test_custom_indexable(self):
         from IronPythonTest import Indexable
         i = Indexable()
-        
+
         i[10] = "Hello Integer"
         i["String"] = "Hello String"
         i[2.4] = "Hello Double"
-        
+
         self.assertTrue(i[10] == "Hello Integer")
         self.assertTrue(i["String"] == "Hello String")
         self.assertTrue(i[2.4] == "Hello Double")
-        
+
         indexes = (10, "String", 2.4)
         for a in indexes:
             for b in indexes:
@@ -132,7 +129,7 @@ class IndexTest(IronPythonTestCase):
     def test_multiple_indexes(self):
         from IronPythonTest import MultipleIndexes
         x = MultipleIndexes()
-        
+
         def get_value(*i):
             value = ""
             append = False
@@ -142,13 +139,13 @@ class IndexTest(IronPythonTestCase):
                 value = value + str(v)
                 append = True
             return value
-        
+
         def get_tuple_value(*i):
             return get_value("Indexing as tuple", *i)
-        
+
         def get_none(*i):
             return None
-        
+
         def verify_values(mi, gv, gtv):
             for i in i_idx:
                 self.assertTrue(x[i] == gv(i))
@@ -165,13 +162,13 @@ class IndexTest(IronPythonTestCase):
                             for m in m_idx:
                                 self.assertTrue(x[i,j,k,l,m] == gv(i,j,k,l,m))
                                 self.assertTrue(x[i,j,k,l,m,] == gtv(i,j,k,l,m))
-        
+
         i_idx = ("Hi", 2.5, 34)
         j_idx = (0, "*", "@")
         k_idx = list(range(3))
         l_idx = ("Sun", "Moon", "Star")
         m_idx = ((9,8,7), (6,5,4,3,2), (4,))
-        
+
         for i in i_idx:
             x[i] = get_value(i)
             for j in j_idx:
@@ -182,9 +179,9 @@ class IndexTest(IronPythonTestCase):
                         x[i,j,k,l] = get_value(i,j,k,l)
                         for m in m_idx:
                             x[i,j,k,l,m] = get_value(i,j,k,l,m)
-        
+
         verify_values(x, get_value, get_none)
-        
+
         for i in i_idx:
             x[i,] = get_tuple_value(i)
             for j in j_idx:
@@ -195,7 +192,7 @@ class IndexTest(IronPythonTestCase):
                         x[i,j,k,l,] = get_tuple_value(i,j,k,l)
                         for m in m_idx:
                             x[i,j,k,l,m,] = get_tuple_value(i,j,k,l,m)
-        
+
         verify_values(x, get_value, get_tuple_value)
 
     @skipUnlessIronPython()
@@ -204,7 +201,7 @@ class IndexTest(IronPythonTestCase):
         a = IndexableList()
         for i in range(5):
             result = a.Add(i)
-        
+
         for i in range(5):
             self.assertEqual(a[str(i)], i)
 
@@ -226,7 +223,7 @@ class IndexTest(IronPythonTestCase):
                     return index
                 def __setitem__(self, index, value):
                     self.res = (index, value)
-        
+
             a = foo()
             self.assertEqual(a[1], 1)
             self.assertEqual(a[1,2], (1,2))
@@ -252,12 +249,12 @@ class IndexTest(IronPythonTestCase):
             (dict,{0:2, 3:4, 5:6, 7:8}, 2),
             (str,'abcde', 'a'),
             (tuple, (1,2,3,4,5), 1),]
-            
+
         for testInfo in tests:
             base = testInfo[0]
             arg  = testInfo[1]
             zero = testInfo[2]
-                    
+
             class foo(base):
                 def __getitem__(self, index):
                     if isinstance(index, tuple):
@@ -281,7 +278,7 @@ class IndexTest(IronPythonTestCase):
             self.assertEqual(a[(0,1)], zero)
             a = foo(arg)
             self.assertEqual(a[(0,1,2)], zero)
-            
+
             if hasattr(base, '__setitem__'):
                 a[0] = 'x'
                 self.assertEqual(a[0], 'x')
@@ -296,19 +293,19 @@ class IndexTest(IronPythonTestCase):
                 a[(0,1,2)] = 'z'
                 self.assertEqual(a[(0,1,2)], 'z')
 
-            
+
     def test_getorsetitem_slice(self):
         tests = [  # base type, constructor arg, result of index 0
         (list,(1,2,3,4,5), 1, lambda x: [x]),
             (str,'abcde', 'a', lambda x: x),
             (tuple, (1,2,3,4,5), 1, lambda x: (x,)),]
-        
+
         for testInfo in tests:
             base = testInfo[0]
             arg  = testInfo[1]
             zero = testInfo[2]
             resL = testInfo[3]
-                    
+
             class foo(base):
                 def __getitem__(self, index):
                     if isinstance(index, tuple):
@@ -332,7 +329,7 @@ class IndexTest(IronPythonTestCase):
             self.assertEqual(a[(slice(0,1),slice(1,2))], resL(zero))
             a = foo(arg)
             self.assertEqual(a[(slice(0,1),slice(1,2),slice(2,3))], resL(zero))
-            
+
             if hasattr(base, '__setitem__'):
                 a[0:1] = 'x'
                 self.assertEqual(a[0:1], ['x'])
@@ -394,13 +391,13 @@ class IndexTest(IronPythonTestCase):
                 self.index = index
             def __index__(self):
                 return self.index
-        
+
         for sliceable in [x(list(range(5))) for x in (list, tuple)]:
             self.assertEqual(sliceable[cust_index(0)], 0)
             self.assertEqual(sliceable[cust_index(0)], 0)
             self.assertEqual(list(sliceable[cust_index(0) : cust_index(3)]), [0, 1, 2])
             self.assertEqual(list(sliceable[cust_index(0) : cust_index(3)]), [0, 1, 2])
-        
+
         # dictionary indexing shouldn't be affected
         x = cust_index(42)
         d = {x:3}
@@ -415,7 +412,7 @@ class IndexTest(IronPythonTestCase):
             self.assertEqual(cli_list[cust_index(0)], 0)
             self.assertEqual(list(cli_list[cust_index(0) : cust_index(3)]), list(range(3)))
             self.assertEqual(type(cli_list[cust_index(0) : cust_index(3)]), List[int])
-        
+
     @skipUnlessIronPython()
     def test_csharp_enumeration(self):
         from IronPythonTest import CSharpEnumerable
@@ -431,20 +428,20 @@ class IndexTest(IronPythonTestCase):
         l = []
         self.assertRaisesPartialMessage(TypeError, "'builtin_function_or_method' object is not subscriptable", lambda: l.append[float](1.0))
         self.assertRaisesPartialMessage(TypeError, "'int' object is not subscriptable", lambda: 1[2])
-        
+
     def test_cp19350_index_restrictions(self):
         global keyValue
         class X(object):
             def __setitem__(self, key, value):
                 global keyValue
                 keyValue = key
-        
+
         def f(a, b):
             X()[a, b] = object()
-        
+
         f(1, 2)
         self.assertEqual(keyValue, (1, 2))
-        f('one', 'two') 
+        f('one', 'two')
         self.assertEqual(keyValue, ('one', 'two'))
 
 run_test(__name__)

--- a/Tests/test_iterator.py
+++ b/Tests/test_iterator.py
@@ -3,7 +3,6 @@
 # See the LICENSE file in the project root for more information.
 
 import sys
-import unittest
 
 from iptest import IronPythonTestCase, is_cli, run_test
 

--- a/Tests/test_kwarg.py
+++ b/Tests/test_kwarg.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_netcoreapp, is_posix, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_netcoreapp, is_posix, run_test, skipUnlessIronPython
 
 #############################################################
 # Helper functions for verifying the calls.  On each call
@@ -46,13 +46,13 @@ def testFunc_kw_2(a, b, **kw):
 class ObjectSubClass(object):
     def testFunc_pw_kw(a, *param, **kw):
         SetArgDict(a, None, param, kw)
-    
+
     def testFunc_kw(a, **kw):
         SetArgDict(a, None, None, kw)
-    
+
     def testFunc_pw_kw_2(a, b, *param, **kw):
         SetArgDict(a, b, param, kw)
-    
+
     def testFunc_kw_2(a, b, **kw):
         SetArgDict(a, b, None, kw)
 
@@ -79,7 +79,7 @@ class NewKwAndExtraParamAndParams(object):
         return object.__new__(cls)
 
 #### kw args on new w/ a corresponding init
-    
+
 class NewInitAll(object):
     def __new__(cls, *param, **kw):
         SetArgDict(cls, None, param, kw)
@@ -108,7 +108,7 @@ class NewInitKwAndExtraParamAndParams(object):
     def __init__(cls, a, *param, **kw):
         SetArgDictInit(cls, a, param, kw)
 
-class KwargTest(unittest.TestCase):
+class KwargTest(IronPythonTestCase):
     def CheckArgDict(self, a, b, param, kw):
         self.assertTrue(argDict['a'] == a, 'a is wrong got ' + repr(argDict['a']) + ' expected ' + repr(a))
         self.assertTrue(argDict['b'] == b, 'b is wrong got ' + repr(argDict['b']) + ' expected ' + repr(b))
@@ -246,23 +246,23 @@ class KwargTest(unittest.TestCase):
         v = NewAll()
         self.CheckArgDict(NewAll, None, (), {})
         self.assertEqual(type(v), NewAll)
-        
+
         v = NewAll(a='abc')
         self.CheckArgDict(NewAll, None, (), {'a': 'abc'})
         self.assertEqual(type(v), NewAll)
-        
+
         v = NewAll('abc')
         self.CheckArgDict(NewAll, None, ('abc',), {})
         self.assertEqual(type(v), NewAll)
-        
+
         v = NewAll('abc', 'def')
         self.CheckArgDict(NewAll, None, ('abc','def'), {})
         self.assertEqual(type(v), NewAll)
-        
+
         v = NewAll('abc', d='def')
         self.CheckArgDict(NewAll, None, ('abc',), {'d': 'def'})
         self.assertEqual(type(v), NewAll)
-        
+
         v = NewAll('abc', 'efg', d='def')
         self.CheckArgDict(NewAll, None, ('abc','efg'), {'d': 'def'})
         self.assertEqual(type(v), NewAll)
@@ -271,15 +271,15 @@ class KwargTest(unittest.TestCase):
         v = NewKw()
         self.CheckArgDict(NewKw, None, None, {})
         self.assertEqual(type(v), NewKw)
-        
+
         v = NewKw(a='abc')
         self.CheckArgDict(NewKw, None, None, {'a': 'abc'})
         self.assertEqual(type(v), NewKw)
-        
+
         v = NewKw(a='abc', b='cde')
         self.CheckArgDict(NewKw, None, None, {'a': 'abc', 'b':'cde'})
         self.assertEqual(type(v), NewKw)
-        
+
         v = NewKw(b='cde', a='abc')
         self.CheckArgDict(NewKw, None, None, {'a': 'abc', 'b':'cde'})
         self.assertEqual(type(v), NewKw)
@@ -288,15 +288,15 @@ class KwargTest(unittest.TestCase):
         v = NewKwAndExtraParam('abc')
         self.CheckArgDict(NewKwAndExtraParam, 'abc', None, {})
         self.assertEqual(type(v), NewKwAndExtraParam)
-        
+
         v = NewKwAndExtraParam(a='abc')
         self.CheckArgDict(NewKwAndExtraParam, 'abc', None, {})
         self.assertEqual(type(v), NewKwAndExtraParam)
-        
+
         v = NewKwAndExtraParam(a='abc', b='cde', e='def')
         self.CheckArgDict(NewKwAndExtraParam, 'abc', None, {'b':'cde', 'e':'def'})
         self.assertEqual(type(v), NewKwAndExtraParam)
-        
+
         v = NewKwAndExtraParam(b='cde', e='def', a='abc')
         self.CheckArgDict(NewKwAndExtraParam, 'abc', None, {'b':'cde', 'e':'def'})
         self.assertEqual(type(v), NewKwAndExtraParam)
@@ -305,31 +305,31 @@ class KwargTest(unittest.TestCase):
         v = NewKwAndExtraParamAndParams('abc')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', (), {})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams(a='abc')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', (), {})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams(a='abc', b='cde', e='def')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', (), {'b':'cde', 'e':'def'})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams(b='cde', e='def', a='abc')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', (), {'b':'cde', 'e':'def'})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams('abc','cde')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', ('cde',), {})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams('abc','cde','def')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', ('cde','def'), {})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams('abc', 'cde', e='def')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', ('cde',), {'e':'def'})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams('abc', 'cde', e='def', f='ghi')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', ('cde',), {'e':'def', 'f':'ghi'})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
@@ -338,23 +338,23 @@ class KwargTest(unittest.TestCase):
         v = NewInitAll()
         self.CheckArgDictInit(v, None, (), {})
         self.assertEqual(type(v), NewInitAll)
-        
+
         v = NewInitAll('abc')
         self.CheckArgDictInit(v, None, ('abc', ), {})
         self.assertEqual(type(v), NewInitAll)
-        
+
         v = NewInitAll('abc', 'cde')
         self.CheckArgDictInit(v, None, ('abc', 'cde'), {})
         self.assertEqual(type(v), NewInitAll)
-        
+
         v = NewInitAll('abc', d='def')
         self.CheckArgDictInit(v, None, ('abc', ), {'d':'def'})
         self.assertEqual(type(v), NewInitAll)
-        
+
         v = NewInitAll('abc', d='def', e='fgi')
         self.CheckArgDictInit(v, None, ('abc', ), {'d':'def', 'e':'fgi'})
         self.assertEqual(type(v), NewInitAll)
-        
+
         v = NewInitAll('abc', 'hgi', d='def', e='fgi')
         self.CheckArgDictInit(v, None, ('abc', 'hgi'), {'d':'def', 'e':'fgi'})
         self.assertEqual(type(v), NewInitAll)
@@ -363,15 +363,15 @@ class KwargTest(unittest.TestCase):
         v = NewInitKw()
         self.CheckArgDictInit(v, None, None, {})
         self.assertEqual(type(v), NewInitKw)
-        
+
         v = NewInitKw(d='def')
         self.CheckArgDictInit(v, None, None, {'d':'def'})
         self.assertEqual(type(v), NewInitKw)
-        
+
         v = NewInitKw(d='def', e='fgi')
         self.CheckArgDictInit(v, None, None, {'d':'def', 'e':'fgi'})
         self.assertEqual(type(v), NewInitKw)
-        
+
         v = NewInitKw(d='def', e='fgi', f='ijk')
         self.CheckArgDictInit(v, None, None, {'d':'def', 'e':'fgi', 'f':'ijk'})
         self.assertEqual(type(v), NewInitKw)
@@ -380,31 +380,31 @@ class KwargTest(unittest.TestCase):
         v = NewInitKwAndExtraParam('abc')
         self.CheckArgDictInit(v, 'abc', None, {})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
-        
+
         v = NewInitKwAndExtraParam('abc',d='def')
         self.CheckArgDictInit(v, 'abc', None, {'d':'def'})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
-        
+
         v = NewInitKwAndExtraParam('abc',d='def', e='fgi')
         self.CheckArgDictInit(v, 'abc', None, {'d':'def', 'e':'fgi'})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
-        
+
         v = NewInitKwAndExtraParam('abc', d='def', e='fgi', f='ijk')
         self.CheckArgDictInit(v, 'abc', None, {'d':'def', 'e':'fgi', 'f':'ijk'})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
-        
+
         v = NewInitKwAndExtraParam(a='abc')
         self.CheckArgDictInit(v, 'abc', None, {})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
-        
+
         v = NewInitKwAndExtraParam(a='abc',d='def')
         self.CheckArgDictInit(v, 'abc', None, {'d':'def'})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
-        
+
         v = NewInitKwAndExtraParam(a='abc',d='def', e='fgi')
         self.CheckArgDictInit(v, 'abc', None, {'d':'def', 'e':'fgi'})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
-        
+
         v = NewInitKwAndExtraParam(a='abc', d='def', e='fgi', f='ijk')
         self.CheckArgDictInit(v, 'abc', None, {'d':'def', 'e':'fgi', 'f':'ijk'})
         self.assertEqual(type(v), NewInitKwAndExtraParam)
@@ -413,23 +413,23 @@ class KwargTest(unittest.TestCase):
         v = NewInitKwAndExtraParamAndParams('abc')
         self.CheckArgDict(NewInitKwAndExtraParamAndParams, 'abc', (), {})
         self.assertEqual(type(v), NewInitKwAndExtraParamAndParams)
-        
+
         v = NewInitKwAndExtraParamAndParams('abc', 'cde')
         self.CheckArgDict(NewInitKwAndExtraParamAndParams, 'abc', ('cde',), {})
         self.assertEqual(type(v), NewInitKwAndExtraParamAndParams)
-        
+
         v = NewInitKwAndExtraParamAndParams('abc', 'cde', 'def')
         self.CheckArgDict(NewInitKwAndExtraParamAndParams, 'abc', ('cde','def'), {})
         self.assertEqual(type(v), NewInitKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams(a='abc', b='cde', e='def')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', (), {'b':'cde', 'e':'def'})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams('abc', 'cde', e='def', d='ghi')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', ('cde',), {'e':'def', 'd':'ghi'})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
-        
+
         v = NewKwAndExtraParamAndParams('abc', e='def', f='ghi')
         self.CheckArgDict(NewKwAndExtraParamAndParams, 'abc', (), {'e':'def', 'f':'ghi'})
         self.assertEqual(type(v), NewKwAndExtraParamAndParams)
@@ -439,7 +439,7 @@ class KwargTest(unittest.TestCase):
         class ListSubcls(list):
             def __new__(cls, **kw):
                 pass
-                
+
         a = ListSubcls(a='abc')
 
     def test_negTestFunc_testFunc_pw_kw_dupArg(self):
@@ -568,9 +568,9 @@ class KwargTest(unittest.TestCase):
         class DoReturn(Exception):
             def __init__(self, *params):
                 pass
-                
+
         a = DoReturn('abc','cde','efg')
-      
+
     def test_object_subclass(self):
         subcls = ObjectSubClass()
 
@@ -646,36 +646,36 @@ class KwargTest(unittest.TestCase):
 
     def test_kw_splat(self):
         def foo(**kw): pass
-        
+
         # should raise because only strings are allowed
         try:
             foo(**{2:3})
             self.fail("Unreachable code reached")
         except TypeError:
             pass
-            
+
         def foo(a, b, **kw): return a, b, kw
-        
+
         self.assertEqual(foo(1,2,**{'abc':3}), (1, 2, {'abc': 3}))
         self.assertEqual(foo(1,b=2,**{'abc':3}), (1, 2, {'abc': 3}))
         self.assertEqual(foo(1,**{'abc':3, 'b':7}), (1, 7, {'abc': 3}))
         self.assertEqual(foo(a=11,**{'abc':3, 'b':7}), (11, 7, {'abc': 3}))
-        
+
         def f(a, b): return a, b
 
         self.assertEqual(f(*(1,), **{'b':7}), (1,7))
         self.assertEqual(f(*(1,2), **{}), (1,2))
         self.assertEqual(f(*(), **{'a':2, 'b':7}), (2,7))
-        
+
         try:
             f(**{'a':2, 'b':3, 'c':4})
             self.fail("Unreachable code reached")
         except TypeError:
             pass
-    
+
     def test_sequence_as_stararg(self):
         def f(x, *args): return x, args
-        
+
         with self.assertRaises(TypeError):
             f(1, x=2) # TypeError: f() got multiple values for keyword argument 'x'
 
@@ -690,7 +690,7 @@ class KwargTest(unittest.TestCase):
         self.assertEqual(f(1, *[2,3]), (1, (2,3)))
         self.assertEqual(f(1, *(2,3)), (1, (2,3)))
         self.assertEqual(f(1, *("23")), (1, ("2","3")))
-        
+
         def f(*arg, **kw): return arg, kw
         self.assertEqual(f(1, x=2, *[3,4]), ((1,3,4), {'x':2}))
         self.assertEqual(f(1, x=2, *(3,4)), ((1,3,4), {'x':2}))

--- a/Tests/test_methodbinder1.py
+++ b/Tests/test_methodbinder1.py
@@ -6,7 +6,6 @@
 # PART 1. how IronPython choose the CLI method, treat parameters WHEN NO OVERLOADS PRESENT
 #
 
-from ast import arguments
 import unittest
 
 from iptest import IronPythonTestCase, is_cli, is_mono, is_netcoreapp, run_test, skipUnlessIronPython
@@ -85,7 +84,7 @@ class MethodBinder1Test(IronPythonTestCase):
             else:
                 self.assertEqual(Flag.Value, flagValue)
                 Flag.Value = -188
-        
+
         for arg in negativeArgs:
             try:
                 _my_call(func, arg)
@@ -94,7 +93,7 @@ class MethodBinder1Test(IronPythonTestCase):
                     self.fail("expected '%s', but got '%s' when calling %s with %s\n%s" % (exceptType, e, func, arg, func.__doc__))
             else:
                 self.fail("expected exception (but didn't get one) when calling func %s on args %s\n%s" % (func, arg, func.__doc__))
-    
+
     def test_this_matrix(self):
         '''This will test the full matrix.'''
         from IronPythonTest.BinderTest import Flag
@@ -175,14 +174,14 @@ class MethodBinder1Test(IronPythonTestCase):
     (        mycomplex1, TypeE, TypeE, TypeE, TypeE, TypeE, True,  TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, True,  )
         )
 
-        
+
         InvariantCulture = System.Globalization.CultureInfo.InvariantCulture
         matrix = list(matrix)
         ##################################################  pass in char    #########################################################
         ####                                     M201   M680   M202   M203   M681   M204   M205   M301   M302   M303   M304   M310   M311   M312   M313   M320   M321   M400
         ####                                     int    int?   double bigint bigint? bool  str    sbyte  i16    i64    single byte   ui16   ui32   ui64   char   decm   obj
         matrix.append((System.Char.Parse('A'),   TypeE, TypeE, TypeE, TypeE, TypeE, True,  True,  TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, TypeE, True,  True, True,  ))
-        
+
         ##################################################  pass in float   #########################################################
         ####    single/double becomes Int32/BigInteger, but this does not apply to other primitive types
         ####                                                          M201   M680   M202   M203   M681   M204   M205   M301   M302   M303   M304   M310   M311   M312   M313   M320   M321   M400
@@ -192,7 +191,7 @@ class MethodBinder1Test(IronPythonTestCase):
         matrix.append((System.Single.Parse("-8.1", InvariantCulture), True,  True,  True,  True,  True,  True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ))
         matrix.append((System.Double.Parse("-1.8", InvariantCulture), TypeE, TypeE, True,  TypeE, TypeE, True,  TypeE, True,  True,  True,  True,  OverF, OverF, OverF, OverF, TypeE, True,  True,  ))
         matrix = tuple(matrix)
-        
+
         for scenario in matrix:
             if isinstance(scenario[0], str):
                 value = clr_numbers[scenario[0]]
@@ -200,11 +199,11 @@ class MethodBinder1Test(IronPythonTestCase):
             else:
                 value = scenario[0]
                 if print_the_matrix: print('(%18s,' % value, end=' ')
-            
+
             for i in range(len(funcnames)):
                 funcname = funcnames[i]
                 func = getattr(self.target, funcname)
-                
+
                 if print_the_matrix:
                     try:
                         func(value)
@@ -258,7 +257,7 @@ class MethodBinder1Test(IronPythonTestCase):
         self._helper(self.target.M320, ['a', System.Char.MaxValue, System.Char.MinValue, 'abc'[2]], 320, ['abc', ('a  b')], TypeError)
         # string asked
         self._helper(self.target.M205, ['a', System.Char.MaxValue, System.Char.MinValue, 'abc'[2], 'abc', 'a b' ], 205, [('a', 'b'), 23, ], TypeError)
-    
+
     def test_pass_extensible_types(self):
         # number covered by that matrix
         # string or char
@@ -276,7 +275,7 @@ class MethodBinder1Test(IronPythonTestCase):
             self.target.M204(arg)
             self.assertTrue(Flag.BValue, "argument is %s" % arg)
             Flag.BValue = False
-            
+
         for arg in [0, System.Byte.Parse('0'), System.UInt64.Parse('0'), 0.0, 0, False, None, tuple(), list()]:
             self.target.M204(arg)
             self.assertTrue(not Flag.BValue, "argument is %s" % (arg,))
@@ -285,10 +284,10 @@ class MethodBinder1Test(IronPythonTestCase):
     def test_user_defined_conversion(self):
         class CP1:
             def __int__(self): return 100
-        
+
         class CP2(object):
             def __int__(self): return 99
-        
+
         class CP3: pass
         cp1, cp2, cp3 = CP1(), CP2(), CP3()
 
@@ -298,7 +297,7 @@ class MethodBinder1Test(IronPythonTestCase):
         works = 'M201 M203       M600 M620   M601               M680  M681        M700     M705            M710    M715'
         for fn in works.split():
             self._helper(getattr(self.target, fn), [cp1, cp2, ], int(fn[1:]), [cp3, ], TypeError)
-        
+
         for fn in dir(self.target):
         ###                                                     bool  obj
             if _self_defined_method(fn) and fn not in (works + 'M204  M400 '):
@@ -316,22 +315,22 @@ class MethodBinder1Test(IronPythonTestCase):
         self._helper(self.target.M401, [C1(), C2(), S1(), cp1, cp2, cp3, cp4,], 401,[C3(), object()], TypeError)
         # C2 asked
         self._helper(self.target.M403, [C2(), cp3, ], 403, [C3(), object(), C1(), cp1, cp2, cp4, ], TypeError)
-        
+
         class CP1(A): pass
         class CP2(C6): pass
         cp1, cp2 = CP1(), CP2()
-        
+
         # A asked
         self._helper(self.target.M410, [C6(), cp1, cp2, cp4,], 410, [C3(), object(), C1(), cp3, ], TypeError)
         # C6 asked
         self._helper(self.target.M411, [C6(), cp2, cp4, ], 411, [C3(), object(), C1(), cp1, cp3,], TypeError)
-        
+
     def test_nullable_int(self):
         self._helper(self.target.M680, [None, 100, 100, System.Byte.MaxValue, System.UInt32.MinValue, myint1, myint2, ], 680, [(), 3+1j], TypeError)
-        
+
     def test_out_int(self):
         self._helper(self.target.M701, [], 701, [1, 10, None, System.Byte.Parse('3')], TypeError)    # not allow to pass in anything
-        
+
     def test_collections(self):
         import System
         from IronPythonTest.BinderTest import I, C1, C2
@@ -342,31 +341,31 @@ class MethodBinder1Test(IronPythonTestCase):
         tupleLong1, tupleLong2  = ((10, 20), ), ((System.Int64.MaxValue, System.Int32.MaxValue * 2),)
         arrayByte = array_byte((10, 20))
         arrayObj = array_object(['str', 10])
-        
+
         # IList<int>
         self._helper(self.target.M650, [arrayInt, tupleInt, listInt, arrayObj, tupleLong1, tupleLong2, ], 650, [arrayByte, ], TypeError)
         # arrayObj, tupleLong1, tupleLong2 : conversion happens late
 
         # Array
         self._helper(self.target.M651, [arrayInt, arrayObj, arrayByte, ], 651, [listInt, tupleInt, tupleLong1, tupleLong2, ], TypeError)
-        
+
         # IEnumerable<int>
         self._helper(self.target.M652, [arrayInt, arrayObj, arrayByte, listInt, tupleInt, tupleLong1, tupleLong2, ], 652, [], TypeError)
-        
+
         # IEnumerator<int>
         self._helper(self.target.M653, [], 653, [arrayInt, arrayObj, arrayByte, listInt, tupleInt, tupleLong1, tupleLong2, ], TypeError)
-        
+
         # Int32[]
         self._helper(self.target.M500, [arrayInt, tupleInt, tupleLong1, tupleBool, ], 500, [listInt, arrayByte, arrayObj, ], TypeError)
         self._helper(self.target.M500, [], 500, [tupleLong2, ], OverflowError)
         # params Int32[]
         self._helper(self.target.M600, [arrayInt, tupleInt, tupleLong1, tupleBool, ], 600, [listInt, arrayByte, arrayObj, ], TypeError)
         self._helper(self.target.M600, [], 600, [tupleLong2, ], OverflowError)
-        
+
         # Int32, params Int32[]
         self._helper(self.target.M620, [(10, 10), (10, 10), (10, 10), (10, 10), (10, arrayInt), (10, (10, 20)), ], 620, [(10, [10, 20]), ], TypeError)
         self._helper(self.target.M620, [], 620, [(10, 123456789101234), ], OverflowError)
-        
+
         arrayI1 = System.Array[I]( (C1(), C2()) )
         arrayI2 = System.Array[I]( () )
         arrayObj3 = System.Array[object]( (C1(), C2()) )
@@ -393,14 +392,14 @@ class MethodBinder1Test(IronPythonTestCase):
 
         for fn in passSet:
             if fn in skipSet: continue
-            
+
             arg = getArg()
             getattr(self.target, fn)(arg)
             left = Flag.Value
             right = int(fn[1:])
             if left != right:
                 self.fail("left %s != right %s when func %s on arg %s" % (left, right, fn, arg))
-        
+
         for fn in dir(self.target):
             if _self_defined_method(fn) and (fn not in passSet) and (fn not in skipSet):
                 arg = getArg()
@@ -428,26 +427,26 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         from IronPythonTest.BinderTest import Flag
         passSet = _get_funcs('NoArg ParamArrInt32 ParamArrBigInt ParamArrS ParamArrI OutInt32 OutBigInt DefValInt32')
         skipSet = [ ]  # be empty before release
-        
+
         for fn in passSet:
             if fn in skipSet: continue
-            
+
             getattr(self.target, fn)()
             left = Flag.Value
             right = int(fn[1:])
             if left != right:
                 self.fail("left %s != right %s when func %s on arg Nothing" % (left, right, fn))
-        
+
         for fn in dir(self.target):
             if _self_defined_method(fn) and (fn not in passSet) and (fn not in skipSet):
                 try:   getattr(self.target, fn)()
                 except TypeError : pass
                 else:  self.fail("expect TypeError, but got none when func %s on arg Nothing" % fn)
-    
+
     def test_other_concern(self):
         from IronPythonTest.BinderTest import C1, C2, COtherConcern, Flag, GOtherConcern, S1
         self.target = COtherConcern()
-        
+
         # static void M100()
         self.target.M100()
         self.assertEqual(Flag.Value, 100); Flag.Value = 99
@@ -455,7 +454,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(Flag.Value, 100); Flag.Value = 99
         self.assertRaises(TypeError, self.target.M100, self.target)
         self.assertRaises(TypeError, COtherConcern.M100, self.target)
-        
+
         # static void M101(COtherConcern arg)
         self.target.M101(self.target)
         self.assertEqual(Flag.Value, 101); Flag.Value = 99
@@ -463,7 +462,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(Flag.Value, 101); Flag.Value = 99
         self.assertRaises(TypeError, self.target.M101)
         self.assertRaises(TypeError, COtherConcern.M101)
-        
+
         # void M102(COtherConcern arg)
         self.target.M102(self.target)
         self.assertEqual(Flag.Value, 102); Flag.Value = 99
@@ -471,7 +470,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(Flag.Value, 102); Flag.Value = 99
         self.assertRaises(TypeError, self.target.M102)
         self.assertRaises(TypeError, COtherConcern.M102, self.target)
-        
+
         # generic method
         self.target.M200[System.Int32](100)
         self.assertEqual(Flag.Value, 200); Flag.Value = 99
@@ -480,7 +479,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(Flag.Value, 99)
         self.target.M200[System.Int32](100)
         self.assertEqual(Flag.Value, 200); Flag.Value = 99
-        
+
         self.target.M200[int](100)
         self.assertEqual(Flag.Value, 200); Flag.Value = 99
         with self.assertRaises(TypeError):
@@ -488,51 +487,51 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(Flag.Value, 99)
         self.target.M200[int](100)
         self.assertEqual(Flag.Value, 200); Flag.Value = 99
-        
+
         self.assertRaises(OverflowError, self.target.M200[System.Byte], 300)
         self.assertRaises(OverflowError, self.target.M200[System.Int32], 12345678901234)
-        
+
         # We should ignore Out attribute on non-byref.
-        # It's used in native interop scenarios to designate a buffer (StringBUilder, arrays, etc.) 
+        # It's used in native interop scenarios to designate a buffer (StringBUilder, arrays, etc.)
         # the caller allocates, passes to the method and expects the callee to populate it with data.
         self.assertRaises(TypeError, self.target.M222)
         self.assertEqual(self.target.M222(0), None)
         self.assertEqual(Flag.Value, 222)
-        
+
         # what does means when passing in None
         self.target.M300(None)
         self.assertEqual(Flag.Value, 300); Flag.Value = 99
         self.assertEqual(Flag.BValue, True)
         self.target.M300(C1())
         self.assertEqual(Flag.BValue, False)
-        
+
         # void M400(ref Int32 arg1, out Int32 arg2, Int32 arg3) etc...
         self.assertEqual(self.target.M400(1, 100), (100, 100))
         self.assertEqual(self.target.M401(1, 100), (100, 100))
         self.assertEqual(self.target.M402(100, 1), (100, 100))
-        
+
         # default Value
         self.target.M450()
         self.assertEqual(Flag.Value, 80); Flag.Value = 99
-        
+
         # 8 args
         self.target.M500(1,2,3,4,5,6,7,8)
         self.assertEqual(Flag.Value, 500)
         self.assertRaises(TypeError, self.target.M500)
         self.assertRaises(TypeError, self.target.M500, 1)
         self.assertRaises(TypeError, self.target.M500, 1,2,3,4,5,6,7,8,9)
-        
+
         # IDictionary
         for x in [ {1:1}, {"str": 3} ]:
             self.target.M550(x)
             self.assertEqual(Flag.Value, 550); Flag.Value = 99
         self.assertRaises(TypeError, self.target.M550, [1, 2])
-        
+
         # not supported
         for fn in (self.target.M600, self.target.M601, self.target.M602):
             for l in ( {1:'a'}, [1,2], (1,2) ):
                 self.assertRaises(TypeError, fn, l)
-                
+
         # delegate
         def f(x): return x * x
         self.assertRaises(TypeError, self.target.M700, f)
@@ -541,20 +540,20 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         for x in (lambda x: x, lambda x: x*2, f):
             self.target.M700(IntIntDelegate(x))
             self.assertEqual(Flag.Value, x(10)); Flag.Value = 99
-        
+
         self.target.M701(lambda x: x*2)
         self.assertEqual(Flag.Value, 20); Flag.Value = 99
         self.assertRaises(TypeError, self.target.M701, lambda : 10)
-        
+
         # keywords
         x = self.target.M800(arg1 = 100, arg2 = 200, arg3 = 'this'); self.assertEqual(x, 'THIS')
         x = self.target.M800(arg3 = 'Python', arg1 = 100, arg2 = 200); self.assertEqual(x, 'PYTHON')
         x = self.target.M800(100, arg3 = 'iron', arg2 = C1()); self.assertEqual(x, 'IRON')
-        
+
         try: self.target.M800(100, 'Yes', arg2 = C1())
         except TypeError: pass
         else: self.fail("expect: got multiple values for keyword argument arg2")
-        
+
         # more ref/out sanity check
         import clr
         def f1(): return clr.Reference[object](None)
@@ -570,7 +569,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         ]:
             expect = (f in 'M850 M852') and S1 or C1
             func = getattr(self.target, f)
-            
+
             for i in range(4):
                 ref = (f1, f2, f3, f4)[i]()
                 if (a,b,c,d)[i]:
@@ -581,15 +580,15 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         # call 854
         self.assertRaises(TypeError, self.target.M854, clr.Reference[object](None))
         self.assertRaises(TypeError, self.target.M854, clr.Reference[int](10))
-        
+
         # call 855
         self.assertRaises(TypeError, self.target.M855, clr.Reference[object](None))
         self.assertRaises(TypeError, self.target.M855, clr.Reference[int](10))
-        
+
         # call 854 and 855 with Reference[bool]
         self.target.M854(clr.Reference[bool](True)); self.assertEqual(Flag.Value, 854)
         self.target.M855(clr.Reference[bool](True)); self.assertEqual(Flag.Value, 855)
-        
+
         # practical
         ref = clr.Reference[System.Int32](0)
         ref2 = clr.Reference[System.Int32](0)
@@ -600,35 +599,35 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(x, None)
         self.assertEqual(ref.Value, 100)
         self.assertEqual(ref2.Value, 500)
-        
+
         # pass one clr.Reference(), and leave the other one open
         ref.Value = 300
         self.assertRaises(TypeError, self.target.M860, ref, 200)
-        
+
         # the other way
         x = self.target.M860(300, 200)
         self.assertEqual(x, (100, 500))
-        
+
         # GOtherConcern<T>
         self.target = GOtherConcern[int]()
         for x in [100, 200, myint1]:
             self.target.M100(x)
             self.assertEqual(Flag.Value, 100); Flag.Value = 99
-        
+
         GOtherConcern[int].M100(self.target, 200)
         self.assertEqual(Flag.Value, 100); Flag.Value = 99
         self.assertRaises(TypeError, self.target.M100, 'abc')
-    
+
         self.target = GOtherConcern[System.Int32]()
         for x in [100, 200, myint1]:
             self.target.M100(x)
             self.assertEqual(Flag.Value, 100); Flag.Value = 99
-        
+
         GOtherConcern[System.Int32].M100(self.target, 200)
         self.assertEqual(Flag.Value, 100); Flag.Value = 99
         self.assertRaises(TypeError, self.target.M100, 'abc')
         self.assertRaises(OverflowError, self.target.M100, 12345678901234)
-    
+
     def test_iterator_sequence(self):
         from IronPythonTest.BinderTest import COtherConcern, Flag
         class C:
@@ -643,21 +642,21 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
                     self.x = 0
                     raise StopIteration
             def __len__(self): return 10
-            
+
         # different size
         c = C()
         list1 = [1, 2, 3]
         tuple1 = [4, 5, 6, 7]
         str1 = "890123"
         all = (list1, tuple1, str1, c)
-        
+
         self.target = COtherConcern()
-        
+
         for x in all:
             # IEnumerable / IEnumerator
             self.target.M620(x)
             self.assertEqual(Flag.Value, len(x)); Flag.Value = 0
-            
+
             # built in types are not IEnumerator, they are enumerable
             if not isinstance(x, C):
                 self.assertRaises(TypeError, self.target.M621, x)
@@ -696,7 +695,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             self.assertRaises(TypeError, self.target.M622, x)
             self.assertRaises(TypeError, self.target.M632, x)
             self.assertRaises(TypeError, self.target.M642, x)
-       
+
     def test_explicit_inheritance(self):
         from IronPythonTest.BinderTest import CInheritMany1, CInheritMany2, CInheritMany3, CInheritMany4, CInheritMany5, CInheritMany6, CInheritMany7, CInheritMany8, Flag, I1, I2, I3, I4
         self.target = CInheritMany1()
@@ -704,11 +703,11 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.target.M()
         self.assertEqual(Flag.Value, 100)
         I1.M(self.target); self.assertEqual(Flag.Value, 100); Flag.Value = 0
-        
+
         self.target = CInheritMany2()
         self.target.M(); self.assertEqual(Flag.Value, 201)
         I1.M(self.target); self.assertEqual(Flag.Value, 200)
-        
+
         self.target = CInheritMany3()
         self.assertTrue(not hasattr(self.target, "M"))
         try: self.target.M()
@@ -716,18 +715,18 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         else: self.fail("Expected AttributeError, got none")
         I1.M(self.target); self.assertEqual(Flag.Value, 300)
         I2.M(self.target); self.assertEqual(Flag.Value, 301)
-        
+
         self.target = CInheritMany4()
         self.target.M(); self.assertEqual(Flag.Value, 401)
         I3[object].M(self.target); self.assertEqual(Flag.Value, 400)
         self.assertRaises(TypeError, I3[int].M, self.target)
-        
+
         self.target = CInheritMany5()
         I1.M(self.target); self.assertEqual(Flag.Value, 500)
         I2.M(self.target); self.assertEqual(Flag.Value, 501)
         I3[object].M(self.target); self.assertEqual(Flag.Value, 502)
         self.target.M(); self.assertEqual(Flag.Value, 503)
-        
+
         self.target = CInheritMany6[int]()
         self.target.M(); self.assertEqual(Flag.Value, 601)
         I3[int].M(self.target); self.assertEqual(Flag.Value, 600)
@@ -737,7 +736,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertTrue(hasattr(self.target, "M"))
         self.target.M(); self.assertEqual(Flag.Value, 700)
         I3[int].M(self.target); self.assertEqual(Flag.Value, 700)
-        
+
         self.target = CInheritMany8()
         self.assertTrue(not hasattr(self.target, "M"))
         try: self.target.M()
@@ -746,7 +745,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         I1.M(self.target); self.assertEqual(Flag.Value, 800); Flag.Value = 0
         I4.M(self.target, 100); self.assertEqual(Flag.Value, 801)
         # target.M(100) ????
-        
+
         # original repro
         from System.Collections.Generic import Dictionary
         d = Dictionary[object,object]()
@@ -761,7 +760,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(nt.DProperty, 2.0)
         nt.DProperty = None
         self.assertEqual(nt.DProperty, None)
-    
+
     #@disabled("Merlin 309716")
     def test_nullable_property_long(self):
         from IronPythonTest import NullableTest
@@ -784,7 +783,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(nt.BProperty, True)
         nt.BProperty = None
         self.assertEqual(nt.BProperty, None)
-    
+
     def test_nullable_property_enum(self):
         from IronPythonTest import NullableTest
         nt = NullableTest()
@@ -816,14 +815,14 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         clr.AddReference("System.Configuration");
         from System.Configuration import ConfigurationManager
         c = ConfigurationManager.ConnectionStrings
-        
+
         #Invoke tests multiple times to make sure DynamicSites are utilized
         for i in range(3):
             if is_mono: # Posix has two default connection strings
                 self.assertEqual(2, c.Count)
             else:
                 self.assertEqual(1, c.Count)
-            
+
         for i in range(3):
             count = c.Count
             if is_mono:
@@ -831,11 +830,11 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             else:
                 self.assertEqual(1, count)
             self.assertEqual(c.Count, count)
-                
+
         for i in range(3):
             #just ensure it doesn't throw
             c[0].Name
-            
+
         #Just to be sure this doesn't throw...
         c.Count
         c.Count
@@ -844,7 +843,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
     def test_interface_only_access(self):
         from IronPythonTest.BinderTest import InterfaceOnlyTest
         pc = InterfaceOnlyTest.PrivateClass
-        
+
         # property set
         pc.Hello = InterfaceOnlyTest.PrivateClass
         # property get
@@ -853,7 +852,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         pc.Foo(pc)
         # method call w/ interface ret val
         self.assertEqual(pc.RetInterface(), pc)
-        
+
         # events
         global fired
         fired = False
@@ -873,25 +872,25 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         from IronPythonTest.BinderTest import COtherConcern, Flag
         import clr
         self.target = COtherConcern()
-        
+
         arr = System.Array[System.Byte]((2,3,4))
-        
+
         res = self.target.M702(arr)
         self.assertEqual(Flag.Value, 702)
         self.assertEqual(type(res), System.Array[System.Byte])
         self.assertEqual(len(res), 0)
-        
+
         i, res = self.target.M703(arr)
         self.assertEqual(Flag.Value, 703)
         self.assertEqual(i, 42)
         self.assertEqual(type(res), System.Array[System.Byte])
         self.assertEqual(len(res), 0)
-        
+
         i, res = self.target.M704(arr, arr)
         self.assertEqual(Flag.Value, 704)
         self.assertEqual(i, 42)
         self.assertEqual(arr, res)
-        
+
         sarr = clr.StrongBox[System.Array[System.Byte]](arr)
         res = self.target.M702(sarr)
         self.assertEqual(Flag.Value, 702)
@@ -899,13 +898,13 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         res = sarr.Value
         self.assertEqual(type(res), System.Array[System.Byte])
         self.assertEqual(len(res), 0)
-        
+
         sarr.Value = arr
         i = self.target.M703(sarr)
         self.assertEqual(Flag.Value, 703)
         self.assertEqual(i, 42)
         self.assertEqual(len(sarr.Value), 0)
-        
+
         i = self.target.M704(arr, sarr)
         self.assertEqual(Flag.Value, 704)
         self.assertEqual(i, 42)
@@ -916,7 +915,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         a = SOtherConcern()
         a.P100 = 42
         self.assertEqual(a.P100, 42)
-    
+
     def test_generic_type_inference(self):
         from IronPythonTest import GenericTypeInference, GenericTypeInferenceInstance, SelfEnumerable
         from System import Array, Exception, ArgumentException
@@ -929,16 +928,16 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
         self.assertEqual(UserGenericType().MInst(42), Int32)
 
         class UserObject(object): pass
-            
+
         userInst = UserObject()
         userInt, userFloat, userComplex, userStr = myint(), myfloat(), mycomplex(), mystr()
         userTuple, userList, userDict = mytuple(), mylist(), mydict()
         objArray = System.Array[object]( (1,2,3) )
         doubleArray = System.Array[float]( (1.0,2.0,3.0) )
-        
 
-        for target in [GenericTypeInference, GenericTypeInferenceInstance(), UserGenericType()]:    
-            tests = [     
+
+        for target in [GenericTypeInference, GenericTypeInferenceInstance(), UserGenericType()]:
+            tests = [
             # simple single type tests, no constraints
             # public static PythonType M0<T>(T x) -> pytypeof(T)
             # target method,   args,                           Result,     KeywordCall,      Exception
@@ -955,7 +954,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M0,        ((), ),                         tuple,      True,             None),
             (target.M0,        ([], ),                         list,       True,             None),
             (target.M0,        ({}, ),                         dict,       True,             None),
-            
+
             # multiple arguments
             # public static PythonType M1<T>(T x, T y) -> pytypeof(T)
             # public static PythonType M2<T>(T x, T y, T z) -> pytypeof(T)
@@ -969,7 +968,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M1,        (1, 'abc'),                     None,       True,             TypeError),
             (target.M1,        (object(), userInst),           object,     True,             None),
             (target.M1,        ([], userList),                 list,       True,             None),
-        
+
             # params arguments
             # public static PythonType M3<T>(params T[] args) -> pytypeof(T)
             (target.M3,        (),                             None,       False,            TypeError),
@@ -983,7 +982,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M3,        (1, 'abc'),                     object,     False,            TypeError),
             (target.M3,        (object(), userInst),           object,     False,            None),
             (target.M3,        ([], userList),                 list,       False,            None),
-            
+
             # public static PythonType M4<T>(T x, params T[] args) -> pytypeof(T)
             (target.M4,        (1, 2),                         Int32,      False,            None),
             (target.M4,        tbig(1, 2),                     int,        False,            None),
@@ -991,7 +990,7 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M4,        (1, 'abc'),                     object,     False,            TypeError),
             (target.M4,        (object(), userInst),           object,     False,            None),
             (target.M4,        ([], userList),                 list,       False,            None),
-            
+
             # simple constraints
             # public static PythonType M5<T>(T x) where T : class -> pytype(T)
             # public static PythonType M6<T>(T x) where T : struct -> pytype(T)
@@ -1008,9 +1007,9 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M6,        tbig(1, ),                      int,        False,            None),
             (target.M7,        ([], ),                         list,       False,            None),
             (target.M7,        (objArray, ),                   type(objArray), False,        None),
-        
+
             # simple dependent constraints
-            # public static PythonTuple M8<T0, T1>(T0 x, T1 y) where T0 : T1 -> (pytype(T0), pytype(T1))     
+            # public static PythonTuple M8<T0, T1>(T0 x, T1 y) where T0 : T1 -> (pytype(T0), pytype(T1))
             (target.M8,        (1, 2),                         (Int32, Int32), False,        None),
             (target.M8,        tbig(1, 2),                     (int, int),   False,          None),
             (target.M8,        (big(1), 2),                    None,         False,          TypeError),
@@ -1020,32 +1019,32 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M8,        (1, object()),                  (Int32, object),False,        None),
             (target.M8,        (big(1), object()),             (int, object),False,          None),
             (target.M8,        (object(), 1),                  None,         False,          TypeError),
-        
+
             # no types can be inferred, error
             # public static PythonTuple M9<T0, T1>(object x, T1 y) where T0 : T1
             # public static PythonTuple M9b<T0, T1>(T0 x, object y) where T0 : T1
             # public static PythonType M11<T>(object x)
-            # public static PythonType M12<T0, T1>(T0 x, object y)     
+            # public static PythonType M12<T0, T1>(T0 x, object y)
             (target.M9,        (1, 2),                         None,         False,          TypeError),
             (target.M9b,       (1, 2),                         None,         False,          TypeError),
             (target.M9,        (object(), object()),           None,         True,           TypeError),
             (target.M9b,       (object(), object()),           None,         True,           TypeError),
             (target.M11,       (1, ),                          None,         False,          TypeError),
             (target.M12,       (1, 2),                         None,         False,          TypeError),
-            
+
             # multiple dependent constraints
             # public static PythonTuple M10<T0, T1, T2>(T0 x, T1 y, T2 z) where T0 : T1 where T1 : T2 -> (pytype(T0), pytype(T1), pytype(T2))
             (target.M10,        (ArgumentException(), Exception(), object()), (ArgumentException, Exception, object),False,           None),
             (target.M10,        (Exception(), ArgumentException(), object()), None,False,    TypeError),
             (target.M10,        (ArgumentException(), object(), Exception()), None,False,    TypeError),
             (target.M10,        (object(), ArgumentException(), Exception()), None,False,    TypeError),
-            (target.M10,        (object(), Exception(), ArgumentException()), None,False,    TypeError),     
-            
+            (target.M10,        (object(), Exception(), ArgumentException()), None,False,    TypeError),
+
             # public static PythonType M11<T>(object x) -> pytypeof(T)
             # public static PythonType M12<T0, T1>(T0 x, object y) -> pytypeof(T0)
             (target.M11,       (object(), ),                   None,       True,             TypeError),
-            (target.M12,       (3, object()),                  None,       True,             TypeError),     
-            
+            (target.M12,       (3, object()),                  None,       True,             TypeError),
+
             # public static PythonType M13<T>(T x, Func<T> y) -> pytype(T), func()
             # public static PythonType M14<T>(T x, Action<T> y) -> pytype(T)
             # public static PythonTuple M15<T>(T x, IList<T> y) -> pytype, list...
@@ -1057,44 +1056,44 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M15,       (1, objArray),                 (object, 1,2,3), True,         None),
             (target.M15,       (1, doubleArray),              None,            True,         TypeError),
             (target.M16,       (1, {1: [1,2]}),               None,            False,        TypeError),
-        
+
             # public static PythonType M17<T>(T x, IEnumerable<T> y) -> pytype(T)
             (target.M17,       (SelfEnumerable(), SelfEnumerable()), SelfEnumerable, True,   None),
             (target.M17,       (1, [1,2,3]),                  object,          True,         None),
             (target.M17,       (1.0, [1,2,3]),                object,          True,         None),
             (target.M17,       (object(), [1,2,3]),           object,          True,         None),
-            
+
             # public static PythonType M18<T>(T x) where T : IEnumerable<T> -> pytype(T)
             (target.M18,       (SelfEnumerable(), ),          SelfEnumerable,  True,         None),
-            
+
             # public static PythonType M19<T0, T1>(T0 x, T1 y) where T0 : IList<T1> -> pytype(T0), pytype(T1)
             (target.M19,       ([], 1),                       None,            True,         TypeError),
             (target.M19,       (List[Int32](), 1),            (List[Int32], Int32), True,    None),
             (target.M19,       (List[int](), big(1)),         (List[int], int), True,        None),
-            
+
             # public static PythonType M20<T0, T1>(T0 x, T1 y) -> pytype(T0), pytype(T1)
             (target.M20,       ([], 1),                       (list, Int32),   True,         None),
             (target.M20,       ([], big(1)),                  (list, int),     True,         None),
             (target.M20,       (List[int](), 1),              (List[int], Int32), True,      None),
-            
+
             # constructed types
             # public static PythonType M21<T>(IEnumerable<T> enumerable)
             (target.M21,       ([1,2,3], ),                   object,          False,        None),
-            
+
             # overloaded by function
             # public static PythonTuple M22<T>(IEnumerable<T> enumerable, Func<T, bool> predicate) -> pytype(T), True
             # public static PythonTuple M22<T>(IEnumerable<T> enumerable, Func<T, int, bool> predicate) -> pytype(T), False
             (target.M22,       ([1,2,3], lambda x:True),     (object, True),   True,         None),
             (target.M22,       ([1,2,3], lambda x,y:True),   (object, False),  True,         None),
-            
+
             # public static PythonType M23<T>(List<T> x) -> pytype(T)
             # public static PythonType M24<T>(List<List<T>> x) -> pytype(T)
             # public static PythonType M25<T>(Dictionary<T, T> x) -> pytype(T)
             (target.M23,       (List[int](), ),               int,             True,         None),
-            (target.M24,       (List[List[int]](), ),         int,             True,         None),     
+            (target.M24,       (List[List[int]](), ),         int,             True,         None),
             (target.M25,       (Dict[int, int](), ),          int,             True,         None),
             (target.M25,       (Dict[int, str](), ),          None,            True,         TypeError),
-            
+
             # constructed types and constraints
             # public static PythonType M26<T>(List<T> x) where T : class -> pytype(T)
             # public static PythonType M27<T>(List<T> x) where T : struct -> pytype(T)
@@ -1105,10 +1104,10 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M26,       (List[str](), ),                str,            False,        None),
             (target.M27,       (List[int](), ),                int,            False,        None),
             (target.M28,       (List[List[str]](), ),          List[str],      False,        None),
-            
+
             # public static PythonType M29<T>(Dictionary<Dictionary<T, T>, Dictionary<T, T>> x)
             (target.M29,       (Dict[Dict[int, int], Dict[int, int]](), ),  int,  True,      None),
-            
+
             # constraints and constructed types
             # public static PythonType M30<T>(Func<T, bool> y) where T : struct -> pytype(T)
             # public static PythonType M31<T>(Func<T, bool> y) where T : IList -> pytype(T)
@@ -1118,18 +1117,18 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
             (target.M31,       (lambda x: False, ),            int,            True,         TypeError),
             (target.M32,       (List[str](), ),                int,            True,         TypeError),
             (target.M33,       (List[int](), ),                int,            True,         TypeError),
-            
+
             # public static PythonType M34<T>(IList<T> x, IList<T> y) -> pytype(T)
             (target.M34,       ((), [], ),                     object,         True,         None),
-            
+
             # T[] and IList<T> overloads:
             (target.M35,       (objArray, ),                   System.Array[object], False,  None),
             ]
-            
+
             # TODO: more by-ref and arrays tests:
             x = Array.Resize(Array.CreateInstance(int, 10), 20)
             self.assertEqual(x.Length, 20)
-            
+
             for method, args, res, kwArgs, excep in tests:
                 self.generic_method_tester(method, args, res, kwArgs, excep)
 
@@ -1162,10 +1161,10 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
                     self.assertEqual(method(**{'x' : args[0], 'y' : args[1], 'z' : args[2]}), res)
             else:
                 raise Exception("need to add new case for len %d " % len(args))
-                
+
             self.assertEqual(method(*args), res)
             self.assertEqual(method(args[0], *args[1:]), res)
-        else:            
+        else:
             # test error method w/ multiple calling conventions
             if len(args) == 0:
                 f = lambda : method()
@@ -1184,18 +1183,18 @@ IListInt Array IEnumerableInt IEnumeratorInt NullableInt NullableBigInt
                 fkw2 = lambda : method(**{'x' : args[0], 'y' : args[1], 'z' : args[2]})
             else:
                 raise Exception("need to add new case for len %d " % len(args))
-        
+
             if not kwArgs:
                 fkw = None
                 fkw2 = None
-            
+
             # test w/o splatting
-            self.assertRaises(excep, f)    
+            self.assertRaises(excep, f)
             if fkw: self.assertRaises(excep, fkw)
             if fkw2: self.assertRaises(excep, fkw2)
             # test with splatting
-            self.assertRaises(excep, method, *args)    
-    
+            self.assertRaises(excep, method, *args)
+
 
 run_test(__name__)
 

--- a/Tests/test_methodbinder2.py
+++ b/Tests/test_methodbinder2.py
@@ -6,8 +6,6 @@
 # PART 2. how IronPython choose the overload methods
 #
 
-import unittest
-
 from iptest import IronPythonTestCase, is_cli, big, run_test, skipUnlessIronPython
 if is_cli:
     from iptest.type_util import array_int, array_byte, array_object, myint, mystr, types
@@ -103,7 +101,7 @@ class MethodBinder2Test(IronPythonTestCase):
         if verbose: print(arg, end=' ')
         for funcname in dir(target):
             if not _self_defined_method(funcname) : continue
-            
+
             if verbose: print(funcname, end=' ')
             func = getattr(target, funcname)
 
@@ -127,38 +125,38 @@ class MethodBinder2Test(IronPythonTestCase):
             else:
                 if not funcname in mapping.keys(): # Expecting exception
                     self.fail("expect %s, but got no exception (flag %s) when func %s with arg %s (%s)\n%s" % (expectError, Flag.Value, funcname, arg, type(arg), func.__doc__))
-                
+
                 left, right = Flag.Value, mapping[funcname]
                 if left != right:
                     self.fail("left %s != right %s when func %s on arg %s (%s)\n%s" % (left, right, funcname, arg, type(arg), func.__doc__))
                 Flag.Value = -99           # reset
         if verbose: print()
-    
+
     def test_other_concerns(self):
         from IronPythonTest.BinderTest import C1, C3, COtherOverloadConcern, Flag
         target = COtherOverloadConcern()
-        
+
         # the one asking for Int32 is private
         target.M100(100)
         self.assertEqual(Flag.Value, 200); Flag.Value = 99
-        
+
         # static / instance
         target.M110(target, 100)
         self.assertEqual(Flag.Value, 110); Flag.Value = 99
         COtherOverloadConcern.M110(100)
         self.assertEqual(Flag.Value, 210); Flag.Value = 99
-        
+
         self.assertRaises(TypeError, COtherOverloadConcern.M110, target, 100)
-        
+
         # static / instance 2
         target.M111(100)
         self.assertEqual(Flag.Value, 111); Flag.Value = 99
         COtherOverloadConcern.M111(target, 100)
         self.assertEqual(Flag.Value, 211); Flag.Value = 99
-            
+
         self.assertRaises(TypeError, target.M111, target, 100)
         self.assertRaises(TypeError, COtherOverloadConcern.M111, 100)
-        
+
         # statics
         target.M120(target, 100)
         self.assertEqual(Flag.Value, 120); Flag.Value = 99
@@ -169,7 +167,7 @@ class MethodBinder2Test(IronPythonTestCase):
         self.assertEqual(Flag.Value, 120); Flag.Value = 99
         COtherOverloadConcern.M120(100)
         self.assertEqual(Flag.Value, 220); Flag.Value = 99
-        
+
         # generic
         target.M130(100)
         self.assertEqual(Flag.Value, 130); Flag.Value = 99
@@ -194,7 +192,7 @@ class MethodBinder2Test(IronPythonTestCase):
 
         class PT_C3_int(C3):
             def __int__(self): return 1
-        
+
         # narrowing levels and __int__ conversion
         target.M140(PT_C3_int(), PT_C3_int())
         self.assertEqual(Flag.Value, 140); Flag.Value = 99

--- a/Tests/test_methoddispatch.py
+++ b/Tests/test_methoddispatch.py
@@ -3,9 +3,8 @@
 # See the LICENSE file in the project root for more information.
 
 import os
-import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_mono, is_netcoreapp, is_posix, big, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_mono, is_netcoreapp, is_posix, big, run_test, skipUnlessIronPython
 
 @skipUnlessIronPython()
 class MethodDispatchTest(IronPythonTestCase):
@@ -52,7 +51,7 @@ class MethodDispatchTest(IronPythonTestCase):
 
         verify_complex(i, ii)
         verify_complex(j, jj)
-        
+
         verify_complex(i + j, ii + jj)
         verify_complex(i - j, ii - jj)
         verify_complex(i * j, ii * jj)
@@ -62,12 +61,12 @@ class MethodDispatchTest(IronPythonTestCase):
         verify_complex(i - 2.5, ii - 2.5)
         verify_complex(i * 2.5, ii * 2.5)
         verify_complex(i / 2.5, ii / 2.5)
-        
+
         verify_complex(2.5 + j, 2.5 + jj)
         verify_complex(2.5 - j, 2.5 - jj)
         verify_complex(2.5 * j, 2.5 * jj)
         verify_complex(2.5 / j, 2.5 / jj)
-        
+
         verify_complex(i + 2, ii + 2)
         verify_complex(i - 2, ii - 2)
         verify_complex(i * 2, ii * 2)
@@ -77,7 +76,7 @@ class MethodDispatchTest(IronPythonTestCase):
         verify_complex(2 - j, 2 - jj)
         verify_complex(2 * j, 2 * jj)
         verify_complex(2 / j, 2 / jj)
-        
+
         verify_complex(-i, -ii)
         verify_complex(-j, -jj)
 
@@ -104,7 +103,7 @@ class MethodDispatchTest(IronPythonTestCase):
         i += 2
         ii += 2
         verify_complex(i, ii)
-        
+
         i *= 2
         ii *= 2
         verify_complex(i, ii)
@@ -142,19 +141,19 @@ class MethodDispatchTest(IronPythonTestCase):
         from System.Drawing import Rectangle
         r = Rectangle(0, 0, 3, 7)
         s = Rectangle(3, 0, 8, 14)
-        
+
         # calling the static method
         i = Rectangle.Intersect(r, s)
         self.assertEqual(i, Rectangle(3, 0, 0, 7))
         self.assertEqual(r, Rectangle(0, 0, 3, 7))
         self.assertEqual(s, Rectangle(3, 0, 8, 14))
-        
+
         # calling the instance
         i = r.Intersect(s)
         self.assertEqual(i, None)
         self.assertEqual(r, Rectangle(3, 0, 0, 7))
         self.assertEqual(s, Rectangle(3, 0, 8, 14))
-        
+
         # calling instance w/ StrongBox
         r = Rectangle(0, 0, 3, 7)
         box = clr.StrongBox[Rectangle](r)
@@ -162,10 +161,10 @@ class MethodDispatchTest(IronPythonTestCase):
         self.assertEqual(i, None)
         self.assertEqual(box.Value, Rectangle(3, 0, 0, 7))
         self.assertEqual(s, Rectangle(3, 0, 8, 14))
-        
+
         # should be able to access properties through the box
         self.assertEqual(box.X, 3)
-        
+
         # multiple sites should produce the same function
         i = box.Intersect
         j = box.Intersect
@@ -203,7 +202,7 @@ class MethodDispatchTest(IronPythonTestCase):
         UIntType    = (System.UInt32,  BindTest.UIntValue,    BindResult.UInt)
         ULongType   = (System.UInt64,  BindTest.ULongValue,   BindResult.ULong)
         UShortType  = (System.UInt16,  BindTest.UShortValue,  BindResult.UShort)
-        
+
         saveType = type
 
         for binding in [BoolType, ByteType, CharType, DecimalType, DoubleType,
@@ -217,7 +216,7 @@ class MethodDispatchTest(IronPythonTestCase):
             select = BindTest.Bind.Overloads[type]
             result = select(value)
             self.assertEqual(expect, result)
-        
+
             # Select using ReflectedType object
             select = BindTest.Bind.Overloads[type]
             result = select(value)
@@ -231,7 +230,7 @@ class MethodDispatchTest(IronPythonTestCase):
             result, output = BindTest.BindRef(value)
             if not binding is CharType:
                 self.assertEqual(expect | BindResult.Ref, result)
-        
+
             # Select using Array type
             arrtype = System.Type.MakeArrayType(type)
             select = BindTest.Bind.Overloads[arrtype]
@@ -279,7 +278,7 @@ class MethodDispatchTest(IronPythonTestCase):
 
             def TestDaysUShort(self):
                 return DaysUShort.Weekdays
-        
+
             def TestDaysUInt(self):
                 return DaysUInt.Weekdays
 
@@ -644,14 +643,14 @@ class MethodDispatchTest(IronPythonTestCase):
 
         def keys_helper(o):
             if hasattr(o, 'keys'): return list(o.keys())
-            
+
             return o.Keys
-            
+
         def CheckDict(res, orig):
             if hasattr(res, "__len__"):
                 self.assertEqual(len(res), len(orig))
             i = 0
-            
+
             for a in keys_helper(res):
                 self.assertEqual(res[a], orig[a])
                 i = i+1
@@ -793,7 +792,7 @@ class MethodDispatchTest(IronPythonTestCase):
 
         class C:
             mymax = max
-            
+
         a = C()
         self.assertEqual(a.mymax(0,0), 0)
 
@@ -826,7 +825,7 @@ class MethodDispatchTest(IronPythonTestCase):
         self.assertEqual(tst.Test_ByRef_Object(r, s, t), "Hi; Hello; Ciao")
         self.assertEqual(tst.Test_ByRef_Object("Hi", "Hello", "Ciao"), ("Hi; Hello; Ciao"))
         self.assertRaises(TypeError, tst.Test_ByRef_Object, "Hi")
-        
+
         self.assertEqual(tst.Test_Default_Cast(), "1")
         self.assertEqual(tst.Test_Default_Cast("Hello"), ("Hello", "Hello"))
         self.assertEqual(tst.Test_Default_Cast(None), ("(null)", None))
@@ -930,16 +929,16 @@ class MethodDispatchTest(IronPythonTestCase):
                     line += 'try: c.IM%d(o, %s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (i, ",".join(['1'] * (i-1)))
                 line += 'try: o.IM%d(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (i, ",".join(['1'] * (i+1)))
                 line += 'try: c.IM%d(o, %s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (i, ",".join(['1'] * (i+1)))
-                    
+
                 line += 'assertEqual(o.SM%d(%s), "SM%d")\n' % (i, args, i)
                 line += 'assertEqual(c.SM%d(%s), "SM%d")\n' % (i, args, i)
-                
+
                 if i > 0:
                     line += 'try: o.SM%d(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (i, ",".join(['1'] * (i-1)))
                     line += 'try: c.SM%d(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (i, ",".join(['1'] * (i-1)))
                 line += 'try: o.SM%d(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (i, ",".join(['1'] * (i+1)))
                 line += 'try: c.SM%d(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (i, ",".join(['1'] * (i+1)))
-            
+
             #print line
             exec(line, globals(), locals())
 
@@ -954,10 +953,10 @@ class MethodDispatchTest(IronPythonTestCase):
                 else:
                     line += 'try: o.IDM0(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (args)
                     line += 'try: c.IDM0(o, %s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (args)
-                
+
             #print line
             exec(line, globals(), locals())
-        
+
             line = ""
             for i in range(7):
                 args = ",".join(['1'] * i)
@@ -967,7 +966,7 @@ class MethodDispatchTest(IronPythonTestCase):
                 else:
                     line += 'try: o.SDM0(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (args)
                     line += 'try: c.SDM0(%s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (args)
-                
+
             #print line
             exec(line, globals(), locals())
 
@@ -985,10 +984,10 @@ class MethodDispatchTest(IronPythonTestCase):
                     line += 'assertEqual(c.IDM1(o,%s), "IDM1-x")\n' % (args)
                     line += 'assertEqual(o.SDM1(%s), "SDM1-x")\n' % (args)
                     line += 'assertEqual(c.SDM1(%s), "SDM1-x")\n' % (args)
-                    
+
             #print line
             exec(line, globals(), locals())
-        
+
             line = ""
             for i in range(7):
                 args = ",".join(['1'] * i)
@@ -1002,7 +1001,7 @@ class MethodDispatchTest(IronPythonTestCase):
                     line += 'assertEqual(c.IDM4(o,%s), "IDM4-x")\n' % (args)
                     line += 'assertEqual(o.SDM4(%s), "SDM4-x")\n' % (args)
                     line += 'assertEqual(c.SDM4(%s), "SDM4-x")\n' % (args)
-                
+
             #print line
             exec(line, globals(), locals())
 
@@ -1018,7 +1017,7 @@ class MethodDispatchTest(IronPythonTestCase):
                     line += 'try: c.IDM2(o, %s) \nexcept TypeError: pass \nelse: raise AssertionError\n' % (args)
             #print line
             exec(line, globals(), locals())
-        
+
             line = ""
             for i in range(7):
                 args = ",".join(['1'] * i)
@@ -1031,7 +1030,7 @@ class MethodDispatchTest(IronPythonTestCase):
 
             #print line
             exec(line, globals(), locals())
-        
+
             ## 4
             line = ""
             for i in range(7):
@@ -1069,10 +1068,10 @@ class MethodDispatchTest(IronPythonTestCase):
                 else:
                     line += 'self.assertEqual(o.IDM3(%s), "IDM3-x")\n' % (args)
                     line += 'self.assertEqual(c.IDM3(o,%s), "IDM3-x")\n' % (args)
-                
+
             #print line
             exec(line, globals(), locals())
-        
+
             line = ""
             for i in range(7):
                 args = ",".join(['1'] * i)
@@ -1082,7 +1081,7 @@ class MethodDispatchTest(IronPythonTestCase):
                 else:
                     line += 'assertEqual(o.SDM3(%s), "SDM3-x")\n' % (args)
                     line += 'assertEqual(c.SDM3(%s), "SDM3-x")\n' % (args)
-                
+
             #print line
             exec(line, globals(), locals())
 
@@ -1094,7 +1093,7 @@ class MethodDispatchTest(IronPythonTestCase):
                 line +=  'assertEqual(o.SPM0(%s), "SPM0-%d")\n' % (args, i)
                 line +=  'assertEqual(c.IPM0(o,%s), "IPM0-%d")\n' % (args, i)
                 line +=  'assertEqual(c.SPM0(%s), "SPM0-%d")\n' % (args, i)
-                
+
                 line +=  'assertEqual(o.SPM1(0,%s), "SPM1-%d")\n' % (args, i)
                 line +=  'assertEqual(o.IPM1(0,%s), "IPM1-%d")\n' % (args, i)
                 line +=  'assertEqual(c.IPM1(o, 0,%s), "IPM1-%d")\n' % (args, i)
@@ -1102,12 +1101,12 @@ class MethodDispatchTest(IronPythonTestCase):
 
             #print line
             exec(line, globals(), locals())
-            
+
         class DispatchAgain2(DispatchAgain): pass
-        
+
         testfunctionhelper(DispatchAgain, DispatchAgain())
         testfunctionhelper(DispatchAgain2, DispatchAgain2())
-        
+
         self.assertEqual(type(BindTest.ReturnTest('char')), System.Char)
         self.assertEqual(type(BindTest.ReturnTest('null')), type(None))
         self.assertEqual(type(BindTest.ReturnTest('object')), object)
@@ -1153,7 +1152,7 @@ class MethodDispatchTest(IronPythonTestCase):
                                     ("10",),
                                     (System.Byte.Parse("2"),),
                     ])
-        
+
         #############################################################################################
         #        public int M1(int arg) { return 1; }
         #        public int M1(long arg) { return 2; }
@@ -1186,13 +1185,13 @@ class MethodDispatchTest(IronPythonTestCase):
         #        public int M2(int arg1, long arg2) { return 3; }
         #        public int M2(long arg1, long arg2) { return 4; }
         #        public int M2(object arg1, object arg2) { return 5; }
-        
+
         func = c.M2
         AllEqual(1, func, [
             (0, 0), (1, maxint), (maxint, 1), (maxint, maxint),
             (int(10), 0),
             ])
-        
+
         AllEqual(2, func, [
             (System.Int64(maxint+1), 0),
             (System.Int64(maxint+10), 10),
@@ -1205,11 +1204,11 @@ class MethodDispatchTest(IronPythonTestCase):
             (0, maxlong1),
             (10, maxlong1),
             ])
-        
+
         AllEqual(4, func, [
             (maxlong1, maxlong1),
             ])
-        
+
         AllEqual(5, func, [
             (big(10), 0),
             (maxint+1, 0),
@@ -1226,25 +1225,25 @@ class MethodDispatchTest(IronPythonTestCase):
             (1, "100L"),
             (10.2, 1),
             ])
-        
+
         #############################################################################################
         #        public int M4(int arg1, int arg2, int arg3, int arg4) { return 1; }
         #        public int M4(object arg1, object arg2, object arg3, object arg4) { return 2; }
-        
+
         one = [t.Parse("5") for t in [System.Byte, System.SByte, System.UInt16, System.Int16, System.UInt32, System.Int32,
                 System.UInt32, System.Int32, System.UInt64, System.Int64,
                 System.Char, System.Decimal, System.Single, System.Double] ]
-        
+
         one.extend([True, False, big(5), DispatchHelpers.Color.Red ])
-        
+
         two = [t.Parse("5.5") for t in [ System.Decimal, System.Single, System.Double] ]
-        
+
         two.extend([None, "5", "5.5", maxint * 2, ])
-        
+
         together = []
         together.extend(one)
         together.extend(two)
-        
+
         ignore = '''
         for a1 in together:
             for a2 in together:
@@ -1263,25 +1262,25 @@ class MethodDispatchTest(IronPythonTestCase):
         #        public int M5(object arg1, object args) { return 3; }
         b = DispatchHelpers.B()
         d = DispatchHelpers.D()
-        
+
         func = c.M5
-        
+
         AllEqual(1, func, [(b, b), (b, d)])
         AllEqual(2, func, [(d, b), (d, d)])
         AllEqual(3, func, [(1, 2)])
-        
+
         #############################################################################################
         #        public int M6(DispatchHelpers.B arg1, DispatchHelpers.B args) { return 1; }
         #        public int M6(DispatchHelpers.B arg1, DispatchHelpers.D args) { return 2; }
         #        public int M6(object arg1, DispatchHelpers.D args) { return 3; }
-        
+
         func = c.M6
 
         AllEqual(1, func, [(b, b), (d, b)])
         AllEqual(2, func, [(b, d), (d, d)])
         AllEqual(3, func, [(1, d), (big(6), d)])
         AllAssert(TypeError, func, [(1,1), (None, None), (None, d), (3, b)])
-        
+
         #############################################################################################
         #        public int M7(DispatchHelpers.B arg1, DispatchHelpers.B args) { return 1; }
         #        public int M7(DispatchHelpers.B arg1, DispatchHelpers.D args) { return 2; }
@@ -1299,7 +1298,7 @@ class MethodDispatchTest(IronPythonTestCase):
         #        public int M8(int arg1, int arg2) { return 1;}
         #        public int M8(DispatchHelpers.B arg1, DispatchHelpers.B args) { return 2; }
         #        public int M8(object arg1, object arg2) { return 3; }
-        
+
         func = c.M8
         AllEqual(1, func, [(1, 2), ]) #(maxint, 2L)])
         AllEqual(2, func, [(b, b), (b, d), (d, b), (d, d)])
@@ -1352,7 +1351,7 @@ class MethodDispatchTest(IronPythonTestCase):
         self.assertEqual(x[1], a)
         # doc for this method should have the out & ref params as return values
         self.assertEqual(a.M98.__doc__, 'M98(self: Dispatch, a: str, b: str, c: str, d: str, di: Dispatch) -> (Int32, Dispatch)%s' % os.linesep)
-        
+
         # call type.InvokeMember on String.ToString - all methods have more arguments than max args.
         res = clr.GetClrType(str).InvokeMember('ToString',
                                                 System.Reflection.BindingFlags.Instance|System.Reflection.BindingFlags.Public|System.Reflection.BindingFlags.InvokeMethod,
@@ -1379,9 +1378,9 @@ class MethodDispatchTest(IronPythonTestCase):
             pass
         else:
             self.fail("Expected AttributeError, got none")
-            
+
         self.assertEqual(x.B(), "ExplicitTest.B")
-        
+
         self.assertTrue(not hasattr(x, "C"))
         try:
             x.C()
@@ -1389,16 +1388,16 @@ class MethodDispatchTest(IronPythonTestCase):
             pass
         else:
             self.fail("Expected AttributeError, got none")
-        
+
         self.assertEqual(x.D(), "ExplicitTest.D")
-        
+
         self.assertEqual(IExplicitTest1.A(x), "ExplicitTest.IExplicitTest1.A")
         self.assertEqual(IExplicitTest1.B(x), "ExplicitTest.IExplicitTest1.B")
         self.assertEqual(IExplicitTest1.C(x), "ExplicitTest.IExplicitTest1.C")
         self.assertEqual(IExplicitTest1.D(x), "ExplicitTest.D")
         self.assertEqual(IExplicitTest2.A(x), "ExplicitTest.IExplicitTest2.A")
         self.assertEqual(IExplicitTest2.B(x), "ExplicitTest.B")
-        
+
         x = ExplicitTestArg()
         try:
             x.M()
@@ -1427,7 +1426,7 @@ class MethodDispatchTest(IronPythonTestCase):
     def test_array_error_message(self):
         import System
         from IronPythonTest import BinderTest
-        
+
         x = BinderTest.CNoOverloads()
         self.assertRaisesMessage(TypeError, 'expected Array[Int32], got Array[Byte]', x.M500, System.Array[System.Byte]([1,2,3]))
 

--- a/Tests/test_namebinding.py
+++ b/Tests/test_namebinding.py
@@ -2,9 +2,7 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import collections
 import sys
-import unittest
 
 from iptest import IronPythonTestCase, is_cli, path_modifier, run_test
 

--- a/Tests/test_nonetype.py
+++ b/Tests/test_nonetype.py
@@ -2,12 +2,10 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-import unittest
-
 from iptest import IronPythonTestCase, is_cli, run_test
 
 class NoneTypeTest(IronPythonTestCase):
-        
+
     def test_trival(self):
         self.assertEqual(type(None), None.__class__)
         self.assertEqual(str(None), None.__str__())
@@ -17,5 +15,5 @@ class NoneTypeTest(IronPythonTestCase):
             self.assertRaisesMessage(TypeError, "NoneType is not callable", None)
         else:
             self.assertRaisesMessage(TypeError, "'NoneType' object is not callable", None)
-    
+
 run_test(__name__)

--- a/Tests/test_python26.py
+++ b/Tests/test_python26.py
@@ -7,7 +7,7 @@ import os
 import sys
 import unittest
 
-from iptest import is_cli, big, run_test, skipUnlessIronPython
+from iptest import big, run_test, skipUnlessIronPython
 
 class OutputCatcher(object):
     def __enter__(self):

--- a/Tests/test_range.py
+++ b/Tests/test_range.py
@@ -9,14 +9,13 @@
 ##
 
 import sys
-import unittest
 
-from iptest import is_cli, run_test
+from iptest import IronPythonTestCase, is_cli, run_test
 
 if is_cli:
     from System import Int64
 
-class RangeTest(unittest.TestCase):
+class RangeTest(IronPythonTestCase):
 
     def test_range(self):
         self.assertTrue(list(range(10)) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -55,16 +54,15 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(len(x), 2)
 
         if is_cli:
-            # TODO: https://github.com/IronLanguages/ironpython3/issues/472
-            with self.assertRaises(OverflowError):
-                x = range(0, Int64.MaxValue, Int64.MaxValue-1)
-                self.assertEqual(x[0], 0)
-                self.assertEqual(x[1], Int64.MaxValue-1)
+            x = range(0, Int64.MaxValue, Int64.MaxValue-1)
+            self.assertEqual(x[0], 0)
+            self.assertEqual(x[1], Int64.MaxValue-1)
 
-                self.assertEqual(len(range(0, Int64.MaxValue, Int64.MaxValue-1)), 2)
+            self.assertEqual(len(range(0, Int64.MaxValue, Int64.MaxValue-1)), 2)
 
-                r = range(-Int64.MaxValue, Int64.MaxValue, 2)
-                self.assertEqual(len(r), Int64.MaxValue)
+            r = range(-Int64.MaxValue, Int64.MaxValue, 2)
+            with self.assertRaises(OverflowError): # len protocol expects an Int32
+                len(r)
 
     def test_range_coverage(self):
         ## ToString

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1195,7 +1195,6 @@ class C:
         y = next(x)
         self.assertTrue(y[0] == 'end' and y[1].tag == 'root')
 
-    @unittest.skipIf(is_cli, "TODO")
     def test_gh463(self):
         """https://github.com/IronLanguages/ironpython2/issues/463"""
         import plistlib

--- a/Tests/test_set.py
+++ b/Tests/test_set.py
@@ -6,9 +6,7 @@
 ## Test built-in types: set/frozenset
 ##
 
-import unittest
-
-from iptest import IronPythonTestCase, is_cli, run_test
+from iptest import IronPythonTestCase, run_test
 from iptest.type_util import myset, myfrozenset
 
 #--GLOBALS---------------------------------------------------------------------
@@ -149,10 +147,7 @@ class SetTest(IronPythonTestCase):
         self.assertEqual(a, b)
 
     def test_deque(self):
-        if is_cli:
-            from _collections import deque
-        else:
-            from collections import deque
+        from _collections import deque
         x = deque([2,3,4,5,6])
         x.remove(2)
         self.assertEqual(x, deque([3,4,5,6]))

--- a/Tests/test_stdmodules.py
+++ b/Tests/test_stdmodules.py
@@ -12,7 +12,7 @@ import os
 import sys
 import locale
 
-from iptest import IronPythonTestCase, is_cli, is_cpython, is_posix, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_posix, run_test, skipUnlessIronPython
 
 class StdModulesTest(IronPythonTestCase):
 
@@ -105,7 +105,7 @@ class StdModulesTest(IronPythonTestCase):
                             "exec", ["1\n"]),
                     ]
 
-        if is_cpython: # https://github.com/IronLanguages/ironpython3/issues/1047
+        if not is_cli: # https://github.com/IronLanguages/ironpython3/issues/1047
             test_list.append(("if 1:\n    print(1)", "exec", ["1\n"]))
 
         for test_case, kind, expected in test_list:
@@ -135,7 +135,7 @@ class StdModulesTest(IronPythonTestCase):
                         ("def f(n):\n    return n*n\n\nf(3)\n", "single"),
                         ("if 1:\n    print(1)",                  "single"),
                     ]
-        if not is_cpython: # https://github.com/IronLanguages/ironpython3/issues/1047
+        if is_cli: # https://github.com/IronLanguages/ironpython3/issues/1047
             bad_test_list.append(("if 1:\n    print(1)",                  "exec"))
 
         for test_case, kind in bad_test_list:

--- a/Tests/test_syntax.py
+++ b/Tests/test_syntax.py
@@ -147,6 +147,8 @@ self.assertEqual(x, 7)
         #   please upload a patch to the tracker!
         # http://mail.python.org/pipermail/python-dev/2009-May/089793.html
         self.assertRaises(SyntaxError, compile, "def f(a):\n\treturn a\n\t", "", "single")
+    else:
+        compile("def f(a):\n\treturn a\n\t", "", "single")
 
     self.assertRaises(SyntaxError, compile, "def f(a):\n\treturn a\n\t", "", "single", 0x200)
     # should work

--- a/Tests/test_with.py
+++ b/Tests/test_with.py
@@ -3,9 +3,8 @@
 # See the LICENSE file in the project root for more information.
 
 import sys
-import unittest
 
-from iptest import is_cpython, run_test
+from iptest import IronPythonTestCase, run_test
 
 class MissingEnter:
     def __exit__(self,a,b,c): pass
@@ -18,7 +17,7 @@ class H:
 
 class Myerr1(Exception):pass
 
-class WithTest(unittest.TestCase):
+class WithTest(IronPythonTestCase):
 
     def test_raise(self):
         events = []


### PR DESCRIPTION
Tried to clean up some `is_cli` uses in the testing codebase:
- Replace some uses of `unittest.skipUnless(is_cli)` with `skipUnlessIronPython`.
- Replace some `unittest.TestCase` with `IronPythonTestCase`.
- Clean up some whitespace.
- Remove some unnecessary skips.