### PR TITLE
Add bin subdir to path on entering IronPython environment

### DIFF
--- a/Src/Scripts/Enter-IronPythonEnvironment.ps1
+++ b/Src/Scripts/Enter-IronPythonEnvironment.ps1
@@ -143,6 +143,8 @@ function global:prompt {
 [string[]] $newEnvPaths = @($IronPythonEnvironmentPath)
 if ($IsWindows) {
     $newEnvPaths += Join-Path $IronPythonEnvironmentPath "Scripts"
+} else {
+    $newEnvPaths += Join-Path $IronPythonEnvironmentPath "bin"
 }
 $newEnvPaths += $env:PATH
 $env:PATH = $newEnvPaths -join [IO.Path]::PathSeparator


### PR DESCRIPTION
Some packages (e.g. `sympy`) install tools in this location on Posix systems.