### PR TITLE
Improve handling of bitfields in ctypes

### DIFF
--- a/Src/IronPython.Modules/_ctypes/Field.cs
+++ b/Src/IronPython.Modules/_ctypes/Field.cs
@@ -45,6 +45,9 @@ namespace IronPython.Modules {
                 if (bits != null) {
                     _bits = bits.Value;
                     _bitsOffset = bitOffset.Value;
+                    if (((SimpleType)_fieldType)._swap) {
+                        _bitsOffset = _fieldType.Size * 8 - _bitsOffset - _bits;
+                    }
                 }
             }
 

--- a/Src/IronPython.Modules/_ctypes/Field.cs
+++ b/Src/IronPython.Modules/_ctypes/Field.cs
@@ -50,7 +50,7 @@ namespace IronPython.Modules {
 
             public int offset => _offset;
 
-            public int size => _fieldType.Size;
+            public int size => _bits == 0 ? _fieldType.Size : (_bits << 16) + _bitsOffset;
 
             #region Internal APIs
 

--- a/Src/IronPython.Modules/_ctypes/Field.cs
+++ b/Src/IronPython.Modules/_ctypes/Field.cs
@@ -213,12 +213,24 @@ namespace IronPython.Modules {
                 // get the value in the form of a ulong which can contain the biggest bitfield
                 value = PythonOps.Index(value);
                 ulong newBits;
-                if (value is int) {
-                    newBits = (ulong)(int)value;
-                } else if (value is BigInteger) {
-                    newBits = (ulong)(long)(BigInteger)value;
+                if (value is int iVal) {
+                    newBits = (ulong)iVal;
+                } else if (value is BigInteger biVal) {
+                    if (biVal.Sign >= 0) {
+                        if (biVal <= ulong.MaxValue) {
+                            newBits = (ulong)biVal;
+                        } else {
+                            newBits = (ulong)(biVal & ulong.MaxValue);
+                        }
+                    } else {
+                        if (biVal >= long.MinValue) {
+                            newBits = (ulong)(long)biVal;
+                        } else {
+                            newBits = (ulong)(biVal & ulong.MaxValue);
+                        }
+                    }
                 } else {
-                    throw PythonOps.TypeErrorForTypeMismatch("int or long", value);
+                    throw PythonOps.TypeErrorForTypeMismatch("int", value);
                 }
 
                 // do the same for the existing value

--- a/Src/IronPython.Modules/_ctypes/Field.cs
+++ b/Src/IronPython.Modules/_ctypes/Field.cs
@@ -43,6 +43,8 @@ namespace IronPython.Modules {
                 _fieldName = fieldName;
 
                 if (bits != null) {
+                    Debug.Assert(bitOffset != null);
+                    Debug.Assert(_fieldType is SimpleType);
                     _bits = bits.Value;
                     _bitsOffset = bitOffset.Value;
                     if (((SimpleType)_fieldType)._swap) {
@@ -163,10 +165,6 @@ namespace IronPython.Modules {
                             value = (BigInteger)bits;
                         }
 
-                    } else if (value is bool bVal) {
-                        int ibVal = ExtractBitsFromInt(bVal ? 1 : 0);
-                        value = ScriptingRuntimeHelpers.BooleanToObject(ibVal != 0);
-
                     } else {
                         throw new InvalidOperationException("we only return int, bigint from GetValue");
                     }
@@ -216,7 +214,7 @@ namespace IronPython.Modules {
                             }
                         }
                     } else {
-                        throw PythonOps.TypeErrorForTypeMismatch("int", value);
+                        throw new InvalidOperationException("unreachable");
                     }
                 }
 

--- a/Src/IronPython.Modules/_ctypes/SimpleType.cs
+++ b/Src/IronPython.Modules/_ctypes/SimpleType.cs
@@ -34,7 +34,7 @@ namespace IronPython.Modules {
             internal readonly SimpleTypeKind _type;
             private readonly char _charType;
             private readonly string _format;
-            private readonly bool _swap;
+            internal readonly bool _swap;
 
             public SimpleType(CodeContext/*!*/ context, string name, PythonTuple bases, PythonDictionary dict) : base(context, name, bases, dict) {
                 string sVal;

--- a/Src/IronPython.Modules/_ctypes/Structure.cs
+++ b/Src/IronPython.Modules/_ctypes/Structure.cs
@@ -50,6 +50,10 @@ namespace IronPython.Modules {
                 INativeType nativeType = NativeType;
                 StructType st = (StructType)nativeType;
 
+                if (args is null) { // None passed as a sole argument
+                    args = new object[1];
+                }
+
                 st.SetValueInternal(MemHolder, 0, args);
             }
 

--- a/Src/IronPython.Modules/_ctypes/Structure.cs
+++ b/Src/IronPython.Modules/_ctypes/Structure.cs
@@ -44,15 +44,11 @@ namespace IronPython.Modules {
                 MemHolder = new MemoryHolder(NativeType.Size);
             }
 
-            public void __init__(params object[] args) {
+            public void __init__([NotNone] params object[] args) {
                 CheckAbstract();
 
                 INativeType nativeType = NativeType;
                 StructType st = (StructType)nativeType;
-
-                if (args is null) { // None passed as a sole argument
-                    args = new object[1];
-                }
 
                 st.SetValueInternal(MemHolder, 0, args);
             }

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -10,6 +10,9 @@ RunCondition=NOT $(IS_OSX) # TODO: debug
 [CPython.ctypes.test_as_parameter]
 Ignore=true
 
+[CPython.ctypes.test_bitfields] # IronPython.modules.type_related.test_bitfields_ctypes_stdlib
+Ignore=true
+
 [CPython.ctypes.test_errno]
 Ignore=true
 Reason=Current implementation of get_last_error needs to be debugged

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -10,9 +10,6 @@ RunCondition=NOT $(IS_OSX) # TODO: debug
 [CPython.ctypes.test_as_parameter]
 Ignore=true
 
-[CPython.ctypes.test_bitfields]
-Ignore=true # blocked by https://github.com/IronLanguages/ironpython3/issues/1297
-
 [CPython.ctypes.test_errno]
 Ignore=true
 Reason=Current implementation of get_last_error needs to be debugged

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -152,6 +152,9 @@ NotParallelSafe=true # Uses fixed file, directory, and environment variable name
 [IronPython.modules.io_related.test_cPickle]
 NotParallelSafe=true # Uses a temporary module with a fixed name
 
+[IronPython.modules.type_related.test_bitfields_ctypes_stdlib]
+RunCondition=NOT $(IS_OSX) # ctypes tests not prepared for macOS
+
 [IronPython.modules.system_related.test_sys_getframe]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 FullFrames=true

--- a/Tests/gen_stdlib_test.py
+++ b/Tests/gen_stdlib_test.py
@@ -2,6 +2,12 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
+"""
+Example usage:
+    ipy gen_stdlib_test.py test_codecs
+    ipy gen_stdlib_test.py test_bitfields ctypes modules/type_related
+"""
+
 import importlib
 import os
 import re
@@ -21,7 +27,7 @@ import sys
 
 from iptest import run_test
 
-import test.{name}
+import {package}test.{name}
 
 def load_tests(loader, standard_tests, pattern):
     if sys.implementation.name == 'ironpython':
@@ -30,22 +36,26 @@ def load_tests(loader, standard_tests, pattern):
         return suite
 
     else:
-        return loader.loadTestsFromModule(test.{name}, pattern)
+        return loader.loadTestsFromModule({package}test.{name}, pattern)
 
 run_test(__name__)
 """
 
 if __name__ == "__main__":
     name = sys.argv[1]
+    package = sys.argv[2] if len(sys.argv) > 2 else None
+    location = sys.argv[3] if len(sys.argv) > 3 else "."
+
+    filepath = os.path.join(location, name + ("_" + package if package else "") + "_stdlib.py")
 
     sys.path.insert(0, os.path.abspath(os.path.join(__file__, "../../Src/StdLib/Lib")))
-    module = importlib.import_module("test.{name}".format(name=name))
+    module = importlib.import_module("{package}test.{name}".format(name=name, package=package + "." if package else ""))
 
     existing_tests = {}
     try:
         re_failure = re.compile(r'^\s*suite\.addTest\(unittest\.expectedFailure\((.*)\)\)( #.*)?$')
         re_ok = re.compile(r'^\s*suite\.addTest\((.*)\)( #.*)?$')
-        with open(name + "_stdlib.py", "r", encoding="utf-8") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             for line in f:
                 match = re_failure.match(line) or re_ok.match(line)
                 if match:
@@ -60,5 +70,5 @@ if __name__ == "__main__":
 
     tests = [existing_tests.get(t, "        suite.addTest({})".format(t)) for t in tests]
 
-    with open(name + "_stdlib.py", "w", encoding="utf-8") as f:
-        f.write(template.format(name=name, tests="\n".join(tests)))
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(template.format(name=name, package=package + "." if package else "", tests="\n".join(tests)))

--- a/Tests/modules/type_related/test_bitfields_ctypes_stdlib.py
+++ b/Tests/modules/type_related/test_bitfields_ctypes_stdlib.py
@@ -1,0 +1,48 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+##
+## Run selected tests from test_bitfields from StdLib
+##
+
+import unittest
+import sys
+
+from iptest import run_test
+
+import ctypes.test.test_bitfields
+
+def load_tests(loader, standard_tests, pattern):
+    if sys.implementation.name == 'ironpython':
+        suite = unittest.TestSuite()
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_anon_bitfields'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_c_wchar'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_longlong'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_mixed_2'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_mixed_3'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_multi_bitfields_size'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_nonint_types'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_signed'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_single_bitfield_size'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_uint32'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_uint32_swap_big_endian'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_uint32_swap_little_endian'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_uint64'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_ulonglong'))
+        suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_unsigned'))
+        suite.addTest(ctypes.test.test_bitfields.C_Test('test_ints'))
+        if sys.platform.startswith('win'):
+            suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_mixed_1'))
+            suite.addTest(ctypes.test.test_bitfields.BitFieldTest('test_mixed_4'))
+            suite.addTest(ctypes.test.test_bitfields.C_Test('test_shorts'))
+        else: # https://github.com/IronLanguages/ironpython3/issues/1442
+            suite.addTest(unittest.expectedFailure(ctypes.test.test_bitfields.BitFieldTest('test_mixed_1')))
+            suite.addTest(unittest.expectedFailure(ctypes.test.test_bitfields.BitFieldTest('test_mixed_4')))
+            suite.addTest(unittest.expectedFailure(ctypes.test.test_bitfields.C_Test('test_shorts')))
+        return suite
+
+    else:
+        return loader.loadTestsFromModule(ctypes.test.test_bitfields, pattern)
+
+run_test(__name__)

--- a/Tests/modules/type_related/test_ctypes.py
+++ b/Tests/modules/type_related/test_ctypes.py
@@ -8,9 +8,10 @@ Tests for CPython's ctypes module.
 
 from ctypes import *
 from array import array
+import sys
 import gc
 
-from iptest import IronPythonTestCase, is_cli, is_mono, big, run_test
+from iptest import IronPythonTestCase, expectedFailureIf, is_cli, big, myint, run_test
 
 class CTypesTest(IronPythonTestCase):
     export_error_msg = "Existing exports of data: object cannot be re-sized" if is_cli else "cannot resize an array that is exporting buffers"
@@ -67,5 +68,155 @@ class CTypesTest(IronPythonTestCase):
         c = (c_char * 15).from_buffer(ba, sizeof(c_char))
         self.assertEqual(c[:], b[1:])
         self.assertRaisesMessage(TypeError, self.readonly_error_msg, (c_char * 15).from_buffer, b, sizeof(c_char))
+
+    def test_bitfield_bool(self):
+        """
+        Tests pertaining of bitfields of type c_bool
+        # https://github.com/IronLanguages/ironpython3/issues/1439
+        """
+
+        # simple 1-field, 1-bit structure
+        class Test1(Structure):
+            _fields_ = [("x", c_bool, 1)]
+
+        self.assertIs(Test1(True).x, True)
+
+        # 2-field, 1-bit structure
+        class Test2(Structure):
+            _fields_ = [("x", c_bool, 1), ("y", c_bool, 1)]
+
+        class Test3(Structure):
+            _fields_ = [("x", c_bool, 3), ("y", c_bool, 4)]
+
+        for T in (Test2, Test3):
+            self.assertIs(T().x, False)
+            self.assertIs(T().y, False)
+            self.assertIs(T(True).x, True)
+            self.assertIs(T(True, True).x, True)
+            self.assertIs(T(True, True).y, True)
+            self.assertIs(T(False, False).x, False)
+            self.assertIs(T(False, False).y, False)
+            self.assertIs(T(True, False).y, False)
+            self.assertIs(T(False, True).y, True)
+            if is_cli: # bug in CPython: https://github.com/python/cpython/issues/90914
+                self.assertIs(T(True, False).x, True)
+                self.assertIs(T(False, True).x, False)
+                self.assertIs(T(True).y, False)
+            self.assertRaisesMessage(TypeError, "too many initializers", T, True, False, True)
+
+            # Testing assignments
+            s = T()
+            self.assertIs(s.x, False)
+            self.assertIs(s.y, False)
+            s.x = True
+            self.assertIs(s.x, True)
+            if is_cli: # bug in CPython: https://github.com/python/cpython/issues/90914
+                self.assertIs(s.y, False)
+
+            s = T()
+            self.assertIs(s.x, False)
+            self.assertIs(s.y, False)
+            s.y = True
+            self.assertIs(s.y, True)
+            if is_cli: # bug in CPython: https://github.com/python/cpython/issues/90914
+                self.assertIs(s.x, False)
+
+            s = T()
+            self.assertIs(s.x, False)
+            self.assertIs(s.y, False)
+            s.y = 2
+            self.assertIs(s.y, True)
+            if is_cli: # bug in CPython: https://github.com/python/cpython/issues/90914
+                self.assertIs(s.x, False)
+
+            s = T()
+            self.assertIs(s.x, False)
+            self.assertIs(s.y, False)
+            s.y = 3
+            self.assertIs(s.y, True)
+            if is_cli: # bug in CPython: https://github.com/python/cpython/issues/90914
+                self.assertIs(s.x, False)
+
+        b = bytearray(1)
+        s =Test3.from_buffer(b)
+        s.x = 2 # meaning True, i.e. 0x01
+        s.y = 4 # meaning True, i.e 0x01 << 3 == 0x08
+        if is_cli: # bug in CPython: https://github.com/python/cpython/issues/90914
+            self.assertEqual(b, b"\x09")
+
+    def test_bitfield_bool_truthy(self):
+        """Testing non-bool arguments for of bitfields of type c_bool"""
+
+        class Test(Structure):
+            _fields_ = [("x", c_bool, 1)]
+
+        class myindex:
+            def __init__(self, value):
+                self.value = value
+            def __index__(self):
+                return self.value
+
+        for val in (None, "", "False", "True", "0", "1", 0, 1, 2, 0.0, 1.0, [], (), {}, object(), myindex(0), myindex(1)):
+            with self.subTest(val=val):
+                self.assertIs(Test(val).x, bool(val))
+
+                s = Test()
+                s.x = val
+                self.assertIs(s.x, bool(val))
+
+    def test_bitfield_long(self):
+        """Tests for bitfields of type c_long"""
+
+        class Test(Structure):
+            _fields_ = [("x", c_long, 16), ("y", c_long, 16), ("z", c_long, 32)]
+
+        class myindex:
+            def __init__(self, value):
+                self.value = value
+            def __index__(self):
+                return self.value
+
+        self.assertEqual(Test(0x1234).x, 0x1234)
+        self.assertEqual(Test(big(0x1234)).x, 0x1234)
+        self.assertEqual(Test(myint(0x1234)).x, 0x1234)
+        self.assertEqual(Test(True).x, 1)
+        if is_cli or sys.version_info >= (3, 8):
+            self.assertEqual(Test(myindex(0x1234)).x, 0x1234)
+            if is_cli or sys.version_info >= (3, 10):
+                msg = "'float' object cannot be interpreted as an integer"
+            else:
+                msg = "int expected instead of float"
+            self.assertRaisesMessage(TypeError, msg, Test, 2.3)
+
+        with self.assertRaisesMessage(ValueError, "number of bits invalid for bit field"):
+            class Test(Structure):
+                _fields_ = [("x", c_int, 0)]
+
+        self.assertEqual(repr(Test.x), "<Field type=c_long, ofs=0:0, bits=16>")
+        self.assertEqual(repr(Test.y), "<Field type=c_long, ofs=0:16, bits=16>")
+        self.assertEqual(repr(Test.z), "<Field type=c_long, ofs=4:0, bits=32>")
+
+        self.assertEqual((Test.x.offset, Test.x.size), (0, (16 << 16) + 0))
+        self.assertEqual((Test.y.offset, Test.y.size), (0, (16 << 16) + 16))
+        self.assertEqual((Test.z.offset, Test.z.size), (4, (32 << 16) + 0))
+
+    def test_bitfield_longlong(self):
+        """Tests for bitfields of type c_longlong"""
+
+        class TestS(Structure):
+            _fields_ = [("x", c_longlong, 63)]
+
+        self.assertEqual(TestS((1 << 64)).x, 0)
+        self.assertEqual(TestS((1 << 64) - 1).x, -1)
+        self.assertEqual(TestS(-(1 << 64)).x, 0)
+        self.assertEqual(TestS(-(1 << 64) - 1).x, -1)
+
+        class TestU(Structure):
+            _fields_ = [("x", c_ulonglong, 63)]
+
+        self.assertEqual(TestU((1 << 64)).x, 0)
+        self.assertEqual(TestU((1 << 64) - 1).x, 0x7fffffffffffffff)
+        self.assertEqual(TestU(-(1 << 64)).x, 0)
+        self.assertEqual(TestU(-(1 << 64) - 1).x, 0x7fffffffffffffff)
 
 run_test(__name__)

--- a/Tests/modules/type_related/test_ctypes.py
+++ b/Tests/modules/type_related/test_ctypes.py
@@ -11,7 +11,7 @@ from array import array
 import sys
 import gc
 
-from iptest import IronPythonTestCase, expectedFailureIf, is_cli, big, myint, run_test
+from iptest import IronPythonTestCase, is_cli, big, myint, run_test
 
 class CTypesTest(IronPythonTestCase):
     export_error_msg = "Existing exports of data: object cannot be re-sized" if is_cli else "cannot resize an array that is exporting buffers"


### PR DESCRIPTION
Addressed #1439 and a few other issues that caught my attention. The most interesting is a fix for python/cpython#90914, which was reported just 3 months ago and is still not resolved. Funny thought that IronPython on one point will be ahead of CPython. Not that this functionality is used anywhere in the wild, since it is not working yet in CPython.