### PR TITLE
Accept bytes as filename arg to compile

### DIFF
--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -2794,13 +2794,7 @@ namespace IronPython.Modules {
             string fname = null;
             if (!Converter.TryConvertToIndex(file, out int fd, false, false)) {
                 fd = -1;
-                var path = PythonOps.FsPath(file);
-                fname = path switch {
-                    string s => s,
-                    Extensible<string> es => es,
-                    Bytes b => b.decode(context, SysModule.getfilesystemencoding(), SysModule.getfilesystemencodeerrors()),
-                    _ => throw new InvalidOperationException(),
-                };
+                fname = PythonOps.FsPathDecoded(context, file);
             }
 
             HashSet<char> modes = MakeSet(mode);

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -342,6 +342,15 @@ namespace IronPython.Runtime.Operations {
             throw PythonOps.TypeError("expected str, bytes or os.PathLike object, not {0}", PythonOps.GetPythonTypeName(path));
         }
 
+        internal static string FsPathDecoded(CodeContext context, object? path) {
+            return PythonOps.FsPath(path) switch {
+                string s => s,
+                Extensible<string> es => es,
+                Bytes b => b.decode(context, SysModule.getfilesystemencoding(), SysModule.getfilesystemencodeerrors()),
+                _ => throw new InvalidOperationException(),
+            };
+        }
+
         public static object Plus(object? o) {
             if (o is int) return o;
             else if (o is double) return o;

--- a/Tests/test_builtinfunc.py
+++ b/Tests/test_builtinfunc.py
@@ -671,9 +671,11 @@ class BuiltinsTest2(IronPythonTestCase):
         f()
 
     def test_compile(self):
-        for x in ['exec', 'eval', 'single']:
-            c = compile('2', 'foo', x)
-            self.assertEqual(c.co_filename, 'foo')
+        for mode in ['exec', 'eval', 'single']:
+            for filename in ['foo', b'foo']:
+                for source in ['2', b'2']:
+                    c = compile(source, filename, mode)
+                    self.assertEqual(c.co_filename, 'foo')
 
         class mystdout(object):
             def __init__(self):


### PR DESCRIPTION
CPython also accepts any buffer protocol aware object but with a deprecation warning starting from 3.7, so I think it is more an implementation artifact slated for removal than a legitimate use case. I also haven't met such usage in real life (unlike bytes, which are being passed).