### PR TITLE
Resolve failure with jedi module

### DIFF
--- a/Src/IronPython.Modules/_csv.cs
+++ b/Src/IronPython.Modules/_csv.cs
@@ -119,23 +119,18 @@ dialect = csv.register_dialect(name, dialect)")]
 
         [Documentation(@"Delete the name/dialect mapping associated with a string name.\n
     csv.unregister_dialect(name)")]
-        public static void unregister_dialect(CodeContext/*!*/ context,
-            string name) {
+        public static void unregister_dialect(CodeContext/*!*/ context, string name) {
             DialectRegistry dialects = GetDialects(context);
-            if (name == null || !dialects.ContainsKey(name))
-                throw MakeError("unknown dialect");
-
-            if (dialects.ContainsKey(name))
-                dialects.Remove(name);
+            if (name is not null && dialects.Remove(name)) return;
+            throw MakeError("unknown dialect");
         }
 
         [Documentation(@"Return the dialect instance associated with name.
     dialect = csv.get_dialect(name)")]
         public static object get_dialect(CodeContext/*!*/ context, string name) {
             DialectRegistry dialects = GetDialects(context);
-            if (name == null || !dialects.ContainsKey(name))
-                throw MakeError("unknown dialect");
-            return dialects[name];
+            if (name is not null && dialects.TryGetValue(name, out var value)) return value;
+            throw MakeError("unknown dialect");
         }
 
         [Documentation(@"Return a list of all know dialect names

--- a/Src/IronPython.Modules/_functools.cs
+++ b/Src/IronPython.Modules/_functools.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 
 using IronPython.Runtime;
@@ -189,6 +190,24 @@ namespace IronPython.Modules {
                 } else {
                     throw PythonOps.TypeError("invalid partial state");
                 }
+            }
+
+            public string __repr__(CodeContext context) {
+                var builder = new StringBuilder();
+                builder.Append("functools.partial(");
+                builder.Append(PythonOps.Repr(context, func));
+                foreach (var x in _args) {
+                    builder.Append(", ");
+                    builder.Append(PythonOps.Repr(context, x));
+                }
+                foreach (var p in _keywordArgs) {
+                    builder.Append(", ");
+                    builder.Append(p.Key);
+                    builder.Append('=');
+                    builder.Append(PythonOps.Repr(context, p.Value));
+                }
+                builder.Append(')');
+                return builder.ToString();
             }
 
             #endregion

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -888,7 +888,9 @@ namespace IronPython.Runtime.Operations {
                 return true;
             }
 
-            object len = PythonContext.InvokeUnaryOperator(DefaultContext.Default, UnaryOperators.Length, o, $"object of type '{GetPythonTypeName(o)}' has no len()");
+            if (!PythonContext.TryInvokeUnaryOperator(DefaultContext.Default, UnaryOperators.Length, o, out object len)) {
+                throw TypeError("object of type '{0}' has no len()", GetPythonTypeName(o));
+            }
 
             var indexObj = Index(len);
 

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -2137,14 +2137,8 @@ namespace IronPython.Runtime {
             return symbol;
         }
 
-        internal static object InvokeUnaryOperator(CodeContext/*!*/ context, UnaryOperators oper, object target, string errorMsg) {
-            object res;
-            if (context.LanguageContext.InvokeOperatorWorker(context, oper, target, out res)) {
-                return res;
-            }
-
-            throw PythonOps.TypeError(errorMsg);
-        }
+        internal static bool TryInvokeUnaryOperator(CodeContext/*!*/ context, UnaryOperators oper, object target, out object res)
+            => context.LanguageContext.InvokeOperatorWorker(context, oper, target, out res);
 
         internal static object InvokeUnaryOperator(CodeContext/*!*/ context, UnaryOperators oper, object target) {
             object res;

--- a/Src/StdLib/Lib/types.py
+++ b/Src/StdLib/Lib/types.py
@@ -38,7 +38,7 @@ except TypeError:
 
 # For Jython, the following two types are identical
 GetSetDescriptorType = type(FunctionType.__code__)
-MemberDescriptorType = type(FunctionType.__globals__)
+MemberDescriptorType = type(ModuleType.__dict__["__dict__"]) # ironpython: type(FunctionType.__globals__) is getset_descriptor
 
 del sys, _f, _g, _C,                              # Not for export
 

--- a/Tests/modules/type_related/test_types.py
+++ b/Tests/modules/type_related/test_types.py
@@ -16,4 +16,8 @@ class TypesTest(unittest.TestCase):
         m = types.ModuleType('m')
         self.assertEqual(m.__doc__, None)
 
+    def test_ipy3_gh1496(self):
+        self.assertEqual(repr(types.MemberDescriptorType), "<class 'member_descriptor'>")
+        self.assertEqual(repr(types.GetSetDescriptorType), "<class 'getset_descriptor'>")
+
 run_test(__name__)

--- a/Tests/test_functools_stdlib.py
+++ b/Tests/test_functools_stdlib.py
@@ -50,7 +50,7 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_functools.TestPartialC('test_pickle'))
         suite.addTest(test.test_functools.TestPartialC('test_positional'))
         suite.addTest(test.test_functools.TestPartialC('test_protection_of_callers_dict_argument'))
-        suite.addTest(unittest.expectedFailure(test.test_functools.TestPartialC('test_repr'))) # AssertionError
+        suite.addTest(test.test_functools.TestPartialC('test_repr'))
         suite.addTest(unittest.expectedFailure(test.test_functools.TestPartialC('test_setstate_refcount'))) # AttributeError: 'partial' object has no attribute '__setstate__'
         suite.addTest(test.test_functools.TestPartialC('test_weakref'))
         suite.addTest(test.test_functools.TestPartialC('test_with_bound_and_unbound_methods'))


### PR DESCRIPTION
The following hello world example is failing:
```py
import jedi
script = jedi.Script(print('Hello World!')
completions = script.complete(1, 3)
```

The failure appears to be caused by `types.MemberDescriptorType` being `<class 'getset_descriptor'>` instead of `<class 'member_descriptor'>`.

In the initial report (by @SebastianBolte on gitter) the sample was run in a hosted scenario and failing with a `TypeError: object of 'NoneType' has no len()`:
```cs
var engine = Python.CreateEngine();
engine.SetSearchPaths(seachPaths);
engine.Execute(@"
import jedi
script = jedi.Script(print('Hello World!')
completions = script.complete(1, 3)
");
```

This is because `sys.executable` is `None` by default. The solution to this is to set its value with `engine.SetHostVariables`. For example:
```cs
engine.SetHostVariables(@"C:\Program Files\IronPython 3.4", @"C:\Program Files\IronPython 3.4\ipy.exe", string.Empty);
```