### PR TITLE
Support str subclass from repr

### DIFF
--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1295,7 +1295,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         }
 
         public static object repr(CodeContext/*!*/ context, object? o)
-            => PythonOps.Repr(context, o);
+            => PythonOps.GetReprObject(context, o);
 
         public static PythonType reversed => DynamicHelpers.GetPythonTypeFromType(typeof(ReversedEnumerator));
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -225,12 +225,13 @@ namespace IronPython.Runtime.Operations {
             return StringOps.AsciiEncode(Repr(context, o));
         }
 
-        public static string Repr(CodeContext/*!*/ context, object? o) {
+        internal static object GetReprObject(CodeContext/*!*/ context, object? o) {
             if (o == null) return "None";
 
+            // Fast tracks
             if (o is string s) return StringOps.__repr__(s);
-            if (o is int) return Int32Ops.__repr__((int)o);
-            if (o is long) return ((long)o).ToString();
+            if (o is int i32) return Int32Ops.__repr__(i32);
+            if (o is BigInteger bi) return BigIntegerOps.__repr__(bi);
 
             // could be a container object, we need to detect recursion, but only
             // for our own built-in types that we're aware of.  The user can setup
@@ -266,6 +267,9 @@ namespace IronPython.Runtime.Operations {
 
             throw PythonOps.TypeError("__repr__ returned non-string (got '{0}' from type '{1}')", PythonOps.GetPythonTypeName(repr), PythonOps.GetPythonTypeName(o));
         }
+
+        public static string Repr(CodeContext/*!*/ context, object? o)
+            => GetReprObject(context, o).ToString() ?? "<unknown>";
 
         public static string Format(CodeContext/*!*/ context, object? argValue, string formatSpec) {
             object? res;

--- a/Tests/test_str.py
+++ b/Tests/test_str.py
@@ -7,7 +7,7 @@ import os
 import sys
 import warnings
 
-from iptest import IronPythonTestCase, is_cli, big, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, big, mystr, run_test, skipUnlessIronPython
 
 class Indexable:
     def __init__(self, value):
@@ -297,6 +297,18 @@ class StrTest(IronPythonTestCase):
         self.assertEqual(o + 'abc', 23)
         self.assertEqual(len(o), 2300)
         self.assertEqual('a' in o, False)
+
+    def test_repr_mystr(self):
+        class A:
+            def __repr__(self) -> str:
+                return mystr("__repr__ called")
+            def __str__(self) -> str:
+                return mystr("__str__ called")
+
+        self.assertIs(type(repr(A())), mystr)
+        self.assertIs(type(str(A())), mystr)
+        self.assertEquals(repr(A()), "__repr__ called")
+        self.assertEquals(str(A()), "__str__ called")
 
     @skipUnlessIronPython()
     def test_str_char_hash(self):


### PR DESCRIPTION
I was hoping this would go away in some new version of CPython, but it's still here in 3.10.