### PR TITLE
Implement module resource

### DIFF
--- a/Src/IronPython.Modules/resource.cs
+++ b/Src/IronPython.Modules/resource.cs
@@ -3,20 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 // TODO: use LightThrowing
-// TODO: use RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
 // TODO: Port to maxOS
 
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Numerics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using static System.Environment; // TODO: remove
 
-using IronPython;
 using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
@@ -37,47 +33,47 @@ public static class PythonResourceModule {
     #region Constants
 
     public static BigInteger RLIM_INFINITY
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (BigInteger)long.MaxValue : BigInteger.MinusOne;
 
     public static int RLIMIT_CPU
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_CPU : (int)linux__rlimit_resource.RLIMIT_CPU;
 
     public static int RLIMIT_FSIZE
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_FSIZE : (int)linux__rlimit_resource.RLIMIT_FSIZE;
 
     public static int RLIMIT_DATA
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_DATA : (int)linux__rlimit_resource.RLIMIT_DATA;
 
     public static int RLIMIT_STACK
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_STACK : (int)linux__rlimit_resource.RLIMIT_STACK;
 
     public static int RLIMIT_CORE
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_CORE : (int)linux__rlimit_resource.RLIMIT_CORE;
 
     public static int RLIMIT_RSS
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_RSS : (int)linux__rlimit_resource.RLIMIT_RSS;
 
     public static int RLIMIT_AS
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_AS : (int)linux__rlimit_resource.RLIMIT_AS;
 
     public static int RLIMIT_MEMLOCK
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_MEMLOCK : (int)linux__rlimit_resource.RLIMIT_MEMLOCK;
 
     public static int RLIMIT_NPROC
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_NPROC : (int)linux__rlimit_resource.RLIMIT_NPROC;
 
     public static int RLIMIT_NOFILE
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)macos__rlimit_resource.RLIMIT_NOFILE : (int)linux__rlimit_resource.RLIMIT_NOFILE;
 
     [PythonHidden(PlatformID.MacOSX)]
@@ -102,7 +98,7 @@ public static class PythonResourceModule {
     public static int RLIMIT_RTTIME => (int)linux__rlimit_resource.RLIMIT_RTTIME;
 
     private static int RLIM_NLIMITS
-        => OSVersion.Platform == PlatformID.MacOSX ?
+        => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
             (int)(macos__rlimit_resource.RLIM_NLIMITS) : (int)(linux__rlimit_resource.RLIM_NLIMITS);
 
     public static int RUSAGE_SELF => 0;
@@ -157,7 +153,7 @@ public static class PythonResourceModule {
                 ThrowValueError();
 
             long rlim = checked((long)lim);
-            if (rlim < 0 && OSVersion.Platform == PlatformID.MacOSX)
+            if (rlim < 0 && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 rlim -= long.MinValue;
             return rlim;
         }
@@ -215,7 +211,7 @@ public static class PythonResourceModule {
                 ThrowValueError();
 
             long rlim = checked((long)lim);
-            if (rlim < 0 && OSVersion.Platform == PlatformID.MacOSX)
+            if (rlim < 0 && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 rlim -= long.MinValue;
             return rlim;
         }
@@ -224,7 +220,7 @@ public static class PythonResourceModule {
     }
 
     public static object getrusage(int who) {
-        int maxWho = OSVersion.Platform == PlatformID.MacOSX ? 0 : 1;
+        int maxWho = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0 : 1;
         if (who < -1 || who > maxWho) throw PythonOps.ValueError("invalid who parameter");
 
         IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf<rusage>());

--- a/Src/IronPython.Modules/resource.cs
+++ b/Src/IronPython.Modules/resource.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+using Microsoft.Scripting.Runtime;
+using IronPython.Runtime;
+using IronPython.Runtime.Exceptions;
+using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
+
+[assembly: PythonModule("resource", typeof(IronPython.Modules.PythonResourceModule), PlatformsAttribute.PlatformFamily.Unix)]
+namespace IronPython.Modules;
+
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
+public static class PythonResourceModule {
+    public const string __doc__ = "Provides basic mechanisms for measuring and controlling system resources utilized by a program. Unix only.";
+
+    [Obsolete("Deprecated in favor of OSError.")]
+    public static PythonType error => PythonExceptions.OSError;
+
+    #region Constants
+
+    public static BigInteger RLIM_INFINITY = ulong.MaxValue; // CPython/macOS convention and consistent with values returned by this implementation
+
+    public static int RLIMIT_CPU
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_CPU : (int)linux__rlimit_resource.RLIMIT_CPU;
+
+    public static int RLIMIT_FSIZE
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_FSIZE : (int)linux__rlimit_resource.RLIMIT_FSIZE;
+
+    public static int RLIMIT_DATA
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_DATA : (int)linux__rlimit_resource.RLIMIT_DATA;
+
+    public static int RLIMIT_STACK
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_STACK : (int)linux__rlimit_resource.RLIMIT_STACK;
+
+    public static int RLIMIT_CORE
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_CORE : (int)linux__rlimit_resource.RLIMIT_CORE;
+
+    public static int RLIMIT_RSS
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_RSS : (int)linux__rlimit_resource.RLIMIT_RSS;
+
+    public static int RLIMIT_AS
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_AS : (int)linux__rlimit_resource.RLIMIT_AS;
+
+    public static int RLIMIT_MEMLOCK
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_MEMLOCK : (int)linux__rlimit_resource.RLIMIT_MEMLOCK;
+
+    public static int RLIMIT_NPROC
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_NPROC : (int)linux__rlimit_resource.RLIMIT_NPROC;
+
+    public static int RLIMIT_NOFILE
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)macos__rlimit_resource.RLIMIT_NOFILE : (int)linux__rlimit_resource.RLIMIT_NOFILE;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RLIMIT_OFILE => RLIMIT_NOFILE;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RLIMIT_LOCKS => (int)linux__rlimit_resource.RLIMIT_LOCKS;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RLIMIT_SIGPENDING => (int)linux__rlimit_resource.RLIMIT_SIGPENDING;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RLIMIT_MSGQUEUE => (int)linux__rlimit_resource.RLIMIT_MSGQUEUE;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RLIMIT_NICE => (int)linux__rlimit_resource.RLIMIT_NICE;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RLIMIT_RTPRIO => (int)linux__rlimit_resource.RLIMIT_RTPRIO;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RLIMIT_RTTIME => (int)linux__rlimit_resource.RLIMIT_RTTIME;
+
+    private static int RLIM_NLIMITS
+        => Environment.OSVersion.Platform == PlatformID.MacOSX ?
+            (int)(macos__rlimit_resource.RLIM_NLIMITS) : (int)(linux__rlimit_resource.RLIM_NLIMITS);
+
+    #endregion
+
+    public static PythonTuple getrlimit(int resource) {
+        if (resource < 0 || resource >= RLIM_NLIMITS) {
+            throw PythonOps.ValueError("invalid resource specified");
+        }
+
+        IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf<rlimit>());
+        try {
+            int err = getrlimit_linux(resource, ptr);
+            ThrowIfError(err);
+            rlimit res = Marshal.PtrToStructure<rlimit>(ptr);
+
+            return PythonTuple.MakeTuple(res.rlim_cur.ToPythonInt(), res.rlim_max.ToPythonInt());
+        } finally {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+
+    private static void ThrowIfError(int err) {
+        if (err != 0) {
+#if NET60_OR_GREATER
+            int errno = Marshal.GetLastPInvokeError();
+#else
+            int errno = Marshal.GetLastWin32Error();
+#endif
+            throw PythonOps.OSError(errno, PythonNT.strerror(errno));
+        }
+    }
+
+    private static object ToPythonInt(this ulong value)
+        => value <= (ulong)int.MaxValue ? (int)value : (BigInteger)value;
+
+
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+    private struct rlimit {
+        public ulong rlim_cur;
+        public ulong rlim_max;
+    }
+#pragma warning restore CS0649
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "getrlimit")]
+    private static extern int getrlimit_linux(int __resource, IntPtr __rlimits);
+
+    enum macos__rlimit_resource {
+        RLIMIT_CPU = 0,
+        RLIMIT_FSIZE = 1,
+        RLIMIT_DATA = 2,
+        RLIMIT_STACK = 3,
+        RLIMIT_CORE = 4,
+        RLIMIT_RSS = 5,
+        RLIMIT_AS = 5,
+        RLIMIT_MEMLOCK = 6,
+        RLIMIT_NPROC = 7,
+        RLIMIT_NOFILE = 8,
+
+        RLIM_NLIMITS
+    }
+
+    enum linux__rlimit_resource {
+        // /usr/include/x86_64-linux-gnu/sys/resource.h 
+
+        RLIMIT_CPU = 0, // Per-process CPU limit
+        RLIMIT_FSIZE = 1,  // Maximum filesize
+        RLIMIT_DATA = 2,  // Maximum size of data segment
+        RLIMIT_STACK = 3,  // Maximum size of stack segment
+        RLIMIT_CORE = 4,  // Maximum size of core file
+        RLIMIT_RSS = 5,  // Largest resident set size
+        RLIMIT_NPROC = 6,  // Maximum number of processes
+        RLIMIT_NOFILE = 7, // Maximum number of open files
+        RLIMIT_MEMLOCK = 8,  // Maximum locked-in-memory address space
+        RLIMIT_AS = 9,  // Address space limit
+        RLIMIT_LOCKS = 10,  // Maximum number of file locks
+        RLIMIT_SIGPENDING = 11,  // Maximum number of pending signals
+        RLIMIT_MSGQUEUE = 12,  // Maximum bytes in POSIX message queues
+        RLIMIT_NICE = 13,  // Maximum nice prio allowed to raise to (20 added to get a non-negative number)
+        RLIMIT_RTPRIO = 14,  // Maximum realtime priority
+        RLIMIT_RTTIME = 15,  // Time slice in us
+
+        RLIM_NLIMITS
+    };
+}

--- a/Src/IronPython.Modules/resource.cs
+++ b/Src/IronPython.Modules/resource.cs
@@ -99,6 +99,13 @@ public static class PythonResourceModule {
         => OSVersion.Platform == PlatformID.MacOSX ?
             (int)(macos__rlimit_resource.RLIM_NLIMITS) : (int)(linux__rlimit_resource.RLIM_NLIMITS);
 
+    public static int RUSAGE_SELF => 0;
+
+    public static int RUSAGE_CHILDREN => -1;
+
+    [PythonHidden(PlatformID.MacOSX)]
+    public static int RUSAGE_THREAD => 1;
+
     #endregion
 
     public static PythonTuple getrlimit(int resource) {
@@ -151,13 +158,13 @@ public static class PythonResourceModule {
         static void ThrowValueError() => throw PythonOps.ValueError("expected a tuple of 2 integers");
     }
 
+    public static BigInteger getpagesize() {
+        return Mono.Unix.Native.Syscall.sysconf(Mono.Unix.Native.SysconfName._SC_PAGESIZE);
+    }
+
     private static void ThrowIfError(int err) {
         if (err != 0) {
-#if NET60_OR_GREATER
-            int errno = Marshal.GetLastPInvokeError();
-#else
-            int errno = Marshal.GetLastWin32Error();
-#endif
+            int errno = Marshal.GetLastWin32Error(); // despite its name, on Posix it retrieves errno set by the last p/Invoke call
             throw PythonOps.OSError(errno, PythonNT.strerror(errno));
         }
     }

--- a/Src/IronPython/Runtime/PlatformsAttribute.cs
+++ b/Src/IronPython/Runtime/PlatformsAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace IronPython.Runtime {
     public class PlatformsAttribute : Attribute {
@@ -16,7 +17,12 @@ namespace IronPython.Runtime {
 
         public PlatformID[] ValidPlatforms { get; protected set; }
 
-        public bool IsPlatformValid => ValidPlatforms == null || ValidPlatforms.Length == 0 || Array.IndexOf(ValidPlatforms, Environment.OSVersion.Platform) >= 0;
+        public bool IsPlatformValid => ValidPlatforms == null || ValidPlatforms.Length == 0 || Array.IndexOf(ValidPlatforms, ActualPlatform) >= 0;
+
+        private static PlatformID ActualPlatform
+            => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? PlatformID.Unix :
+               RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? PlatformID.MacOSX :
+               Environment.OSVersion.Platform;
 
         protected void SetValidPlatforms(PlatformFamily validPlatformFamily) {
             switch (validPlatformFamily) {

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -773,10 +773,8 @@ IsolationLevel=PROCESS
 [CPython.test_reprlib]
 Ignore=true
 
-[CPython.test_resource]
-RunCondition=$(IS_POSIX)
+[CPython.test_resource] # IronPython.test_resource_stdlib
 Ignore=true
-Reason=unittest.case.SkipTest: No module named 'resource'
 
 [CPython.test_robotparser]
 Ignore=true

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -159,6 +159,9 @@ NotParallelSafe=true # Uses a temporary module with a fixed name
 [IronPython.modules.type_related.test_bitfields_ctypes_stdlib]
 RunCondition=NOT $(IS_OSX) # ctypes tests not prepared for macOS
 
+[IronPython.modules.system_related.test_resource]
+RunCondition=$(IS_POSIX) # Posix-only module
+
 [IronPython.modules.system_related.test_sys_getframe]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 FullFrames=true

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -159,9 +159,6 @@ NotParallelSafe=true # Uses a temporary module with a fixed name
 [IronPython.modules.type_related.test_bitfields_ctypes_stdlib]
 RunCondition=NOT $(IS_OSX) # ctypes tests not prepared for macOS
 
-[IronPython.modules.system_related.test_resource]
-RunCondition=$(IS_POSIX) # Posix-only module
-
 [IronPython.modules.system_related.test_sys_getframe]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 FullFrames=true

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -143,6 +143,9 @@ IsolationLevel=PROCESS # causes a failure in IronPython.test_attrinjector
 [IronPython.interop.net.type.test_reachtype]
 IsolationLevel=PROCESS # causes failures in IronPython.test_ast and IronPython.scripts.test_cgcheck
 
+[IronPython.modules.io_related.test_cPickle]
+NotParallelSafe=true # Uses a temporary module with a fixed name
+
 [IronPython.modules.misc.test__weakref]
 RetryCount=2
 
@@ -153,15 +156,15 @@ NotParallelSafe=true # test_data.gz
 RunCondition=NOT $(IS_POSIX)
 NotParallelSafe=true # Uses fixed file, directory, and environment variable names
 
-[IronPython.modules.io_related.test_cPickle]
-NotParallelSafe=true # Uses a temporary module with a fixed name
-
-[IronPython.modules.type_related.test_bitfields_ctypes_stdlib]
-RunCondition=NOT $(IS_OSX) # ctypes tests not prepared for macOS
+[IronPython.modules.system_related.test_resource_stdlib]
+RunCondition=$(IS_POSIX) # Module resource is Posix-specific
 
 [IronPython.modules.system_related.test_sys_getframe]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 FullFrames=true
+
+[IronPython.modules.type_related.test_bitfields_ctypes_stdlib]
+RunCondition=NOT $(IS_OSX) # ctypes tests not prepared for macOS
 
 [IronPython.scripts.test_builder]
 Ignore=true

--- a/Tests/modules/system_related/test_resource.py
+++ b/Tests/modules/system_related/test_resource.py
@@ -2,22 +2,85 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
+# tests fro module 'resource' (Posix only)
+
 import os
 import sys
 import unittest
 import resource
 
-from iptest import IronPythonTestCase, is_cli, is_linux, path_modifier, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_linux, is_osx, run_test, skipUnlessIronPython
 
 class ResourceTest(IronPythonTestCase):
-    def test_getrlimit(self):
-        RLIM_NLIMITS = 16 if is_linux else 9
+    def setUp(self):
+        self.RLIM_NLIMITS = 16 if is_linux else 9
 
-        for r in range(RLIM_NLIMITS):
+    def test_infinity(self):
+        if is_osx:
+            self.assertEqual(resource.RLIM_INFINITY, (1<<63)-1)
+        else:
+            self.assertEqual(resource.RLIM_INFINITY, -1)
+
+    def test_getrlimit(self):
+        for r in range(self.RLIM_NLIMITS):
             lims = resource.getrlimit(r)
             self.assertIsInstance(lims, tuple)
             self.assertEqual(len(lims), 2)
             self.assertIsInstance(lims[0], int)
             self.assertIsInstance(lims[1], int)
+
+        self.assertRaises(TypeError, resource.getrlimit, None)
+        self.assertRaises(TypeError, resource.getrlimit, "abc")
+        self.assertRaises(TypeError, resource.getrlimit, 4.0)
+        self.assertRaises(ValueError, resource.getrlimit, -1)
+        self.assertRaises(ValueError, resource.getrlimit, self.RLIM_NLIMITS)
+
+    def test_setrlimit(self):
+        r = resource.RLIMIT_CORE
+        lims = resource.getrlimit(r)
+        rlim_max = lims[1]
+        # usually max core size is unlimited so a good resource limit to test setting
+        if (rlim_max == resource.RLIM_INFINITY):
+            try:
+                resource.setrlimit(r, (0, rlim_max))
+                self.assertEqual(resource.getrlimit(r), (0, rlim_max) )
+
+                resource.setrlimit(r, (10, rlim_max))
+                self.assertEqual(resource.getrlimit(r), (10, rlim_max) )
+
+                resource.setrlimit(r, [0, rlim_max]) # using a list
+                self.assertEqual(resource.getrlimit(r), (0, rlim_max) )
+
+                resource.setrlimit(r, (resource.RLIM_INFINITY, rlim_max))
+                self.assertEqual(resource.getrlimit(r), (resource.RLIM_INFINITY, rlim_max) )
+
+                resource.setrlimit(r, (-1, rlim_max))
+                self.assertEqual(resource.getrlimit(r), (resource.RLIM_INFINITY, rlim_max) )
+
+                resource.setrlimit(r, (-2, rlim_max))
+                self.assertEqual(resource.getrlimit(r), (resource.RLIM_INFINITY-1, rlim_max) )
+
+                resource.setrlimit(r, ((1<<63)-1, rlim_max))
+                self.assertEqual(resource.getrlimit(r), ((1<<63)-1, rlim_max) )
+
+                resource.setrlimit(r, (-(1<<63), rlim_max))
+                if is_osx:
+                    self.assertEqual(resource.getrlimit(r), (0, rlim_max) )
+                else:
+                    self.assertEqual(resource.getrlimit(r), (-(1<<63), rlim_max) )
+
+            finally:
+                resource.setrlimit(r, lims)
+
+    def test_setrlimit_error(self):
+        self.assertRaises(TypeError, resource.setrlimit, None, (0, 0))
+        self.assertRaises(TypeError, resource.setrlimit, "abc", (0, 0))
+        self.assertRaises(TypeError, resource.setrlimit, 4.0, (0, 0))
+        self.assertRaises(ValueError, resource.setrlimit, -1, (0, 0))
+        self.assertRaises(ValueError, resource.setrlimit, self.RLIM_NLIMITS, (0, 0))
+        self.assertRaises(ValueError, resource.setrlimit, 0, (0,))
+        self.assertRaises(ValueError, resource.setrlimit, 0, (0, 0, 0))
+        self.assertRaises(ValueError, resource.setrlimit, 0, (2.3, 0, 0))
+        self.assertRaises(TypeError, resource.setrlimit, 0, None)
 
 run_test(__name__)

--- a/Tests/modules/system_related/test_resource.py
+++ b/Tests/modules/system_related/test_resource.py
@@ -1,0 +1,23 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+import os
+import sys
+import unittest
+import resource
+
+from iptest import IronPythonTestCase, is_cli, is_linux, path_modifier, run_test, skipUnlessIronPython
+
+class ResourceTest(IronPythonTestCase):
+    def test_getrlimit(self):
+        RLIM_NLIMITS = 16 if is_linux else 9
+
+        for r in range(RLIM_NLIMITS):
+            lims = resource.getrlimit(r)
+            self.assertIsInstance(lims, tuple)
+            self.assertEqual(len(lims), 2)
+            self.assertIsInstance(lims[0], int)
+            self.assertIsInstance(lims[1], int)
+
+run_test(__name__)

--- a/Tests/modules/system_related/test_resource.py
+++ b/Tests/modules/system_related/test_resource.py
@@ -97,6 +97,7 @@ class ResourceTest(IronPythonTestCase):
         self.assertRaises(TypeError, resource.setrlimit, 0, None)
 
     @unittest.skipUnless(is_posix, "Posix-specific test")
+    @unittest.skipUnless(not is_osx, "prlimit not available on macOS")
     def test_prlimit(self):
         r = resource.RLIMIT_CORE
         lims = resource.getrlimit(r)

--- a/Tests/modules/system_related/test_resource.py
+++ b/Tests/modules/system_related/test_resource.py
@@ -2,11 +2,11 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-# tests fro module 'resource' (Posix only)
+# tests for module 'resource' (Posix only)
 
 import unittest
 
-from iptest import IronPythonTestCase, is_cli, is_posix, is_linux, is_osx, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_posix, is_linux, is_osx, run_test
 
 if is_posix:
     import resource
@@ -18,18 +18,17 @@ else:
     else:
         raise AssertionError("There should be no module resource on Windows")
 
+@unittest.skipUnless(is_posix, "Posix-specific test")
 class ResourceTest(IronPythonTestCase):
     def setUp(self):
         self.RLIM_NLIMITS = 16 if is_linux else 9
 
-    @unittest.skipUnless(is_posix, "Posix-specific test")
     def test_infinity(self):
         if is_osx:
             self.assertEqual(resource.RLIM_INFINITY, (1<<63)-1)
         else:
             self.assertEqual(resource.RLIM_INFINITY, -1)
 
-    @unittest.skipUnless(is_posix, "Posix-specific test")
     def test_getrlimit(self):
         for r in range(self.RLIM_NLIMITS):
             lims = resource.getrlimit(r)
@@ -44,7 +43,6 @@ class ResourceTest(IronPythonTestCase):
         self.assertRaises(ValueError, resource.getrlimit, -1)
         self.assertRaises(ValueError, resource.getrlimit, self.RLIM_NLIMITS)
 
-    @unittest.skipUnless(is_posix, "Posix-specific test")
     def test_setrlimit(self):
         r = resource.RLIMIT_CORE
         lims = resource.getrlimit(r)
@@ -84,7 +82,6 @@ class ResourceTest(IronPythonTestCase):
             finally:
                 resource.setrlimit(r, lims)
 
-    @unittest.skipUnless(is_posix, "Posix-specific test")
     def test_setrlimit_error(self):
         self.assertRaises(TypeError, resource.setrlimit, None, (0, 0))
         self.assertRaises(TypeError, resource.setrlimit, "abc", (0, 0))
@@ -96,7 +93,6 @@ class ResourceTest(IronPythonTestCase):
         self.assertRaises(ValueError, resource.setrlimit, 0, (2.3, 0, 0))
         self.assertRaises(TypeError, resource.setrlimit, 0, None)
 
-    @unittest.skipUnless(is_posix, "Posix-specific test")
     @unittest.skipUnless(not is_osx, "prlimit not available on macOS")
     def test_prlimit(self):
         r = resource.RLIMIT_CORE
@@ -112,14 +108,12 @@ class ResourceTest(IronPythonTestCase):
             finally:
                 resource.prlimit(0, r, lims)
 
-    @unittest.skipUnless(is_posix, "Posix-specific test")
     def test_pagesize(self):
         ps = resource.getpagesize()
         self.assertIsInstance(ps, int)
         self.assertTrue(ps > 0)
         self.assertTrue((ps & (ps-1) == 0)) # ps is power of 2
 
-    @unittest.skipUnless(is_posix, "Posix-specific test")
     def test_getrusage(self):
         self.assertEqual(resource.struct_rusage.n_fields, 16)
         self.assertEqual(resource.struct_rusage.n_sequence_fields, 16)

--- a/Tests/modules/system_related/test_resource_stdlib.py
+++ b/Tests/modules/system_related/test_resource_stdlib.py
@@ -1,0 +1,34 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+##
+## Run selected tests from test_resource from StdLib
+##
+
+import unittest
+import sys
+
+from iptest import run_test
+
+import test.test_resource
+
+def load_tests(loader, standard_tests, pattern):
+    if sys.implementation.name == 'ironpython':
+        suite = unittest.TestSuite()
+        suite.addTest(test.test_resource.ResourceTest('test_args'))
+        suite.addTest(test.test_resource.ResourceTest('test_freebsd_contants'))
+        #suite.addTest(test.test_resource.ResourceTest('test_fsize_enforced')) # TODO: handle SIGXFSZ
+        suite.addTest(test.test_resource.ResourceTest('test_fsize_ismax'))
+        suite.addTest(test.test_resource.ResourceTest('test_fsize_toobig'))
+        suite.addTest(test.test_resource.ResourceTest('test_getrusage'))
+        suite.addTest(test.test_resource.ResourceTest('test_linux_constants'))
+        suite.addTest(test.test_resource.ResourceTest('test_pagesize'))
+        suite.addTest(test.test_resource.ResourceTest('test_prlimit'))
+        suite.addTest(test.test_resource.ResourceTest('test_setrusage_refcount'))
+        return suite
+
+    else:
+        return loader.loadTestsFromModule(test.test_resource, pattern)
+
+run_test(__name__)


### PR DESCRIPTION
Module `resource` is Posix-only. The implementation here is fairly complete as far as I know, except for a small incompatibility when attempting to increase a maximum limit while not being a superuser. CPython raises `ValueError` while this implementation raises `OSError`. I think CPython's choice is a mistake. A `ValueError` is supposed to indicate an invalid value, something that the caller should be able to prevent from happening with proper value checks and preconditions. For instance, trying to set a a pair of limits where _current_ is higher than _maximum_ is a legitimate `ValueError`. But to decide whether the caller is or is not allowed to raise the maximum is the domain of the OS. Some lightweight OS implementations may allow it in some circumstances or for some users. Therefore `OSError` is more appropriate, especially since the call already can raise `OSError` when the systems says "ni" for some reason.

But this is not the main reason I haven't implemented the CPython's behaviour in such case. In general, I prefer to implement all CPython's quirkiness, as unreasonable as it may be — for the sake of compatibility. In this case, however, I think it is not worth the effort, performance, and extra complexity. First, such situations should be rare. Second, to actually properly raise `ValueError`, the implementation would need to add another system call (at least); all this just to report the expected error type for a rare case. Finally, when I looked up how real life modules on PyPI handle such calls, in all cases I found they were catching both `ValueError` and `OSError` together, which is not surprising, given that the caller cannot predict which one might happen. (This by itself is another indication that the CPython's choice is unfortunate). So unless some real-life problem gets reported, I leave it as it is.

Still to do: make working on macOS.