### PR TITLE
Enable test_numtypes

### DIFF
--- a/Src/IronPython/Runtime/Operations/BoolOps.cs
+++ b/Src/IronPython/Runtime/Operations/BoolOps.cs
@@ -48,6 +48,16 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
+        public static BigInteger BitwiseAnd(BigInteger x, bool y) {
+            return BigIntegerOps.BitwiseAnd(y ? 1 : 0, x);
+        }
+
+        [SpecialName]
+        public static BigInteger BitwiseAnd(bool x, BigInteger y) {
+            return BigIntegerOps.BitwiseAnd(x ? 1 : 0, y);
+        }
+
+        [SpecialName]
         public static int BitwiseOr(int x, bool y) {
             return Int32Ops.BitwiseOr(y ? 1 : 0, x);
         }
@@ -58,6 +68,16 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
+        public static BigInteger BitwiseOr(BigInteger x, bool y) {
+            return BigIntegerOps.BitwiseOr(y ? 1 : 0, x);
+        }
+
+        [SpecialName]
+        public static BigInteger BitwiseOr(bool x, BigInteger y) {
+            return BigIntegerOps.BitwiseOr(x ? 1 : 0, y);
+        }
+
+        [SpecialName]
         public static int ExclusiveOr(int x, bool y) {
             return Int32Ops.ExclusiveOr(y ? 1 : 0, x);
         }
@@ -65,6 +85,16 @@ namespace IronPython.Runtime.Operations {
         [SpecialName]
         public static int ExclusiveOr(bool x, int y) {
             return Int32Ops.ExclusiveOr(x ? 1 : 0, y);
+        }
+
+        [SpecialName]
+        public static BigInteger ExclusiveOr(BigInteger x, bool y) {
+            return BigIntegerOps.ExclusiveOr(y ? 1 : 0, x);
+        }
+
+        [SpecialName]
+        public static BigInteger ExclusiveOr(bool x, BigInteger y) {
+            return BigIntegerOps.ExclusiveOr(x ? 1 : 0, y);
         }
 
         public static string/*!*/ __repr__(bool self) {

--- a/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.Generated.cs
@@ -2332,12 +2332,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static object Add(UInt64 x, Int64 y) {
+        public static object Add(UInt64 x, BigInteger y) {
             return BigIntegerOps.Add((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static object Add(Int64 x, UInt64 y) {
+        public static object Add(BigInteger x, UInt64 y) {
             return BigIntegerOps.Add((BigInteger)x, (BigInteger)y);
         }
 
@@ -2351,12 +2351,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static object Subtract(UInt64 x, Int64 y) {
+        public static object Subtract(UInt64 x, BigInteger y) {
             return BigIntegerOps.Subtract((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static object Subtract(Int64 x, UInt64 y) {
+        public static object Subtract(BigInteger x, UInt64 y) {
             return BigIntegerOps.Subtract((BigInteger)x, (BigInteger)y);
         }
 
@@ -2370,12 +2370,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static object Multiply(UInt64 x, Int64 y) {
+        public static object Multiply(UInt64 x, BigInteger y) {
             return BigIntegerOps.Multiply((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static object Multiply(Int64 x, UInt64 y) {
+        public static object Multiply(BigInteger x, UInt64 y) {
             return BigIntegerOps.Multiply((BigInteger)x, (BigInteger)y);
         }
 
@@ -2385,12 +2385,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static double TrueDivide(UInt64 x, Int64 y) {
+        public static double TrueDivide(UInt64 x, BigInteger y) {
             return BigIntegerOps.TrueDivide((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static double TrueDivide(Int64 x, UInt64 y) {
+        public static double TrueDivide(BigInteger x, UInt64 y) {
             return BigIntegerOps.TrueDivide((BigInteger)x, (BigInteger)y);
         }
 
@@ -2400,12 +2400,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static object FloorDivide(UInt64 x, Int64 y) {
+        public static object FloorDivide(UInt64 x, BigInteger y) {
             return BigIntegerOps.FloorDivide((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static object FloorDivide(Int64 x, UInt64 y) {
+        public static object FloorDivide(BigInteger x, UInt64 y) {
             return BigIntegerOps.FloorDivide((BigInteger)x, (BigInteger)y);
         }
 
@@ -2415,12 +2415,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static BigInteger Mod(UInt64 x, Int64 y) {
+        public static BigInteger Mod(UInt64 x, BigInteger y) {
             return BigIntegerOps.Mod((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static BigInteger Mod(Int64 x, UInt64 y) {
+        public static BigInteger Mod(BigInteger x, UInt64 y) {
             return BigIntegerOps.Mod((BigInteger)x, (BigInteger)y);
         }
 
@@ -2430,12 +2430,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static object Power(UInt64 x, Int64 y) {
+        public static object Power(UInt64 x, BigInteger y) {
             return BigIntegerOps.Power((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static object Power(Int64 x, UInt64 y) {
+        public static object Power(BigInteger x, UInt64 y) {
             return BigIntegerOps.Power((BigInteger)x, (BigInteger)y);
         }
 
@@ -2459,12 +2459,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static BigInteger BitwiseAnd(UInt64 x, Int64 y) {
+        public static BigInteger BitwiseAnd(UInt64 x, BigInteger y) {
             return BigIntegerOps.BitwiseAnd((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static BigInteger BitwiseAnd(Int64 x, UInt64 y) {
+        public static BigInteger BitwiseAnd(BigInteger x, UInt64 y) {
             return BigIntegerOps.BitwiseAnd((BigInteger)x, (BigInteger)y);
         }
 
@@ -2474,12 +2474,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static BigInteger BitwiseOr(UInt64 x, Int64 y) {
+        public static BigInteger BitwiseOr(UInt64 x, BigInteger y) {
             return BigIntegerOps.BitwiseOr((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static BigInteger BitwiseOr(Int64 x, UInt64 y) {
+        public static BigInteger BitwiseOr(BigInteger x, UInt64 y) {
             return BigIntegerOps.BitwiseOr((BigInteger)x, (BigInteger)y);
         }
 
@@ -2489,12 +2489,12 @@ namespace IronPython.Runtime.Operations {
         }
 
         [SpecialName]
-        public static BigInteger ExclusiveOr(UInt64 x, Int64 y) {
+        public static BigInteger ExclusiveOr(UInt64 x, BigInteger y) {
             return BigIntegerOps.ExclusiveOr((BigInteger)x, (BigInteger)y);
         }
 
         [SpecialName]
-        public static BigInteger ExclusiveOr(Int64 x, UInt64 y) {
+        public static BigInteger ExclusiveOr(BigInteger x, UInt64 y) {
             return BigIntegerOps.ExclusiveOr((BigInteger)x, (BigInteger)y);
         }
 
@@ -2505,27 +2505,27 @@ namespace IronPython.Runtime.Operations {
         [SpecialName]
         public static bool LessThan(UInt64 x, UInt64 y) => x < y;
         [SpecialName]
-        public static bool LessThan(UInt64 x, Int64 y) => BigIntegerOps.LessThan((BigInteger)x, (BigInteger)y);
+        public static bool LessThan(UInt64 x, BigInteger y) => BigIntegerOps.LessThan((BigInteger)x, (BigInteger)y);
         [SpecialName]
         public static bool LessThanOrEqual(UInt64 x, UInt64 y) => x <= y;
         [SpecialName]
-        public static bool LessThanOrEqual(UInt64 x, Int64 y) => BigIntegerOps.LessThanOrEqual((BigInteger)x, (BigInteger)y);
+        public static bool LessThanOrEqual(UInt64 x, BigInteger y) => BigIntegerOps.LessThanOrEqual((BigInteger)x, (BigInteger)y);
         [SpecialName]
         public static bool GreaterThan(UInt64 x, UInt64 y) => x > y;
         [SpecialName]
-        public static bool GreaterThan(UInt64 x, Int64 y) => BigIntegerOps.GreaterThan((BigInteger)x, (BigInteger)y);
+        public static bool GreaterThan(UInt64 x, BigInteger y) => BigIntegerOps.GreaterThan((BigInteger)x, (BigInteger)y);
         [SpecialName]
         public static bool GreaterThanOrEqual(UInt64 x, UInt64 y) => x >= y;
         [SpecialName]
-        public static bool GreaterThanOrEqual(UInt64 x, Int64 y) => BigIntegerOps.GreaterThanOrEqual((BigInteger)x, (BigInteger)y);
+        public static bool GreaterThanOrEqual(UInt64 x, BigInteger y) => BigIntegerOps.GreaterThanOrEqual((BigInteger)x, (BigInteger)y);
         [SpecialName]
         public static bool Equals(UInt64 x, UInt64 y) => x == y;
         [SpecialName]
-        public static bool Equals(UInt64 x, Int64 y) => BigIntegerOps.Equals((BigInteger)x, (BigInteger)y);
+        public static bool Equals(UInt64 x, BigInteger y) => BigIntegerOps.Equals((BigInteger)x, (BigInteger)y);
         [SpecialName]
         public static bool NotEquals(UInt64 x, UInt64 y) => x != y;
         [SpecialName]
-        public static bool NotEquals(UInt64 x, Int64 y) => BigIntegerOps.NotEquals((BigInteger)x, (BigInteger)y);
+        public static bool NotEquals(UInt64 x, BigInteger y) => BigIntegerOps.NotEquals((BigInteger)x, (BigInteger)y);
 
         #endregion
 

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -66,10 +66,6 @@ Reason=Fails intermittently - https://github.com/IronLanguages/ironpython3/issue
 [IronPython.test_number]
 Timeout=300000 # 5 minute timeout - slow on macOS
 
-[IronPython.test_numtypes]
-Ignore=true
-Reason=Takes way too long
-
 [IronPython.test_peverify]
 Ignore=true
 Reason=T CreateDelegate[T](System.Reflection.MethodInfo ByRef) is not a GenericMethodDefinition. MakeGenericMethod may only be called on a method for which MethodBase.IsGenericMethodDefinition is true.

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -66,6 +66,9 @@ Reason=Fails intermittently - https://github.com/IronLanguages/ironpython3/issue
 [IronPython.test_number]
 Timeout=300000 # 5 minute timeout - slow on macOS
 
+[IronPython.test_numtypes]
+Timeout=300000 # 5 minute timeout - slow in general, but should finish within 3 min
+
 [IronPython.test_peverify]
 Ignore=true
 Reason=T CreateDelegate[T](System.Reflection.MethodInfo ByRef) is not a GenericMethodDefinition. MakeGenericMethod may only be called on a method for which MethodBase.IsGenericMethodDefinition is true.

--- a/Src/Scripts/generate_alltypes.py
+++ b/Src/Scripts/generate_alltypes.py
@@ -285,7 +285,10 @@ def write_binop1_general(func, cw, body, name, ty, **kws):
     func(cw, body, name, ty, **kws)
 
     if not ty.is_signed:
-        oty = ty.get_signed()
+        if ty.name in ["UInt64"]:
+            oty = bigint
+        else:
+            oty = ty.get_signed()
         if 'return_type' not in kws or kws['return_type'] == ty.name:
             if name == 'FloorDivide':
                 kws['return_type'] = 'object'
@@ -313,7 +316,10 @@ def write_rich_comp_general(func, cw, body, name, ty, **kws):
     func(cw, body, name, ty, **kws)
 
     if not ty.is_signed:
-        oty = ty.get_signed()
+        if ty.name in ["UInt64"]:
+            oty = bigint
+        else:
+            oty = ty.get_signed()
         kws['ltype'] = oty.name
         if cw.kws.get('bigger_signed') == "BigInteger":
             func(cw, unsigned_signed_body, name, ty, **kws)

--- a/Tests/test_complex.py
+++ b/Tests/test_complex.py
@@ -185,7 +185,7 @@ class ComplexTest(IronPythonTestCase):
         test(complex(-0., +0.),  "(-0+0j)")
         test(complex(-0., -0.),  "(-0-0j)")
 
-        # NOTE: -0j not a complex literal in Python code but negated 0j, which is == -(0+0j) == (-0-0j)
+        # NOTE: -0j is not a complex literal in Python code but negated 0j, which is == -(0+0j) == (-0-0j)
         test(0j,  "0j")
         test(complex(0j),  "0j")
         test(-0j,  "(-0-0j)")

--- a/Tests/test_numtypes.py
+++ b/Tests/test_numtypes.py
@@ -10,9 +10,9 @@ results produced by the operators implemented on the .NET types.
 """
 
 import unittest
-from operator import add, sub, mul, div, mod, and_, or_, xor, floordiv, truediv, lshift, rshift, neg, pos, abs, invert
+from operator import add, sub, mul, mod, and_, or_, xor, floordiv, truediv, lshift, rshift, neg, pos, abs, invert
 
-from iptest import is_cli, run_test, skipUnlessIronPython
+from iptest import is_cli, big, run_test, skipUnlessIronPython
 from iptest.type_util import *
 
 if is_cli:
@@ -26,13 +26,9 @@ biops_math_add = [
 biops_math_sub = [
     ("sub", sub),
     ]
-    
+
 biops_math_mul = [
     ("mul", mul),
-    ]
-    
-biops_math_div = [
-    ("div", div),
     ]
 
 biops_math_floordiv = [
@@ -42,11 +38,11 @@ biops_math_floordiv = [
 biops_math_truediv = [
     ("truediv", truediv),
     ]
-    
+
 biops_math_mod = [
     ("mod", mod),
     ]
-    
+
 biops_math_pow = [
     ("pow", pow),
     #("divmod", divmod) #, !!! not supporting divmod on non-standard types
@@ -62,8 +58,8 @@ biops_bool_shift = [
     ("lshift", lshift),
     ("rshift", rshift),
     ]
-    
-    
+
+
 unops = [
     ("neg", neg),
     ("pos", pos),
@@ -82,6 +78,7 @@ def get_clr_values(string, types):
     return clr_values
 
 
+# TODO: check if still true
 # Some values are not generated (myint, mylong, myfloat) because of the semantic difference
 # between calling (2L).__div__(single) and (mylong(2L)).__div__(single)
 
@@ -92,23 +89,17 @@ def get_values(values, itypes, ftypes):
     ( python_value, [ all_values ] ),
     ... ]
 
-    all_values: Byte, UInt16, UInt32, UInt64, SByte, Int16, Int32, Int64, Single, Double, myint, mylong, myfloat
+    all_values: Byte, UInt16, UInt32, UInt64, SByte, Int16, Int32, Int64, myint, Single, Double, myfloat, Complex, mycomplex
     """
     all = []
     for v in values:
         sv  = str(v)
-        py  = int(v)
-        clr = get_clr_values(sv, itypes)
-        clr.append(int(py))
-        clr.append(myint(py))
-        clr.append(mylong(py))
-        all.append( (py, clr) )
 
         py  = int(v)
         clr = get_clr_values(sv, itypes)
-        clr.append(py)
+        clr.append(int(py))
+        clr.append(big(int(py)))
         clr.append(myint(py))
-        clr.append(mylong(py))
         all.append( (py, clr) )
 
         py  = float(v)
@@ -134,9 +125,7 @@ def mystr(x):
     elif isinstance(x, Double):
         return str(round(x, 3))
     else:
-        s = str(x)
-        if s.endswith("L"): return s[:-1]
-        else: return s
+        return str(x)
 
 def get_message(a, b, op, x_s, x_v, g_s, g_v):
     return """
@@ -192,7 +181,7 @@ def calc_0(op):
 
 def extensible(l, r):
     ii = isinstance
-    return ii(l, myint) or ii(l, mylong) or ii(l, myfloat) or ii(l, mycomplex) or ii(r, myint) or ii(r, mylong) or ii(r, myfloat) or ii(r, mycomplex)
+    return ii(l, myint) or ii(l, myfloat) or ii(l, mycomplex) or ii(r, myint) or ii(r, myfloat) or ii(r, mycomplex)
 
 if is_cli:
     values = [-2, -3, -5, 2, 3, 5, 0]
@@ -275,7 +264,7 @@ class NumTypesTest(unittest.TestCase):
                                     implemented = True
                                     self.verify_b(l, r, l_name, x_s, x_v, g_s, g_v)
                                     total += 1
-                                    
+
                             # r.__rxxx__(l)
                             m = getattr(r, r_name, None)
                             if m is not None:
@@ -320,7 +309,7 @@ class NumTypesTest(unittest.TestCase):
                             implemented = True
                             self.verify_u(l, m_name, x_s, x_v, g_s, g_v)
                             total += 1
-                                
+
                     self.verify_implemented_u(implemented, name, l)
         return total
 
@@ -342,43 +331,39 @@ class NumTypesTest(unittest.TestCase):
     def test_validate_biops_bool_shift(self):
         total = self.validate_binary_ops(all, biops_bool_shift)
         print(total, "tests ran.")
-        
+
     def test_validate_biops_math_add(self):
         total = self.validate_binary_ops(all, biops_math_add)
         print(total, "tests ran.")
-        
+
     def test_validate_biops_math_sub(self):
         total = self.validate_binary_ops(all, biops_math_sub)
         print(total, "tests ran.")
-        
+
     def test_validate_biops_math_mul(self):
         total = self.validate_binary_ops(all, biops_math_mul)
-        print(total, "tests ran.")
-        
-    def test_validate_biops_math_div(self):
-        total = self.validate_binary_ops(all, biops_math_div)
         print(total, "tests ran.")
 
     def test_validate_biops_math_floordiv(self):
         total = self.validate_binary_ops(all, biops_math_floordiv)
         print(total, "tests ran.")
-        
+
     def test_validate_biops_math_truediv(self):
         total = self.validate_binary_ops(all, biops_math_truediv)
         print(total, "tests ran.")
-        
+
     def test_validate_biops_math_mod(self):
         total = self.validate_binary_ops(all, biops_math_mod)
         print(total, "tests ran.")
-        
+
     def test_validate_biops_math_pow(self):
         total = self.validate_binary_ops(all, biops_math_pow)
         print(total, "tests ran.")
-        
+
     def test_validate_unary_ops(self):
         total = self.validate_unary_ops(all)
         print(total, "tests ran.")
-  
+
     def test_validate_constructors(self):
         total = self.validate_constructors(values)
         print(total, "tests ran.")

--- a/Tests/test_numtypes.py
+++ b/Tests/test_numtypes.py
@@ -314,12 +314,15 @@ class NumTypesTest(unittest.TestCase):
         return total
 
     def validate_constructors(self, values):
-        types = [Byte, UInt16, UInt32, UInt64, SByte, Int16, Int32, Int64]
         total = 0
         for value in values:
-            for first in types:
+            for first in clr_int_types:
+                if first in clr_unsigned_types and value < 0:
+                    continue
                 v1 = first(value)
-                for second in types:
+                for second in clr_int_types:
+                    if second in clr_unsigned_types and value < 0:
+                        continue
                     v2 = first(second((value)))
                 total += 1
         return total

--- a/Tests/test_numtypes.py
+++ b/Tests/test_numtypes.py
@@ -99,12 +99,12 @@ def get_values(values, itypes, ftypes):
         sv  = str(v)
         py  = int(v)
         clr = get_clr_values(sv, itypes)
-        clr.append(long(py))
+        clr.append(int(py))
         clr.append(myint(py))
         clr.append(mylong(py))
         all.append( (py, clr) )
 
-        py  = long(v)
+        py  = int(v)
         clr = get_clr_values(sv, itypes)
         clr.append(py)
         clr.append(myint(py))
@@ -175,19 +175,19 @@ def get_messageun(a, op, x_s, x_v, g_s, g_v):
 def calc_1(op, arg1):
     try:
         return True, op(arg1)
-    except Exception, e:
+    except Exception as e:
         return False, e.clsException
 
 def calc_2(op, arg1, arg2):
     try:
         return True, op(arg1, arg2)
-    except Exception, e:
+    except Exception as e:
         return False, e.clsException
 
 def calc_0(op):
     try:
         return True, op()
-    except Exception, e:
+    except Exception as e:
         return False, e.clsException
 
 def extensible(l, r):
@@ -288,7 +288,7 @@ class NumTypesTest(unittest.TestCase):
                             self.verify_implemented_b(implemented, name, l, r)
 
                             if total - last > 10000:
-                                print "." ,
+                                print(".", end=' ')
                                 last = total
 
         return total
@@ -337,50 +337,50 @@ class NumTypesTest(unittest.TestCase):
 
     def test_validate_biops_bool_simple(self):
         total = self.validate_binary_ops(all, biops_bool_simple)
-        print total, "tests ran."
+        print(total, "tests ran.")
 
     def test_validate_biops_bool_shift(self):
         total = self.validate_binary_ops(all, biops_bool_shift)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_biops_math_add(self):
         total = self.validate_binary_ops(all, biops_math_add)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_biops_math_sub(self):
         total = self.validate_binary_ops(all, biops_math_sub)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_biops_math_mul(self):
         total = self.validate_binary_ops(all, biops_math_mul)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_biops_math_div(self):
         total = self.validate_binary_ops(all, biops_math_div)
-        print total, "tests ran."
+        print(total, "tests ran.")
 
     def test_validate_biops_math_floordiv(self):
         total = self.validate_binary_ops(all, biops_math_floordiv)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_biops_math_truediv(self):
         total = self.validate_binary_ops(all, biops_math_truediv)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_biops_math_mod(self):
         total = self.validate_binary_ops(all, biops_math_mod)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_biops_math_pow(self):
         total = self.validate_binary_ops(all, biops_math_pow)
-        print total, "tests ran."
+        print(total, "tests ran.")
         
     def test_validate_unary_ops(self):
         total = self.validate_unary_ops(all)
-        print total, "tests ran."
+        print(total, "tests ran.")
   
     def test_validate_constructors(self):
         total = self.validate_constructors(values)
-        print total, "tests ran."
+        print(total, "tests ran.")
 
 run_test(__name__)

--- a/Tests/test_numtypes.py
+++ b/Tests/test_numtypes.py
@@ -12,7 +12,7 @@ results produced by the operators implemented on the .NET types.
 import unittest
 from operator import add, sub, mul, mod, and_, or_, xor, floordiv, truediv, lshift, rshift, neg, pos, abs, invert
 
-from iptest import is_cli, big, run_test, skipUnlessIronPython
+from iptest import is_cli, big, run_test, skipUnlessIronPython, IronPythonTestCase
 from iptest.type_util import *
 
 if is_cli:
@@ -89,7 +89,7 @@ def get_values(values, itypes, ftypes):
     ( python_value, [ all_values ] ),
     ... ]
 
-    all_values: Byte, UInt16, UInt32, UInt64, SByte, Int16, Int32, Int64, myint, Single, Double, myfloat, Complex, mycomplex
+    all_values: Byte, UInt16, UInt32, UInt64, SByte, Int16, Int32, Int64, BigInteger, myint, Single, Double, myfloat, Complex, mycomplex
     """
     all = []
     for v in values:
@@ -190,7 +190,7 @@ if is_cli:
     all = get_values(values, itypes, ftypes)
 
 @skipUnlessIronPython()
-class NumTypesTest(unittest.TestCase):
+class NumTypesTest(IronPythonTestCase):
     def verify_b(self, a, b, op, x_s, x_v, g_s, g_v):
         if not x_s == g_s:
             self.fail(get_message(a, b, op, x_s, x_v, g_s, g_v))
@@ -329,46 +329,46 @@ class NumTypesTest(unittest.TestCase):
 
     def test_validate_biops_bool_simple(self):
         total = self.validate_binary_ops(all, biops_bool_simple)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_bool_shift(self):
         total = self.validate_binary_ops(all, biops_bool_shift)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_math_add(self):
         total = self.validate_binary_ops(all, biops_math_add)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_math_sub(self):
         total = self.validate_binary_ops(all, biops_math_sub)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_math_mul(self):
         total = self.validate_binary_ops(all, biops_math_mul)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_math_floordiv(self):
         total = self.validate_binary_ops(all, biops_math_floordiv)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_math_truediv(self):
         total = self.validate_binary_ops(all, biops_math_truediv)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_math_mod(self):
         total = self.validate_binary_ops(all, biops_math_mod)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_biops_math_pow(self):
         total = self.validate_binary_ops(all, biops_math_pow)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_unary_ops(self):
         total = self.validate_unary_ops(all)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
     def test_validate_constructors(self):
         total = self.validate_constructors(values)
-        print(total, "tests ran.")
+        print(total, "tests ran: ", end='')
 
 run_test(__name__)

--- a/Tests/test_numtypes.py
+++ b/Tests/test_numtypes.py
@@ -97,8 +97,8 @@ def get_values(values, itypes, ftypes):
 
         py  = int(v)
         clr = get_clr_values(sv, itypes)
-        clr.append(int(py))
-        clr.append(big(int(py)))
+        clr.append(py)
+        clr.append(big(py))
         clr.append(myint(py))
         all.append( (py, clr) )
 


### PR DESCRIPTION
It looks like this test has never been run on IronPython 3 before — it was still using Python 2 syntax. After upgrading, it exposed some gaps in the operators on the non-Python integers.

I am torn between enabling and not enabling this test by default. It was originally disabled because it "takes way too long". Indeed, it takes about 30 seconds on my rig, which I think means it can be some extra 3 minutes on the CI server. In the end I enabled it because I have some resolver-related tinkering planned ahead and would prefer the test to catch as much mistakes as possible.