### PR TITLE
Formatting cleanup

### DIFF
--- a/Src/IronPython/Runtime/FormattingHelper.cs
+++ b/Src/IronPython/Runtime/FormattingHelper.cs
@@ -24,28 +24,28 @@ namespace IronPython.Runtime
 {
     internal static class FormattingHelper
     {
-        private static NumberFormatInfo _invariantCommaSeperatorInfo;
+        private static NumberFormatInfo _invariantUnderscoreSeperatorInfo;
 
         /// <summary>
         /// Helper NumberFormatInfo for use by int/BigInteger __format__ routines
-        /// for width specified leading zero support that contains ','s every 3 digits.
+        /// for width specified leading zero support that contains '_'s every 3 digits.
         /// i.e. For use by d/g/G format specifiers. NOT for use by n format specifiers.
         /// </summary>
-        public static NumberFormatInfo InvariantCommaNumberInfo {
+        public static NumberFormatInfo InvariantUnderscoreNumberInfo {
             get {
-                if (_invariantCommaSeperatorInfo == null) {
+                if (_invariantUnderscoreSeperatorInfo == null) {
                     Interlocked.CompareExchange(
-                        ref _invariantCommaSeperatorInfo,
+                        ref _invariantUnderscoreSeperatorInfo,
                         new NumberFormatInfo()
                         {
-                            NumberGroupSeparator = ",",
+                            NumberGroupSeparator = "_",
                             NumberDecimalSeparator = ".",
                             NumberGroupSizes = new int[] {3}
                         },
                         null
                     );
                 }
-                return _invariantCommaSeperatorInfo;
+                return _invariantUnderscoreSeperatorInfo;
             }
         }
 

--- a/Src/IronPython/Runtime/FormattingHelper.cs
+++ b/Src/IronPython/Runtime/FormattingHelper.cs
@@ -1,29 +1,14 @@
-﻿/* ****************************************************************************
- *
- * Copyright (c) Microsoft Corporation.
- *
- * This source code is subject to terms and conditions of the Apache License, Version 2.0. A
- * copy of the license can be found in the License.html file at the root of this distribution. If
- * you cannot locate the  Apache License, Version 2.0, please send an email to
- * dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
- * by the terms of the Apache License, Version 2.0.
- *
- * You must not remove this notice, or any other, from this software.
- *
- *
- * ***************************************************************************/
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Threading;
 
-namespace IronPython.Runtime
-{
-    internal static class FormattingHelper
-    {
+namespace IronPython.Runtime {
+    internal static class FormattingHelper {
         private static NumberFormatInfo _invariantUnderscoreSeperatorInfo;
 
         /// <summary>
@@ -36,11 +21,10 @@ namespace IronPython.Runtime
                 if (_invariantUnderscoreSeperatorInfo == null) {
                     Interlocked.CompareExchange(
                         ref _invariantUnderscoreSeperatorInfo,
-                        new NumberFormatInfo()
-                        {
+                        new NumberFormatInfo() {
                             NumberGroupSeparator = "_",
                             NumberDecimalSeparator = ".",
-                            NumberGroupSizes = new int[] {3}
+                            NumberGroupSizes = new int[] { 3 }
                         },
                         null
                     );
@@ -49,14 +33,14 @@ namespace IronPython.Runtime
             }
         }
 
-        public static string/*!*/ ToCultureString<T>(T/*!*/ val, NumberFormatInfo/*!*/ nfi, StringFormatSpec spec) {
+        public static string/*!*/ ToCultureString<T>(T/*!*/ val, NumberFormatInfo/*!*/ nfi, StringFormatSpec spec, int? overrideWidth = null) {
             string separator = nfi.NumberGroupSeparator;
             int[] separatorLocations = nfi.NumberGroupSizes;
             string digits = val.ToString();
 
             // If we're adding leading zeros, we need to know how
             // many we need.
-            int width = spec.Width ?? 0;
+            int width = overrideWidth ?? spec.Width ?? 0;
             int fillerLength = Math.Max(width - digits.Length, 0);
             bool addLeadingZeros = (spec.Fill ?? '\0') == '0' && width > digits.Length;
             int beginningOfDigits = fillerLength;
@@ -127,12 +111,10 @@ namespace IronPython.Runtime
                                     break;
                                 }
                             }
-                        }
-                        else {
+                        } else {
                             res.Remove(0, beginningOfMaximumWidth);
                         }
-                    }
-                    else {
+                    } else {
                         // If we ran out of remainingWidth just formatting
                         // the actual digits, then remove any extra leading zeros
                         // we added.

--- a/Src/IronPython/Runtime/NewStringFormatter.cs
+++ b/Src/IronPython/Runtime/NewStringFormatter.cs
@@ -1,24 +1,11 @@
-﻿/* ****************************************************************************
- *
- * Copyright (c) Microsoft Corporation.
- *
- * This source code is subject to terms and conditions of the Apache License, Version 2.0. A
- * copy of the license can be found in the License.html file at the root of this distribution. If
- * you cannot locate the  Apache License, Version 2.0, please send an email to
- * dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
- * by the terms of the Apache License, Version 2.0.
- *
- * You must not remove this notice, or any other, from this software.
- *
- *
- * ***************************************************************************/
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Diagnostics;
 
-using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 

--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -789,16 +789,16 @@ namespace IronPython.Runtime.Operations {
                     digits = DoubleOps.DoubleToFormatString(context, ToDouble(val), spec);
                     break;
                 case 'X':
-                    digits = AbsToHex(val, false);
+                    digits = AbsToHex(val, lowercase: false);
                     break;
                 case 'x':
-                    digits = AbsToHex(val, true);
+                    digits = AbsToHex(val, lowercase: true);
                     break;
                 case 'o': // octal
-                    digits = ToOctal(val, true);
+                    digits = ToOctal(val, lowercase: true);
                     break;
                 case 'b': // binary
-                    digits = ToBinary(val, false, true);
+                    digits = ToBinary(val, includeType: false, lowercase: true);
                     break;
                 case 'c': // single char
                     int iVal;

--- a/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
+++ b/Src/IronPython/Runtime/Operations/BigIntegerOps.cs
@@ -746,6 +746,7 @@ namespace IronPython.Runtime.Operations {
             if (self < 0) {
                 val = -self;
             }
+
             string digits;
 
             switch (spec.Type) {
@@ -758,72 +759,34 @@ namespace IronPython.Runtime.Operations {
                         goto case 'd';
                     }
 
-                    digits = FormattingHelper.ToCultureString(val, context.LanguageContext.NumericCulture.NumberFormat, spec);
+                    digits = FormattingHelper.ToCultureString(val, culture.NumberFormat, spec);
                     break;
                 case null:
                 case 'd':
-                    if (spec.ThousandsComma) {
+                    if (spec.ThousandsComma || spec.ThousandsUnderscore) {
+                        var numberFormat = spec.ThousandsUnderscore ? FormattingHelper.InvariantUnderscoreNumberInfo : CultureInfo.InvariantCulture.NumberFormat;
                         var width = spec.Width ?? 0;
+
                         // If we're inserting commas, and we're padding with leading zeros.
                         // AlignNumericText won't know where to place the commas,
                         // so force .Net to help us out here.
                         if (spec.Fill.HasValue && spec.Fill.Value == '0' && width > 1) {
-                            digits = val.ToString(FormattingHelper.ToCultureString(self, FormattingHelper.InvariantCommaNumberInfo, spec));
+                            digits = FormattingHelper.ToCultureString(val, numberFormat, spec);
+                        } else {
+                            digits = val.ToString("#,0", numberFormat);
                         }
-                        else {
-                        digits = val.ToString("#,0", CultureInfo.InvariantCulture);
-                        }
-                    }
-                    else {
+                    } else {
                         digits = val.ToString("D", CultureInfo.InvariantCulture);
                     }
                     break;
                 case '%':
-                    if (spec.ThousandsComma) {
-                        digits = val.ToString("#,0.000000%", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = val.ToString("0.000000%", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'e':
-                    if (spec.ThousandsComma) {
-                        digits = val.ToString("#,0.000000e+00", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = val.ToString("0.000000e+00", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'E':
-                    if (spec.ThousandsComma) {
-                        digits = val.ToString("#,0.000000E+00", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = val.ToString("0.000000E+00", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'f':
                 case 'F':
-                    if (spec.ThousandsComma) {
-                        digits = val.ToString("#,########0.000000", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = val.ToString("#########0.000000", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'g':
-                    if (val >= 1000000) {
-                        digits = val.ToString("0.#####e+00", CultureInfo.InvariantCulture);
-                    } else if (spec.ThousandsComma) {
-                        goto case 'd';
-                    } else {
-                        digits = val.ToString(CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'G':
-                    if (val >= 1000000) {
-                        digits = val.ToString("0.#####E+00", CultureInfo.InvariantCulture);
-                    } else if (spec.ThousandsComma) {
-                        goto case 'd';
-                    } else {
-                        digits = val.ToString(CultureInfo.InvariantCulture);
-                    }
+                    digits = DoubleOps.DoubleToFormatString(context, ToDouble(val), spec);
                     break;
                 case 'X':
                     digits = AbsToHex(val, false);

--- a/Src/IronPython/Runtime/Operations/FloatOps.cs
+++ b/Src/IronPython/Runtime/Operations/FloatOps.cs
@@ -813,7 +813,7 @@ namespace IronPython.Runtime.Operations {
         /// <summary>
         /// Returns the digits for the format spec, no sign is included.
         /// </summary>
-        private static string DoubleToFormatString(CodeContext/*!*/ context, double self, StringFormatSpec/*!*/ spec) {
+        internal static string DoubleToFormatString(CodeContext/*!*/ context, double self, StringFormatSpec/*!*/ spec) {
             self = Math.Abs(self);
             const int DefaultPrecision = 6;
             int precision = spec.Precision ?? DefaultPrecision;

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -212,7 +212,7 @@ namespace IronPython.Runtime.Operations {
             }
 
             string digits;
-            int width = 0;
+            int width;
 
             switch (spec.Type) {
                 case 'n':
@@ -236,69 +236,30 @@ namespace IronPython.Runtime.Operations {
                     break;
                 case null:
                 case 'd':
-                    if (spec.ThousandsComma) {
+                    if (spec.ThousandsComma || spec.ThousandsUnderscore) {
+                        var numberFormat = spec.ThousandsUnderscore ? FormattingHelper.InvariantUnderscoreNumberInfo : CultureInfo.InvariantCulture.NumberFormat;
                         width = spec.Width ?? 0;
 
                         // If we're inserting commas, and we're padding with leading zeros.
                         // AlignNumericText won't know where to place the commas,
                         // so use FormattingHelper.ToCultureString for that support.
                         if (spec.Fill.HasValue && spec.Fill.Value == '0' && width > 1) {
-                            digits = FormattingHelper.ToCultureString(self, FormattingHelper.InvariantCommaNumberInfo, spec);
+                            digits = FormattingHelper.ToCultureString(self, numberFormat, spec);
                         } else {
-                            digits = self.ToString("#,0", CultureInfo.InvariantCulture);
+                            digits = self.ToString("#,0", numberFormat);
                         }
                     } else {
                         digits = self.ToString("D", CultureInfo.InvariantCulture);
                     }
                     break;
                 case '%':
-                    if (spec.ThousandsComma) {
-                        digits = self.ToString("#,0.000000%", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = self.ToString("0.000000%", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'e':
-                    if (spec.ThousandsComma) {
-                        digits = self.ToString("#,0.000000e+00", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = self.ToString("0.000000e+00", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'E':
-                    if (spec.ThousandsComma) {
-                        digits = self.ToString("#,0.000000E+00", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = self.ToString("0.000000E+00", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'f':
                 case 'F':
-                    if (spec.ThousandsComma) {
-                        digits = self.ToString("#,########0.000000", CultureInfo.InvariantCulture);
-                    } else {
-                        digits = self.ToString("#########0.000000", CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'g':
-                    if (self >= 1000000 || self <= -1000000) {
-                        digits = self.ToString("0.#####e+00", CultureInfo.InvariantCulture);
-                    } else if (spec.ThousandsComma) {
-                        // Handle the common case in 'd'.
-                        goto case 'd';
-                    } else {
-                        digits = self.ToString(CultureInfo.InvariantCulture);
-                    }
-                    break;
                 case 'G':
-                    if (self >= 1000000 || self <= -1000000) {
-                        digits = self.ToString("0.#####E+00", CultureInfo.InvariantCulture);
-                    } else if (spec.ThousandsComma) {
-                        // Handle the common case in 'd'.
-                        goto case 'd';
-                    } else {
-                        digits = self.ToString(CultureInfo.InvariantCulture);
-                    }
+                    digits = DoubleOps.DoubleToFormatString(context, self, spec);
                     break;
                 case 'X':
                     digits = ToHex(self, false);

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -262,16 +262,16 @@ namespace IronPython.Runtime.Operations {
                     digits = DoubleOps.DoubleToFormatString(context, self, spec);
                     break;
                 case 'X':
-                    digits = ToHex(self, false);
+                    digits = ToHex(self, lowercase: false);
                     break;
                 case 'x':
-                    digits = ToHex(self, true);
+                    digits = ToHex(self, lowercase: true);
                     break;
                 case 'o': // octal
-                    digits = ToOctal(self, true);
+                    digits = ToOctal(self, lowercase: true);
                     break;
                 case 'b': // binary
-                    digits = ToBinary(self, false);
+                    digits = ToBinary(self, includeType: false);
                     break;
                 case 'c': // single char
                     if (spec.Sign != null) {

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -5,9 +5,8 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Numerics;
 using System.Text;
 
@@ -205,14 +204,17 @@ namespace IronPython.Runtime.Operations {
         #region Public API - String/Bytes
 
         public static string __format__(CodeContext/*!*/ context, int self, [NotNone] string/*!*/ formatSpec) {
+            if (self == int.MinValue) return BigIntegerOps.__format__(context, self, formatSpec);
+
             StringFormatSpec spec = StringFormatSpec.FromString(formatSpec);
 
             if (spec.Precision != null) {
                 throw PythonOps.ValueError("Precision not allowed in integer format specifier");
             }
 
+            int val = Math.Abs(self);
+
             string digits;
-            int width;
 
             switch (spec.Type) {
                 case 'n':
@@ -223,33 +225,31 @@ namespace IronPython.Runtime.Operations {
                         // include any formatting info.
                         goto case 'd';
                     }
-                    width = spec.Width ?? 0;
 
                     // If we're padding with leading zeros and we might be inserting
                     // culture sensitive number group separators. (i.e. commas)
                     // So use FormattingHelper.ToCultureString for that support.
-                    if (spec.Fill.HasValue && spec.Fill.Value == '0' && width > 1) {
-                        digits = FormattingHelper.ToCultureString(self, culture.NumberFormat, spec);
+                    if (spec.Fill == '0' && spec.Width > 1) {
+                        digits = FormattingHelper.ToCultureString(val, culture.NumberFormat, spec, (spec.Sign != null && spec.Sign != '-' || self < 0) ? spec.Width - 1 : null);
                     } else {
-                        digits = self.ToString("N0", culture);
+                        digits = val.ToString("N0", culture);
                     }
                     break;
                 case null:
                 case 'd':
                     if (spec.ThousandsComma || spec.ThousandsUnderscore) {
                         var numberFormat = spec.ThousandsUnderscore ? FormattingHelper.InvariantUnderscoreNumberInfo : CultureInfo.InvariantCulture.NumberFormat;
-                        width = spec.Width ?? 0;
 
                         // If we're inserting commas, and we're padding with leading zeros.
                         // AlignNumericText won't know where to place the commas,
                         // so use FormattingHelper.ToCultureString for that support.
-                        if (spec.Fill.HasValue && spec.Fill.Value == '0' && width > 1) {
-                            digits = FormattingHelper.ToCultureString(self, numberFormat, spec);
+                        if (spec.Fill == '0' && spec.Width > 1) {
+                            digits = FormattingHelper.ToCultureString(val, numberFormat, spec, (spec.Sign != null && spec.Sign != '-' || self < 0) ? spec.Width - 1 : null);
                         } else {
-                            digits = self.ToString("#,0", numberFormat);
+                            digits = val.ToString("#,0", numberFormat);
                         }
                     } else {
-                        digits = self.ToString("D", CultureInfo.InvariantCulture);
+                        digits = val.ToString("D", CultureInfo.InvariantCulture);
                     }
                     break;
                 case '%':
@@ -259,19 +259,19 @@ namespace IronPython.Runtime.Operations {
                 case 'F':
                 case 'g':
                 case 'G':
-                    digits = DoubleOps.DoubleToFormatString(context, self, spec);
+                    digits = DoubleOps.DoubleToFormatString(context, val, spec);
                     break;
                 case 'X':
-                    digits = ToHex(self, lowercase: false);
+                    digits = ToHex(val, lowercase: false);
                     break;
                 case 'x':
-                    digits = ToHex(self, lowercase: true);
+                    digits = ToHex(val, lowercase: true);
                     break;
                 case 'o': // octal
-                    digits = ToOctal(self, lowercase: true);
+                    digits = ToOctal(val, lowercase: true);
                     break;
                 case 'b': // binary
-                    digits = ToBinary(self, includeType: false);
+                    digits = ToBinary(val, includeType: false);
                     break;
                 case 'c': // single char
                     if (spec.Sign != null) {
@@ -288,9 +288,7 @@ namespace IronPython.Runtime.Operations {
                     throw PythonOps.ValueError("Unknown format code '{0}' for object of type 'int'", spec.TypeRepr);
             }
 
-            if (self < 0 && digits[0] == '-') {
-                digits = digits.Substring(1);
-            }
+            Debug.Assert(digits[0] != '-');
 
             return spec.AlignNumericText(digits, self == 0, self > 0);
         }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -311,6 +311,8 @@ namespace IronPython.Runtime.Operations {
                 throw PythonOps.ValueError("'=' alignment not allowed in string format specifier");
             } else if (spec.ThousandsComma) {
                 throw PythonOps.ValueError("Cannot specify ',' with 's'.");
+            } else if (spec.ThousandsUnderscore) {
+                throw PythonOps.ValueError("Cannot specify '_' with 's'.");
             } else if (spec.AlternateForm) {
                 throw PythonOps.ValueError("Alternate form (#) not allowed in string format specifier");
             }

--- a/Src/IronPython/Runtime/StringFormatSpec.cs
+++ b/Src/IronPython/Runtime/StringFormatSpec.cs
@@ -174,6 +174,7 @@ namespace IronPython.Runtime {
                 } else if (thousandsUnderscore) {
                     switch (type) {
                         // integer types
+                        case 'b':
                         case 'd':
                         case 'o':
                         case 'x':


### PR DESCRIPTION
Dispatches the float formatting to `DoubleOps` and resolves some formatting issues, for example:
```py
import System
assert format(-1111, "08,d") == format((-1111).ToBigInteger(), "08,d")
```

Prep work for PEP 515 https://github.com/IronLanguages/ironpython3/issues/105.