### PR TITLE
Workaround for issue with concat and radd

### DIFF
--- a/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
+++ b/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
@@ -705,8 +705,10 @@ namespace IronPython.Runtime.Binding {
             rSlot = null;
             PythonType fParent, rParent;
 
+            bool isSequence = IsSequence(types[0]);
+
             if (oper == PythonOperationKind.Multiply &&
-                IsSequence(types[0]) &&
+                isSequence &&
                 !PythonOps.IsNonExtensibleNumericType(types[1].GetLimitType())) {
                 // class M:
                 //      def __rmul__(self, other):
@@ -751,8 +753,16 @@ namespace IronPython.Runtime.Binding {
                 }
             }
 
+            // TODO: this is incorrect - if the rslot returns NotImplemented then fslot is never called and a TypeError will be raised
             if (fParent != null && (rbinder.Success || rSlot != null) && rParent != fParent && rParent.IsSubclassOf(fParent)) {
                 // Python says if x + subx and subx defines __r*__ we should call r*.
+                fbinder = SlotOrFunction.Empty;
+                fSlot = null;
+            }
+
+            // TODO: this is incorrect - if the rslot returns NotImplemented then fslot is never called and a TypeError will be raised
+            if (oper == PythonOperationKind.Add && fParent != null && (rbinder.Success || rSlot != null) && rParent != fParent && isSequence) {
+                // if the left operand is a sequence and the right operand defines __radd__, we should call __radd__.
                 fbinder = SlotOrFunction.Empty;
                 fSlot = null;
             }

--- a/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
+++ b/Src/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
@@ -753,14 +753,14 @@ namespace IronPython.Runtime.Binding {
                 }
             }
 
-            // TODO: this is incorrect - if the rslot returns NotImplemented then fslot is never called and a TypeError will be raised
+            // TODO: this is incorrect - if the rslot returns NotImplemented then fslot is never called and a TypeError will be raised (https://github.com/IronLanguages/ironpython3/issues/1479)
             if (fParent != null && (rbinder.Success || rSlot != null) && rParent != fParent && rParent.IsSubclassOf(fParent)) {
                 // Python says if x + subx and subx defines __r*__ we should call r*.
                 fbinder = SlotOrFunction.Empty;
                 fSlot = null;
             }
 
-            // TODO: this is incorrect - if the rslot returns NotImplemented then fslot is never called and a TypeError will be raised
+            // TODO: this is incorrect - if the rslot returns NotImplemented then fslot is never called and a TypeError will be raised (https://github.com/IronLanguages/ironpython3/issues/560)
             if (oper == PythonOperationKind.Add && fParent != null && (rbinder.Success || rSlot != null) && rParent != fParent && isSequence) {
                 // if the left operand is a sequence and the right operand defines __radd__, we should call __radd__.
                 fbinder = SlotOrFunction.Empty;

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1310,6 +1310,7 @@ namespace IronPython.Runtime.Operations {
         #endregion
 
         #region operators
+
         [SpecialName]
         public static string Add([NotNone] string self, [NotNone] string other) {
             return self + other;
@@ -1323,6 +1324,13 @@ namespace IronPython.Runtime.Operations {
         [SpecialName]
         public static string Add(char self, [NotNone] string other) {
             return self + other;
+        }
+
+        [SpecialName]
+        public static string Add([NotNone] string self, object? other) {
+            if (other is string s) return Add(self, s);
+            if (other is char c) return Add(self, c);
+            throw PythonOps.TypeError($"can only concatenate str (not \"{PythonOps.GetPythonTypeName(other)}\") to str");
         }
 
         [SpecialName]

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -225,6 +225,11 @@ namespace IronPython.Runtime {
             }
         }
 
+        public static PythonList operator +([NotNone] PythonList self, object? other) {
+            if (other is PythonList l) return self + l;
+            throw PythonOps.TypeError($"can only concatenate list (not \"{PythonOps.GetPythonTypeName(other)}\") to list");
+        }
+
         /// <summary>
         /// Gets a reasonable size for the addition of two arrays.  We round
         /// to a power of two so that we usually have some extra space if

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1667,5 +1667,25 @@ plistlib.loads(plistlib.dumps({})) # check that this does not fail
         for code in ['b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q', 'n', 'N', 'P']:
             self.assertEqual(_struct.Struct(code).pack(x(42))[idx], 42)
 
+    def test_ipy3_gh1475(self):
+        # The following test is adapted from https://github.com/IronLanguages/ironpython3/issues/560 and
+        # covers the issue described in https://github.com/IronLanguages/ironpython3/issues/1475
+
+        class M:
+            def __rmul__(self, other):
+                return 23
+            def __radd__(self, other):
+                return 64
+
+        m = M()
+        for seq in ([], (), "", b"", bytearray()):
+            with self.assertRaises(TypeError):
+                seq.__add__(m)
+
+            with self.assertRaises(TypeError):
+                seq.__mul__(m)
+
+            self.assertEqual(seq * m, 23)
+            self.assertEqual(seq + m, 64)
 
 run_test(__name__)


### PR DESCRIPTION
This resolves https://github.com/IronLanguages/ironpython3/issues/1475. The patch is not actually correct but it "fixes" the more common scenario. See https://github.com/IronLanguages/ironpython3/issues/560 for details on the remaining issues.