### PR TITLE
Rename ConvertToLong to ConvertToInt

### DIFF
--- a/Src/IronPython.Modules/_csv.cs
+++ b/Src/IronPython.Modules/_csv.cs
@@ -910,7 +910,6 @@ elements will be converted to string.")]
                     object field = e.Current;
                     var quoted = _dialect.quoting switch {
                         QUOTE_NONNUMERIC => !(PythonOps.CheckingConvertToFloat(field) ||
-                                                PythonOps.CheckingConvertToInt(field) ||
                                                 PythonOps.CheckingConvertToBigInt(field)),
                         QUOTE_ALL => true,
                         _ => false,

--- a/Src/IronPython.Modules/_csv.cs
+++ b/Src/IronPython.Modules/_csv.cs
@@ -911,7 +911,7 @@ elements will be converted to string.")]
                     var quoted = _dialect.quoting switch {
                         QUOTE_NONNUMERIC => !(PythonOps.CheckingConvertToFloat(field) ||
                                                 PythonOps.CheckingConvertToInt(field) ||
-                                                PythonOps.CheckingConvertToLong(field)),
+                                                PythonOps.CheckingConvertToBigInt(field)),
                         QUOTE_ALL => true,
                         _ => false,
                     };

--- a/Src/IronPython.Modules/_csv.cs
+++ b/Src/IronPython.Modules/_csv.cs
@@ -910,7 +910,7 @@ elements will be converted to string.")]
                     object field = e.Current;
                     var quoted = _dialect.quoting switch {
                         QUOTE_NONNUMERIC => !(PythonOps.CheckingConvertToFloat(field) ||
-                                                PythonOps.CheckingConvertToBigInt(field)),
+                                                PythonOps.CheckingConvertToInt(field)),
                         QUOTE_ALL => true,
                         _ => false,
                     };

--- a/Src/IronPython/Runtime/Binding/MetaUserObject.cs
+++ b/Src/IronPython/Runtime/Binding/MetaUserObject.cs
@@ -192,7 +192,9 @@ namespace IronPython.Runtime.Binding {
                         }
                         break;
                     case TypeCode.Int32:
-                        return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToInt");
+                        return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToBigInt",
+                            () => FallbackConvert(conversion),
+                            (x) => Ast.Call(null, typeof(PythonOps).GetMethod(nameof(PythonOps.ConvertIntToInt32)), x));  // GH #52
                     case TypeCode.Double:
                         return MakeConvertRuleForCall(conversion, type, this, "__float__", "ConvertToFloat");
                     case TypeCode.Boolean:

--- a/Src/IronPython/Runtime/Binding/MetaUserObject.cs
+++ b/Src/IronPython/Runtime/Binding/MetaUserObject.cs
@@ -179,7 +179,7 @@ namespace IronPython.Runtime.Binding {
                                 (x) => x);
                         } else if (type == typeof(BigInteger)) {
                             if (!typeof(Extensible<BigInteger>).IsAssignableFrom(LimitType)) {
-                                return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToBigInt",
+                                return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToInt",
                                     () => FallbackConvert(conversion),
                                     (x) => Ast.Call(null, typeof(PythonOps).GetMethod(nameof(PythonOps.ConvertIntToBigInt)), x));  // GH #52
                             }
@@ -192,7 +192,7 @@ namespace IronPython.Runtime.Binding {
                         }
                         break;
                     case TypeCode.Int32:
-                        return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToBigInt",
+                        return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToInt",
                             () => FallbackConvert(conversion),
                             (x) => Ast.Call(null, typeof(PythonOps).GetMethod(nameof(PythonOps.ConvertIntToInt32)), x));  // GH #52
                     case TypeCode.Double:

--- a/Src/IronPython/Runtime/Binding/MetaUserObject.cs
+++ b/Src/IronPython/Runtime/Binding/MetaUserObject.cs
@@ -179,7 +179,7 @@ namespace IronPython.Runtime.Binding {
                                 (x) => x);
                         } else if (type == typeof(BigInteger)) {
                             if (!typeof(Extensible<BigInteger>).IsAssignableFrom(LimitType)) {
-                                return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToLong",
+                                return MakeConvertRuleForCall(conversion, type, this, "__int__", "ConvertToBigInt",
                                     () => FallbackConvert(conversion),
                                     (x) => Ast.Call(null, typeof(PythonOps).GetMethod(nameof(PythonOps.ConvertIntToBigInt)), x));  // GH #52
                             }

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2833,13 +2833,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object? ConvertFloatToComplex(object value) {
-            if (value == null) {
-                return null;
-            }
-
-            if (value is double d) return new Complex(d, 0.0);
-            if (value is Extensible<double> ed) return new Complex(ed.Value, 0.0);
-            throw new InvalidOperationException();
+            return value switch {
+                null => null,
+                double d => new Complex(d, 0.0),
+                Extensible<double> ed => new Complex(ed.Value, 0.0),
+                _ => throw new InvalidOperationException(),
+            };
         }
 
         public static object? ConvertIntToBigInt(object? value) {
@@ -2847,6 +2846,7 @@ namespace IronPython.Runtime.Operations {
                 null => null,
                 int i => new BigInteger(i),
                 BigInteger bi => bi,
+                Extensible<BigInteger> ebi => ebi.Value,
                 _ => throw new InvalidOperationException(),
             };
         }
@@ -2856,6 +2856,7 @@ namespace IronPython.Runtime.Operations {
                 null => null,
                 int i => i,
                 BigInteger bi => (int)bi,
+                Extensible<BigInteger> ebi => (int)ebi.Value,
                 _ => throw new InvalidOperationException(),
             };
         }
@@ -2865,11 +2866,11 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static bool CheckingConvertToFloat(object value) {
-            return value is double || (value != null && value is Extensible<double>);
+            return value is double || value is Extensible<double>;
         }
 
         internal static bool CheckingConvertToComplex(object value) {
-            return value is Complex || value is Extensible<Complex> || CheckingConvertToInt(value) || CheckingConvertToFloat(value);
+            return value is Complex || value is Extensible<Complex>;
         }
 
         internal static bool CheckingConvertToString(object value) {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2860,7 +2860,7 @@ namespace IronPython.Runtime.Operations {
             };
         }
 
-        internal static bool CheckingConvertToBigInt(object value) {
+        internal static bool CheckingConvertToInt(object value) {
             return value is int || value is BigInteger || value is Extensible<BigInteger>;
         }
 
@@ -2869,7 +2869,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static bool CheckingConvertToComplex(object value) {
-            return value is Complex || value is Extensible<Complex> || CheckingConvertToBigInt(value) || CheckingConvertToFloat(value);
+            return value is Complex || value is Extensible<Complex> || CheckingConvertToInt(value) || CheckingConvertToFloat(value);
         }
 
         internal static bool CheckingConvertToString(object value) {
@@ -2880,8 +2880,8 @@ namespace IronPython.Runtime.Operations {
             return value is bool;
         }
 
-        public static object? NonThrowingConvertToBigInt(object value) {
-            if (!CheckingConvertToBigInt(value)) return null;
+        public static object? NonThrowingConvertToInt(object value) {
+            if (!CheckingConvertToInt(value)) return null;
             return value;
         }
 
@@ -2905,8 +2905,8 @@ namespace IronPython.Runtime.Operations {
             return value;
         }
 
-        public static object ThrowingConvertToBigInt(object value) {
-            if (!CheckingConvertToBigInt(value)) throw TypeError(" __int__ returned non-int (type {0})", PythonOps.GetPythonTypeName(value));
+        public static object ThrowingConvertToInt(object value) {
+            if (!CheckingConvertToInt(value)) throw TypeError(" __int__ returned non-int (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2816,18 +2816,15 @@ namespace IronPython.Runtime.Operations {
             return value switch
             {
                 float f => (double)f,
-                double d => d,
                 sbyte sb => (int)sb,
                 byte b => (int)b,
                 char c => (int)c,
                 short s => (int)s,
                 ushort us => (int)us,
-                int i => i,
                 uint ui => (BigInteger)ui,
                 long l => (BigInteger)l,
                 ulong ul => (BigInteger)ul,
-                BigInteger bi => bi,
-                bool b => b,
+                // no conversion needed for: double, int, BigInteger, bool
                 _ => value,
             };
         }
@@ -2845,7 +2842,7 @@ namespace IronPython.Runtime.Operations {
             return value switch {
                 null => null,
                 int i => new BigInteger(i),
-                BigInteger bi => bi,
+                BigInteger => value,
                 Extensible<BigInteger> ebi => ebi.Value,
                 _ => throw new InvalidOperationException(),
             };
@@ -2854,7 +2851,7 @@ namespace IronPython.Runtime.Operations {
         public static object? ConvertIntToInt32(object? value) {
             return value switch {
                 null => null,
-                int i => i,
+                int => value,
                 BigInteger bi => (int)bi,
                 Extensible<BigInteger> ebi => (int)ebi.Value,
                 _ => throw new InvalidOperationException(),

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2855,8 +2855,8 @@ namespace IronPython.Runtime.Operations {
             return value is int || value is BigInteger || value is Extensible<BigInteger>;
         }
 
-        internal static bool CheckingConvertToLong(object value) {
-            return CheckingConvertToInt(value);
+        internal static bool CheckingConvertToBigInt(object value) {
+            return value is int || value is BigInteger || value is Extensible<BigInteger>;
         }
 
         internal static bool CheckingConvertToFloat(object value) {
@@ -2880,8 +2880,8 @@ namespace IronPython.Runtime.Operations {
             return value;
         }
 
-        public static object? NonThrowingConvertToLong(object value) {
-            if (!CheckingConvertToInt(value)) return null;
+        public static object? NonThrowingConvertToBigInt(object value) {
+            if (!CheckingConvertToBigInt(value)) return null;
             return value;
         }
 
@@ -2910,6 +2910,11 @@ namespace IronPython.Runtime.Operations {
             return value;
         }
 
+        public static object ThrowingConvertToBigInt(object value) {
+            if (!CheckingConvertToBigInt(value)) throw TypeError(" __int__ returned non-int (type {0})", PythonOps.GetPythonTypeName(value));
+            return value;
+        }
+
         public static object ThrowingConvertToFloat(object value) {
             if (!CheckingConvertToFloat(value)) throw TypeError(" __float__ returned non-float (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
@@ -2917,11 +2922,6 @@ namespace IronPython.Runtime.Operations {
 
         public static object ThrowingConvertToComplex(object value) {
             if (!CheckingConvertToComplex(value)) throw TypeError(" __complex__ returned non-complex (type {0})", PythonOps.GetPythonTypeName(value));
-            return value;
-        }
-
-        public static object ThrowingConvertToLong(object value) {
-            if (!CheckingConvertToLong(value)) throw TypeError(" __int__ returned non-int (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -2851,8 +2851,13 @@ namespace IronPython.Runtime.Operations {
             };
         }
 
-        internal static bool CheckingConvertToInt(object value) {
-            return value is int || value is BigInteger || value is Extensible<BigInteger>;
+        public static object? ConvertIntToInt32(object? value) {
+            return value switch {
+                null => null,
+                int i => i,
+                BigInteger bi => (int)bi,
+                _ => throw new InvalidOperationException(),
+            };
         }
 
         internal static bool CheckingConvertToBigInt(object value) {
@@ -2864,7 +2869,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static bool CheckingConvertToComplex(object value) {
-            return value is Complex || value is Extensible<Complex> || CheckingConvertToInt(value) || CheckingConvertToFloat(value);
+            return value is Complex || value is Extensible<Complex> || CheckingConvertToBigInt(value) || CheckingConvertToFloat(value);
         }
 
         internal static bool CheckingConvertToString(object value) {
@@ -2873,11 +2878,6 @@ namespace IronPython.Runtime.Operations {
 
         public static bool CheckingConvertToBool(object value) {
             return value is bool;
-        }
-
-        public static object? NonThrowingConvertToInt(object value) {
-            if (!CheckingConvertToInt(value)) return null;
-            return value;
         }
 
         public static object? NonThrowingConvertToBigInt(object value) {
@@ -2902,11 +2902,6 @@ namespace IronPython.Runtime.Operations {
 
         public static object? NonThrowingConvertToBool(object value) {
             if (!CheckingConvertToBool(value)) return null;
-            return value;
-        }
-
-        public static object ThrowingConvertToInt(object value) {
-            if (!CheckingConvertToInt(value)) throw TypeError(" __int__ returned non-int (type {0})", PythonOps.GetPythonTypeName(value));
             return value;
         }
 

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -866,7 +866,7 @@ namespace IronPython.Runtime {
                         key = arg.Value;
                         break;
                     case "reverse":
-                        if (!PythonOps.CheckingConvertToBool(arg.Value) && !PythonOps.CheckingConvertToBigInt(arg.Value)) { // Python 3.8: PythonOps.TryToIndex
+                        if (!PythonOps.CheckingConvertToBool(arg.Value) && !PythonOps.CheckingConvertToInt(arg.Value)) { // Python 3.8: PythonOps.TryToIndex
                             throw PythonOps.TypeErrorForTypeMismatch("integer", arg.Value);
                         }
                         reverse = Convert.ToBoolean(arg.Value);

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -866,7 +866,7 @@ namespace IronPython.Runtime {
                         key = arg.Value;
                         break;
                     case "reverse":
-                        if (!PythonOps.CheckingConvertToBool(arg.Value) && !PythonOps.CheckingConvertToInt(arg.Value)) {
+                        if (!PythonOps.CheckingConvertToBool(arg.Value) && !PythonOps.CheckingConvertToBigInt(arg.Value)) { // Python 3.8: PythonOps.TryToIndex
                             throw PythonOps.TypeErrorForTypeMismatch("integer", arg.Value);
                         }
                         reverse = Convert.ToBoolean(arg.Value);

--- a/Src/IronPythonTest/EngineTest.cs
+++ b/Src/IronPythonTest/EngineTest.cs
@@ -1088,6 +1088,9 @@ class ns(object):
 
     SomeDelegate = somecallable
 
+class ns_bigint(ns):
+    def __int__(self): return (42).ToBigInteger()
+
 class ns_getattr(object):
     ClassVal = 'ClassVal'
 
@@ -1192,10 +1195,14 @@ class os:
 
     SomeDelegate = somecallable
 
+class os_bigint(os):
+    def __int__(self): return (42).ToBigInteger()
+
 class plain_os:
     pass
 
-class plain_ns(object): pass
+class plain_ns(object):
+    pass
 
 class os_getattr:
     ClassVal = 'ClassVal'
@@ -1242,12 +1249,14 @@ TestFunc.ClassVal = 'ClassVal'  # just here to simplify tests
 if not clr.IsNetCoreApp and not clr.IsMono:
     controlinst = control()
 nsinst = ns()
+nsinstbig = ns_bigint()
 iterable = IterableObject()
 iterableos = IterableObjectOs()
 plainnsinst = plain_ns()
 nsmethod = nsinst.NsMethod
 alinst = MyArrayList()
 osinst = os()
+osinstbig = os_bigint()
 plainosinst = plain_os()
 os_getattrinst = os_getattr()
 ns_getattrinst = ns_getattr()
@@ -1269,7 +1278,7 @@ range = range
             var indexableObjects = new object[] { scope.GetVariable("nsinst"), scope.GetVariable("osinst") };
             var unindexableObjects = new object[] { scope.GetVariable("TestFunc"), scope.GetVariable("ns_getattrinst"), scope.GetVariable("somecallable") }; // scope.GetVariable("plainosinst"),
             var invokableObjects = new object[] { scope.GetVariable("Invokable"), scope.GetVariable("nsinst"), scope.GetVariable("osinst"), scope.GetVariable("nsmethod"), };
-            var convertableObjects = new object[] { scope.GetVariable("nsinst"), scope.GetVariable("osinst") };
+            var convertableObjects = new object[] { scope.GetVariable("nsinst"), scope.GetVariable("osinst"), scope.GetVariable("nsinstbig"), scope.GetVariable("osinstbig") };
             var unconvertableObjects = new object[] { scope.GetVariable("plainnsinst"), scope.GetVariable("plainosinst") };
             var iterableObjects = new object[] { scope.GetVariable("iterable"), scope.GetVariable("iterableos") };
 
@@ -1377,7 +1386,7 @@ range = range
                 var ssite = CallSite<Func<CallSite, object, string>>.Create(new MyConvertBinder(typeof(string)));
                 Assert.AreEqual(ssite.Target(ssite, inst), "Python");
 
-                // this call site works only if __int__ happens to return an Int32 instance
+                // this call site works only if __int__ happens to return an Int32 instance or a BigInteger instance that fits in 32 bits
                 var isite = CallSite<Func<CallSite, object, int>>.Create(new MyConvertBinder(typeof(int), 23));
                 Assert.AreEqual(isite.Target(isite, inst), 42);
 


### PR DESCRIPTION
Follow-up on https://github.com/IronLanguages/ironpython3/pull/1329 (issue https://github.com/IronLanguages/ironpython3/issues/52).

Since `__long__` is gone, to avoid confusion, `XxxConvertToLong` is renamed to `XxxConvertToInt`, while the old `XxxConvertToInt` is gone. Plus some cleanup. A couple of functional changes are fixes:

* If `__int__` returns a `BigInteger` instance, a conversion call site with return type `Int32` succeeds or throws `OverflowException` if the value does not fit in 32 bits. Previously it was always throwing `TypeErrorException` with a rather cryptic message: `__int__ returned non-int (int)`, regardless of the value.
* If `__complex__` returns non-complex, `TypeErrorException` with a proper message is returned `__complex__ returned non-complex (xxx)` rather than `InvalidCastException`.