### PR TITLE
Convert internal field CData._memHolder to property CData.MemHolder

### DIFF
--- a/Src/IronPython.Modules/ModuleOps.cs
+++ b/Src/IronPython.Modules/ModuleOps.cs
@@ -55,15 +55,15 @@ namespace IronPython.Modules {
             Debug.Assert(holder is MemoryHolder);
 
             CTypes.CData data = (CTypes.CData)type.CreateInstance(type.Context.SharedContext);
-            data._memHolder = (MemoryHolder)holder;
+            data.MemHolder = (MemoryHolder)holder;
             return data;
         }
 
         public static object CreateCData(IntPtr dataAddress, PythonType type) {
             CTypes.INativeType nativeType = (CTypes.INativeType)type;
             CTypes.CData data = (CTypes.CData)type.CreateInstance(type.Context.SharedContext);
-            data._memHolder = new MemoryHolder(nativeType.Size);
-            data._memHolder.CopyFrom(dataAddress, new IntPtr(nativeType.Size));
+            data.MemHolder = new MemoryHolder(nativeType.Size);
+            data.MemHolder.CopyFrom(dataAddress, new IntPtr(nativeType.Size));
             return data;
         }
 
@@ -325,7 +325,7 @@ namespace IronPython.Modules {
                     simpType._type == CTypes.SimpleTypeKind.CharPointer) {
                     return sd.UnsafeAddress;
                 } else if (simpType._type == CTypes.SimpleTypeKind.Pointer) {
-                    return sd._memHolder.ReadIntPtr(0);
+                    return sd.MemHolder.ReadIntPtr(0);
                 }
             }
 

--- a/Src/IronPython.Modules/_ctypes/Array.cs
+++ b/Src/IronPython.Modules/_ctypes/Array.cs
@@ -28,7 +28,7 @@ namespace IronPython.Modules {
             public void __init__(params object[] args) {
                 INativeType nativeType = NativeType;
 
-                _memHolder = new MemoryHolder(nativeType.Size);
+                MemHolder = new MemoryHolder(nativeType.Size);
 
                 if (args.Length > ((ArrayType)nativeType).Length) {
                     throw PythonOps.IndexError("too many arguments");
@@ -36,7 +36,7 @@ namespace IronPython.Modules {
 
                 INativeType elementType = ElementType;
                 for (var i = 0; i < args.Length; i++) {
-                    elementType.SetValue(_memHolder, checked(i * elementType.Size), args[i]);
+                    elementType.SetValue(MemHolder, checked(i * elementType.Size), args[i]);
                 }
             }
 
@@ -45,7 +45,7 @@ namespace IronPython.Modules {
                     index = PythonOps.FixIndex(index, ((ArrayType)NativeType).Length);
                     INativeType elementType = ElementType;
                     return elementType.GetValue(
-                        _memHolder,
+                        MemHolder,
                         this,
                         checked(index * elementType.Size),
                         false
@@ -56,13 +56,13 @@ namespace IronPython.Modules {
                     INativeType elementType = ElementType;
 
                     object keepAlive = elementType.SetValue(
-                        _memHolder,
+                        MemHolder,
                         checked(index * elementType.Size),
                         value
                     );
 
                     if (keepAlive != null) {
-                        _memHolder.AddObject(index.ToString(), keepAlive);
+                        MemHolder.AddObject(index.ToString(), keepAlive);
                     }
                 }
             }
@@ -86,11 +86,11 @@ namespace IronPython.Modules {
                         if (elemType._type == SimpleTypeKind.Char) {
                             Debug.Assert(((INativeType)elemType).Size == 1);
                             if (step == 1) {
-                                return _memHolder.ReadBytes(start, count);
+                                return MemHolder.ReadBytes(start, count);
                             } else {
                                 var buffer = new byte[count];
                                 for (int i = 0, index = start; i < count; i++, index += step) {
-                                    buffer[i] = _memHolder.ReadByte(index);
+                                    buffer[i] = MemHolder.ReadByte(index);
                                 }
                                 return Bytes.Make(buffer);
                             }
@@ -98,11 +98,11 @@ namespace IronPython.Modules {
                         if (elemType._type == SimpleTypeKind.WChar) {
                             int elmSize = ((INativeType)elemType).Size;
                             if (step == 1) {
-                                return _memHolder.ReadUnicodeString(checked(start * elmSize), count);
+                                return MemHolder.ReadUnicodeString(checked(start * elmSize), count);
                             } else {
                                 var res = new StringBuilder(count);
                                 for (int i = 0, index = start; i < count; i++, index += step) {
-                                    res.Append((char)_memHolder.ReadInt16(checked(index * elmSize)));
+                                    res.Append((char)MemHolder.ReadInt16(checked(index * elmSize)));
                                 }
                                 return res.ToString();
                             }

--- a/Src/IronPython.Modules/_ctypes/ArrayType.cs
+++ b/Src/IronPython.Modules/_ctypes/ArrayType.cs
@@ -104,8 +104,8 @@ namespace IronPython.Modules {
 
                 _Array res = (_Array)CreateInstance(context);
                 IntPtr addr = array.GetArrayAddress();
-                res._memHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
-                res._memHolder.AddObject("ffffffff", array);
+                res.MemHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
+                res.MemHolder.AddObject("ffffffff", array);
                 return res;
             }
 
@@ -113,8 +113,8 @@ namespace IronPython.Modules {
                 ValidateArraySizes(array, offset, ((INativeType)this).Size);
 
                 _Array res = (_Array)CreateInstance(context);
-                res._memHolder = new MemoryHolder(((INativeType)this).Size);
-                res._memHolder.CopyFrom(array.GetArrayAddress().Add(offset), new IntPtr(((INativeType)this).Size));
+                res.MemHolder = new MemoryHolder(((INativeType)this).Size);
+                res.MemHolder.CopyFrom(array.GetArrayAddress().Add(offset), new IntPtr(((INativeType)this).Size));
                 GC.KeepAlive(array);
                 return res;
             }
@@ -123,9 +123,9 @@ namespace IronPython.Modules {
                 ValidateArraySizes(array, offset, ((INativeType)this).Size);
 
                 _Array res = (_Array)CreateInstance(context);
-                res._memHolder = new MemoryHolder(((INativeType)this).Size);
+                res.MemHolder = new MemoryHolder(((INativeType)this).Size);
                 for (int i = 0; i < ((INativeType)this).Size; i++) {
-                    res._memHolder.WriteByte(i, ((IList<byte>)array)[i]);
+                    res.MemHolder.WriteByte(i, ((IList<byte>)array)[i]);
                 }
                 return res;
             }
@@ -134,9 +134,9 @@ namespace IronPython.Modules {
                 ValidateArraySizes(data, offset, ((INativeType)this).Size);
 
                 _Array res = (_Array)CreateInstance(context);
-                res._memHolder = new MemoryHolder(((INativeType)this).Size);
+                res.MemHolder = new MemoryHolder(((INativeType)this).Size);
                 for (int i = 0; i < ((INativeType)this).Size; i++) {
-                    res._memHolder.WriteByte(i, (byte)data[i]);
+                    res.MemHolder.WriteByte(i, (byte)data[i]);
                 }
                 return res;
             }
@@ -208,7 +208,7 @@ namespace IronPython.Modules {
                 }
 
                 _Array arr = (_Array)CreateInstance(Context.SharedContext);
-                arr._memHolder = new MemoryHolder(owner.UnsafeAddress.Add(offset), ((INativeType)this).Size, owner);
+                arr.MemHolder = new MemoryHolder(owner.UnsafeAddress.Add(offset), ((INativeType)this).Size, owner);
                 return arr;
             }
 
@@ -276,8 +276,8 @@ namespace IronPython.Modules {
                     }
                 } else {
                     if (value is _Array arr && arr.NativeType == this) {
-                        arr._memHolder.CopyTo(address, offset, ((INativeType)this).Size);
-                        return arr._memHolder.EnsureObjects();
+                        arr.MemHolder.CopyTo(address, offset, ((INativeType)this).Size);
+                        return arr.MemHolder.EnsureObjects();
                     }
 
                     throw PythonOps.TypeError("unexpected {0} instance, got {1}", Name, PythonOps.GetPythonTypeName(value));

--- a/Src/IronPython.Modules/_ctypes/CData.cs
+++ b/Src/IronPython.Modules/_ctypes/CData.cs
@@ -36,12 +36,14 @@ namespace IronPython.Modules {
         /// </summary>
         [PythonType("_CData"), PythonHidden]
         public abstract class CData : IBufferProtocol, IPythonBuffer {
-            internal MemoryHolder _memHolder;
+            internal MemoryHolder MemHolder {
+                get => _memHolder ?? throw new InvalidOperationException($"{nameof(CData)} object not fully initialized.");
+                set => _memHolder = value;
+            }
+            private MemoryHolder? _memHolder;
 
             // members: __setstate__,  __reduce__ _b_needsfree_ __ctypes_from_outparam__ __hash__ _objects _b_base_ __doc__
-            protected CData() {
-                _memHolder = null!;
-            }
+            protected CData() { }
 
             // TODO: What if a user directly subclasses CData?
             [PythonHidden]
@@ -49,15 +51,15 @@ namespace IronPython.Modules {
 
             // TODO: Accesses via Ops class
             [PythonHidden]
-            public IntPtr UnsafeAddress => _memHolder.UnsafeAddress;
+            public IntPtr UnsafeAddress => MemHolder.UnsafeAddress;
 
             internal INativeType NativeType => (INativeType)DynamicHelpers.GetPythonType(this);
 
-            public virtual object _objects => _memHolder.Objects;
+            public virtual object _objects => MemHolder.Objects;
 
             internal void SetAddress(IntPtr address) {
                 Debug.Assert(_memHolder == null);
-                _memHolder = new MemoryHolder(address, NativeType.Size);
+                MemHolder = new MemoryHolder(address, NativeType.Size);
             }
 
             internal virtual PythonTuple GetBufferInfo()
@@ -73,10 +75,10 @@ namespace IronPython.Modules {
             object IPythonBuffer.Object => this;
 
             unsafe ReadOnlySpan<byte> IPythonBuffer.AsReadOnlySpan()
-                => new Span<byte>(_memHolder.UnsafeAddress.ToPointer(), _memHolder.Size);
+                => new Span<byte>(MemHolder.UnsafeAddress.ToPointer(), MemHolder.Size);
 
             unsafe Span<byte> IPythonBuffer.AsSpan()
-                => new Span<byte>(_memHolder.UnsafeAddress.ToPointer(), _memHolder.Size);
+                => new Span<byte>(MemHolder.UnsafeAddress.ToPointer(), MemHolder.Size);
 
             int IPythonBuffer.Offset => 0;
 

--- a/Src/IronPython.Modules/_ctypes/CFuncPtr.cs
+++ b/Src/IronPython.Modules/_ctypes/CFuncPtr.cs
@@ -85,18 +85,18 @@ namespace IronPython.Modules {
                     }
                 }
 
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
                 addr = tmpAddr;
                 _id = Interlocked.Increment(ref _curId);
             }
 
             public _CFuncPtr() {
                 _id = Interlocked.Increment(ref _curId);
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
             }
 
             public _CFuncPtr(CodeContext context, object function) {
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
                 if (function != null) {
                     if (!PythonOps.IsCallable(context, function)) {
                         throw PythonOps.TypeError("argument must be called or address of function");
@@ -120,7 +120,7 @@ namespace IronPython.Modules {
             /// Creates a new CFuncPtr which calls a COM method.
             /// </summary>
             public _CFuncPtr(int index, string name) {
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
                 _comInterfaceIndex = index;
                 _id = Interlocked.Increment(ref _curId);
             }
@@ -130,7 +130,7 @@ namespace IronPython.Modules {
             /// Creates a new CFuncPtr with the specfied address.
             /// </summary>
             public _CFuncPtr(int handle) {
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
                 addr = new IntPtr(handle);
                 _id = Interlocked.Increment(ref _curId);
             }
@@ -139,13 +139,13 @@ namespace IronPython.Modules {
             /// Creates a new CFuncPtr with the specfied address.
             /// </summary>
             public _CFuncPtr([NotNull] BigInteger handle) {
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
                 addr = new IntPtr((long)handle);
                 _id = Interlocked.Increment(ref _curId);
             }
 
             public _CFuncPtr(IntPtr handle) {
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
                 addr = handle;
                 _id = Interlocked.Increment(ref _curId);
             }
@@ -251,11 +251,11 @@ namespace IronPython.Modules {
             public IntPtr addr {
                 [PythonHidden]
                 get {
-                    return _memHolder.ReadIntPtr(0);
+                    return MemHolder.ReadIntPtr(0);
                 }
                 [PythonHidden]
                 set {
-                    _memHolder.WriteIntPtr(0, value);
+                    MemHolder.WriteIntPtr(0, value);
                 }
             }
 

--- a/Src/IronPython.Modules/_ctypes/Field.cs
+++ b/Src/IronPython.Modules/_ctypes/Field.cs
@@ -68,7 +68,7 @@ namespace IronPython.Modules {
             internal override bool TryGetValue(CodeContext context, object instance, PythonType owner, out object value) {
                 if (instance != null) {
                     CData inst = (CData)instance;
-                    value = _fieldType.GetValue(inst._memHolder, inst, _offset, false);
+                    value = _fieldType.GetValue(inst.MemHolder, inst, _offset, false);
                     if (_bits == -1) {
                         return true;
                     }
@@ -90,7 +90,7 @@ namespace IronPython.Modules {
 
             internal override bool TrySetValue(CodeContext context, object instance, PythonType owner, object value) {
                 if (instance != null) {
-                    SetValue(((CData)instance)._memHolder, 0, value);
+                    SetValue(((CData)instance).MemHolder, 0, value);
                     return true;
 
                 }

--- a/Src/IronPython.Modules/_ctypes/Pointer.cs
+++ b/Src/IronPython.Modules/_ctypes/Pointer.cs
@@ -25,16 +25,16 @@ namespace IronPython.Modules {
 #pragma warning restore 414
 
             public Pointer() {
-                _memHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder = new MemoryHolder(IntPtr.Size);
             }
 
             public Pointer(CData value) {
                 _object = value; // Keep alive the object, more to do here.
-                _memHolder = new MemoryHolder(IntPtr.Size);
-                _memHolder.WriteIntPtr(0, value._memHolder);
-                _memHolder.AddObject("1", value);
+                MemHolder = new MemoryHolder(IntPtr.Size);
+                MemHolder.WriteIntPtr(0, value.MemHolder);
+                MemHolder.AddObject("1", value);
                 if (value._objects != null) {
-                    _memHolder.AddObject("0", value._objects);
+                    MemHolder.AddObject("0", value._objects);
                 }
             }
 
@@ -43,8 +43,8 @@ namespace IronPython.Modules {
                     PythonType elementType = (PythonType)((PointerType)NativeType)._type;
 
                     CData res = (CData)elementType.CreateInstance(elementType.Context.SharedContext);
-                    res._memHolder = _memHolder.ReadMemoryHolder(0);
-                    if(res._memHolder.UnsafeAddress == IntPtr.Zero) {
+                    res.MemHolder = MemHolder.ReadMemoryHolder(0);
+                    if(res.MemHolder.UnsafeAddress == IntPtr.Zero) {
                         throw PythonOps.ValueError("NULL value access");
                     }
                     return res;
@@ -56,23 +56,23 @@ namespace IronPython.Modules {
             public object this[int index] {
                 get {
                     INativeType type = ((PointerType)NativeType)._type;
-                    MemoryHolder address = _memHolder.ReadMemoryHolder(0);
+                    MemoryHolder address = MemHolder.ReadMemoryHolder(0);
 
                     return type.GetValue(address, this, checked(type.Size * index), false);
                 }
                 set {
-                    MemoryHolder address = _memHolder.ReadMemoryHolder(0);
+                    MemoryHolder address = MemHolder.ReadMemoryHolder(0);
 
                     INativeType type = ((PointerType)NativeType)._type;
                     object keepAlive = type.SetValue(address, checked(type.Size * index), value);
                     if (keepAlive != null) {
-                        _memHolder.AddObject(index.ToString(), keepAlive);
+                        MemHolder.AddObject(index.ToString(), keepAlive);
                     }
                 }
             }
 
             public bool __bool__() {
-                return _memHolder.ReadIntPtr(0) != IntPtr.Zero;
+                return MemHolder.ReadIntPtr(0) != IntPtr.Zero;
             }
 
             public object this[Slice index] {
@@ -103,7 +103,7 @@ namespace IronPython.Modules {
                         return new PythonList();
                     }
 
-                    MemoryHolder address = _memHolder.ReadMemoryHolder(0);
+                    MemoryHolder address = MemHolder.ReadMemoryHolder(0);
                     if (elemType != null) {
                         if (elemType._type == SimpleTypeKind.Char) {
                             Debug.Assert(((INativeType)elemType).Size == 1);

--- a/Src/IronPython.Modules/_ctypes/PointerType.cs
+++ b/Src/IronPython.Modules/_ctypes/PointerType.cs
@@ -64,7 +64,7 @@ namespace IronPython.Modules {
                 }
 
                 Pointer res = (Pointer)PythonCalls.Call(this);
-                res._memHolder.WriteIntPtr(0, obj._memHolder.ReadMemoryHolder(0));
+                res.MemHolder.WriteIntPtr(0, obj.MemHolder.ReadMemoryHolder(0));
                 return res;
             }
 
@@ -112,8 +112,8 @@ namespace IronPython.Modules {
             object INativeType.GetValue(MemoryHolder owner, object readingFrom, int offset, bool raw) {
                 if (!raw) {
                     Pointer res = (Pointer)PythonCalls.Call(Context.SharedContext, this);
-                    res._memHolder.WriteIntPtr(0, owner.ReadIntPtr(offset));
-                    res._memHolder.AddObject(offset, readingFrom);
+                    res.MemHolder.WriteIntPtr(0, owner.ReadIntPtr(offset));
+                    res.MemHolder.AddObject(offset, readingFrom);
                     return res;
                 }
                 return owner.ReadIntPtr(offset).ToPython();
@@ -129,10 +129,10 @@ namespace IronPython.Modules {
                 } else if (value is BigInteger) {
                     address.WriteIntPtr(offset, new IntPtr((long)(BigInteger)value));
                 } else if ((ptr = value as Pointer) != null) {
-                    address.WriteIntPtr(offset, ptr._memHolder.ReadMemoryHolder(0));
+                    address.WriteIntPtr(offset, ptr.MemHolder.ReadMemoryHolder(0));
                     return PythonOps.MakeDictFromItems(ptr, "0", ptr._objects, "1");
                 } else if ((array = value as _Array) != null) {
-                    address.WriteIntPtr(offset, array._memHolder);
+                    address.WriteIntPtr(offset, array.MemHolder);
                     return array;
                 } else {
                     throw PythonOps.TypeErrorForTypeMismatch(Name, value);

--- a/Src/IronPython.Modules/_ctypes/SimpleCData.cs
+++ b/Src/IronPython.Modules/_ctypes/SimpleCData.cs
@@ -32,7 +32,7 @@ namespace IronPython.Modules {
             }
 
             public void __init__() {
-                _memHolder = new MemoryHolder(Size);
+                MemHolder = new MemoryHolder(Size);
             }
 
             public void __init__(CodeContext/*!*/ context, object value) {
@@ -105,25 +105,25 @@ namespace IronPython.Modules {
                         break;
                 }
 
-                _memHolder = new MemoryHolder(Size);
-                NativeType.SetValue(_memHolder, 0, value);
+                MemHolder = new MemoryHolder(Size);
+                NativeType.SetValue(MemHolder, 0, value);
                 if (IsString) {
-                    _memHolder.AddObject("str", value);
+                    MemHolder.AddObject("str", value);
                 }
             }
 
             // implemented as PropertyMethod's so that we can have delete
             [PropertyMethod, SpecialName]
             public void Setvalue(object value) {
-                NativeType.SetValue(_memHolder, 0, value);
+                NativeType.SetValue(MemHolder, 0, value);
                 if (IsString) {
-                    _memHolder.AddObject("str", value);
+                    MemHolder.AddObject("str", value);
                 }
             }
 
             [PropertyMethod, SpecialName]
             public object Getvalue() {
-                return NativeType.GetValue(_memHolder, this, 0, true);
+                return NativeType.GetValue(MemHolder, this, 0, true);
             }
 
             [PropertyMethod, SpecialName]
@@ -134,13 +134,13 @@ namespace IronPython.Modules {
             public override object _objects {
                 get {
                     if (IsString) {
-                        PythonDictionary objs = _memHolder.Objects;
+                        PythonDictionary objs = MemHolder.Objects;
                         if (objs != null) {
                             return objs["str"];
                         }
                     }
 
-                    return _memHolder.Objects;
+                    return MemHolder.Objects;
                 }
             }
 
@@ -163,7 +163,7 @@ namespace IronPython.Modules {
             }
 
             private string GetDataRepr(CodeContext/*!*/ context) {
-                return PythonOps.Repr(context, NativeType.GetValue(_memHolder, this, 0, false));
+                return PythonOps.Repr(context, NativeType.GetValue(MemHolder, this, 0, false));
             }
 
             #endregion

--- a/Src/IronPython.Modules/_ctypes/SimpleType.cs
+++ b/Src/IronPython.Modules/_ctypes/SimpleType.cs
@@ -136,8 +136,8 @@ namespace IronPython.Modules {
 
                 SimpleCData res = (SimpleCData)CreateInstance(Context.SharedContext);
                 IntPtr addr = array.GetArrayAddress();
-                res._memHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
-                res._memHolder.AddObject("ffffffff", array);
+                res.MemHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
+                res.MemHolder.AddObject("ffffffff", array);
                 return res;
             }
 
@@ -145,8 +145,8 @@ namespace IronPython.Modules {
                 ValidateArraySizes(array, offset, ((INativeType)this).Size);
 
                 SimpleCData res = (SimpleCData)CreateInstance(Context.SharedContext);
-                res._memHolder = new MemoryHolder(((INativeType)this).Size);
-                res._memHolder.CopyFrom(array.GetArrayAddress().Add(offset), new IntPtr(((INativeType)this).Size));
+                res.MemHolder = new MemoryHolder(((INativeType)this).Size);
+                res.MemHolder.CopyFrom(array.GetArrayAddress().Add(offset), new IntPtr(((INativeType)this).Size));
                 GC.KeepAlive(array);
                 return res;
             }
@@ -251,7 +251,7 @@ namespace IronPython.Modules {
 
             object INativeType.SetValue(MemoryHolder/*!*/ owner, int offset, object value) {
                 if (value is SimpleCData data && data.NativeType == this) {
-                    data._memHolder.CopyTo(owner, offset, ((INativeType)this).Size);
+                    data.MemHolder.CopyTo(owner, offset, ((INativeType)this).Size);
                     return null;
                 }
 

--- a/Src/IronPython.Modules/_ctypes/StructType.cs
+++ b/Src/IronPython.Modules/_ctypes/StructType.cs
@@ -94,8 +94,8 @@ namespace IronPython.Modules {
 
                 _Structure res = (_Structure)CreateInstance(context);
                 IntPtr addr = array.GetArrayAddress();
-                res._memHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
-                res._memHolder.AddObject("ffffffff", array);
+                res.MemHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
+                res.MemHolder.AddObject("ffffffff", array);
                 return res;
             }
 
@@ -103,8 +103,8 @@ namespace IronPython.Modules {
                 ValidateArraySizes(array, offset, ((INativeType)this).Size);
 
                 _Structure res = (_Structure)CreateInstance(Context.SharedContext);
-                res._memHolder = new MemoryHolder(((INativeType)this).Size);
-                res._memHolder.CopyFrom(array.GetArrayAddress().Add(offset), new IntPtr(((INativeType)this).Size));
+                res.MemHolder = new MemoryHolder(((INativeType)this).Size);
+                res.MemHolder.CopyFrom(array.GetArrayAddress().Add(offset), new IntPtr(((INativeType)this).Size));
                 GC.KeepAlive(array);
                 return res;
             }
@@ -160,7 +160,7 @@ namespace IronPython.Modules {
 
             object INativeType.GetValue(MemoryHolder/*!*/ owner, object readingFrom, int offset, bool raw) {
                 _Structure res = (_Structure)CreateInstance(this.Context.SharedContext);
-                res._memHolder = owner.GetSubBlock(offset);
+                res.MemHolder = owner.GetSubBlock(offset);
                 return res;
             }
 
@@ -191,8 +191,8 @@ namespace IronPython.Modules {
                 } else {
                     CData data = value as CData;
                     if (data != null) {
-                        data._memHolder.CopyTo(address, offset, data.Size);
-                        return data._memHolder.EnsureObjects();
+                        data.MemHolder.CopyTo(address, offset, data.Size);
+                        return data.MemHolder.EnsureObjects();
                     } else {
                         throw new NotImplementedException("set value");
                     }

--- a/Src/IronPython.Modules/_ctypes/Structure.cs
+++ b/Src/IronPython.Modules/_ctypes/Structure.cs
@@ -41,7 +41,7 @@ namespace IronPython.Modules {
         public abstract class _Structure : CData {
             protected _Structure() {
                 ((StructType)NativeType).EnsureFinal();
-                _memHolder = new MemoryHolder(NativeType.Size);
+                MemHolder = new MemoryHolder(NativeType.Size);
             }
 
             public void __init__(params object[] args) {
@@ -50,7 +50,7 @@ namespace IronPython.Modules {
                 INativeType nativeType = NativeType;
                 StructType st = (StructType)nativeType;
 
-                st.SetValueInternal(_memHolder, 0, args);
+                st.SetValueInternal(MemHolder, 0, args);
             }
 
             public void __init__(CodeContext/*!*/ context, [ParamDictionary]IDictionary<string, object> kwargs) {

--- a/Src/IronPython.Modules/_ctypes/Union.cs
+++ b/Src/IronPython.Modules/_ctypes/Union.cs
@@ -15,7 +15,7 @@ namespace IronPython.Modules {
         [PythonType("Union")]
         public abstract class _Union : CData {
             public void __init__(CodeContext/*!*/ context) {
-                _memHolder = new MemoryHolder(Size);
+                MemHolder = new MemoryHolder(Size);
             }
         }
     }

--- a/Src/IronPython.Modules/_ctypes/UnionType.cs
+++ b/Src/IronPython.Modules/_ctypes/UnionType.cs
@@ -80,8 +80,8 @@ namespace IronPython.Modules {
 
                 _Union res = (_Union)CreateInstance(context);
                 IntPtr addr = array.GetArrayAddress();
-                res._memHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
-                res._memHolder.AddObject("ffffffff", array);
+                res.MemHolder = new MemoryHolder(addr.Add(offset), ((INativeType)this).Size);
+                res.MemHolder.AddObject("ffffffff", array);
                 return res;
             }
 
@@ -101,7 +101,7 @@ namespace IronPython.Modules {
 
             object INativeType.GetValue(MemoryHolder owner, object readingFrom, int offset, bool raw) {
                 _Union res = (_Union)CreateInstance(this.Context.SharedContext);
-                res._memHolder = owner.GetSubBlock(offset);
+                res.MemHolder = owner.GetSubBlock(offset);
                 return res;
             }
 
@@ -118,8 +118,8 @@ namespace IronPython.Modules {
                 } else {
                     CData data = value as CData;
                     if (data != null) {
-                        data._memHolder.CopyTo(address, offset, data.Size);
-                        return data._memHolder.EnsureObjects();
+                        data.MemHolder.CopyTo(address, offset, data.Size);
+                        return data.MemHolder.EnsureObjects();
                     } else {
                         throw new NotImplementedException("Union set value");
                     }

--- a/Src/IronPython.Modules/_ctypes/_ctypes.cs
+++ b/Src/IronPython.Modules/_ctypes/_ctypes.cs
@@ -105,22 +105,22 @@ namespace IronPython.Modules {
 
                 CData res = (CData)pt.CreateInstance(pt.Context.SharedContext);
                 if (IsPointer(pt)) {
-                    res._memHolder = new MemoryHolder(IntPtr.Size);
+                    res.MemHolder = new MemoryHolder(IntPtr.Size);
                     if (IsPointer(DynamicHelpers.GetPythonType(cdata))) {
-                        res._memHolder.WriteIntPtr(0, cdata._memHolder.ReadIntPtr(0));
+                        res.MemHolder.WriteIntPtr(0, cdata.MemHolder.ReadIntPtr(0));
                     } else {
-                        res._memHolder.WriteIntPtr(0, data);
+                        res.MemHolder.WriteIntPtr(0, data);
                     }
 
                     if (cdata != null) {
-                        res._memHolder.Objects = cdata._memHolder.Objects;
-                        res._memHolder.AddObject(IdDispenser.GetId(cdata), cdata);
+                        res.MemHolder.Objects = cdata.MemHolder.Objects;
+                        res.MemHolder.AddObject(IdDispenser.GetId(cdata), cdata);
                     }
                 } else {
                     if (cdata != null) {
-                        res._memHolder = new MemoryHolder(data, ((INativeType)pt).Size, cdata._memHolder);
+                        res.MemHolder = new MemoryHolder(data, ((INativeType)pt).Size, cdata.MemHolder);
                     } else {
-                        res._memHolder = new MemoryHolder(data, ((INativeType)pt).Size);
+                        res.MemHolder = new MemoryHolder(data, ((INativeType)pt).Size);
                     }
                 }
 
@@ -331,7 +331,7 @@ namespace IronPython.Modules {
         /// stay alive if memory in the resulting address is to be used later.
         /// </summary>
         public static object addressof(CData data) {
-            return data._memHolder.UnsafeAddress.ToPython();
+            return data.MemHolder.UnsafeAddress.ToPython();
         }
 
         /// <summary>
@@ -438,8 +438,8 @@ namespace IronPython.Modules {
             }
 
             MemoryHolder newMem = new MemoryHolder(newSize);
-            obj._memHolder.CopyTo(newMem, 0, Math.Min(obj._memHolder.Size, newSize));
-            obj._memHolder = newMem;
+            obj.MemHolder.CopyTo(newMem, 0, Math.Min(obj.MemHolder.Size, newSize));
+            obj.MemHolder = newMem;
         }
 
         public static PythonTuple/*!*/ set_conversion_mode(CodeContext/*!*/ context, string encoding, string errors) {
@@ -472,8 +472,8 @@ namespace IronPython.Modules {
         }
 
         public static int @sizeof(object/*!*/ instance) {
-            if (instance is CData cdata && cdata._memHolder != null) {
-                return cdata._memHolder.Size;
+            if (instance is CData cdata && cdata.MemHolder != null) {
+                return cdata.MemHolder.Size;
             }
             return @sizeof(DynamicHelpers.GetPythonType(instance));
         }
@@ -710,12 +710,12 @@ namespace IronPython.Modules {
         // TODO: Move these to an Ops class
         [PythonHidden]
         public static object GetCharArrayValue(_Array arr) {
-            return arr.NativeType.GetValue(arr._memHolder, arr, 0, false);
+            return arr.NativeType.GetValue(arr.MemHolder, arr, 0, false);
         }
 
         [PythonHidden]
         public static void SetCharArrayValue(_Array arr, object value) {
-            arr.NativeType.SetValue(arr._memHolder, 0, value);
+            arr.NativeType.SetValue(arr.MemHolder, 0, value);
         }
 
         [PythonHidden]
@@ -725,12 +725,12 @@ namespace IronPython.Modules {
 
         [PythonHidden]
         public static object GetCharArrayRaw(_Array arr) {
-            return ((ArrayType)arr.NativeType).GetRawValue(arr._memHolder, 0);
+            return ((ArrayType)arr.NativeType).GetRawValue(arr.MemHolder, 0);
         }
 
         [PythonHidden]
         public static void SetCharArrayRaw(_Array arr, object value) {
-            ((ArrayType)arr.NativeType).SetRawValue(arr._memHolder, 0, value);
+            ((ArrayType)arr.NativeType).SetRawValue(arr.MemHolder, 0, value);
         }
 
         [PythonHidden]
@@ -740,12 +740,12 @@ namespace IronPython.Modules {
 
         [PythonHidden]
         public static object GetWCharArrayValue(_Array arr) {
-            return arr.NativeType.GetValue(arr._memHolder, arr, 0, false);
+            return arr.NativeType.GetValue(arr.MemHolder, arr, 0, false);
         }
 
         [PythonHidden]
         public static void SetWCharArrayValue(_Array arr, object value) {
-            arr.NativeType.SetValue(arr._memHolder, 0, value);
+            arr.NativeType.SetValue(arr.MemHolder, 0, value);
         }
 
         [PythonHidden]


### PR DESCRIPTION
Prepares ground for #1297.

It is a simple, not-functional change but because of the rename it touches many places so I submit it as a separate PR to keep subsequent PRs small (hopefully).