### PR TITLE
Use P/Invoke for os.strerror

### DIFF
--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -1496,7 +1496,7 @@ namespace IronPython.Modules {
         public static object stat(CodeContext context, int fd)
             => fstat(context, fd);
 
-        public static string strerror_r(int code) {
+        public static string strerror(int code) {
 #if FEATURE_NATIVE
             const int bufsize = 0x1FF;
             var buffer = new StringBuilder(bufsize);
@@ -1513,55 +1513,6 @@ namespace IronPython.Modules {
             }
 #endif
             return "Unknown error " + code;
-        }
-
-        public static string strerror(int code) {
-            switch (code) {
-                case 0: return "No error";
-                case PythonErrorNumber.E2BIG: return "Arg list too long";
-                case PythonErrorNumber.EACCES: return "Permission denied";
-                case PythonErrorNumber.EAGAIN: return "Resource temporarily unavailable";
-                case PythonErrorNumber.EBADF: return "Bad file descriptor";
-                case PythonErrorNumber.EBUSY: return "Resource device";
-                case PythonErrorNumber.ECHILD: return "No child processes";
-                case PythonErrorNumber.EDEADLK: return "Resource deadlock avoided";
-                case PythonErrorNumber.EDOM: return "Domain error";
-                case PythonErrorNumber.EDQUOT: return "Unknown error";
-                case PythonErrorNumber.EEXIST: return "File exists";
-                case PythonErrorNumber.EFAULT: return "Bad address";
-                case PythonErrorNumber.EFBIG: return "File too large";
-                case PythonErrorNumber.EILSEQ: return "Illegal byte sequence";
-                case PythonErrorNumber.EINTR: return "Interrupted function call";
-                case PythonErrorNumber.EINVAL: return "Invalid argument";
-                case PythonErrorNumber.EIO: return "Input/output error";
-                case PythonErrorNumber.EISCONN: return "Unknown error";
-                case PythonErrorNumber.EISDIR: return "Is a directory";
-                case PythonErrorNumber.EMFILE: return "Too many open files";
-                case PythonErrorNumber.EMLINK: return "Too many links";
-                case PythonErrorNumber.ENAMETOOLONG: return "Filename too long";
-                case PythonErrorNumber.ENFILE: return "Too many open files in system";
-                case PythonErrorNumber.ENODEV: return "No such device";
-                case PythonErrorNumber.ENOENT: return "No such file or directory";
-                case PythonErrorNumber.ENOEXEC: return "Exec format error";
-                case PythonErrorNumber.ENOLCK: return "No locks available";
-                case PythonErrorNumber.ENOMEM: return "Not enough space";
-                case PythonErrorNumber.ENOSPC: return "No space left on device";
-                case PythonErrorNumber.ENOSYS: return "Function not implemented";
-                case PythonErrorNumber.ENOTDIR: return "Not a directory";
-                case PythonErrorNumber.ENOTEMPTY: return "Directory not empty";
-                case PythonErrorNumber.ENOTSOCK: return "Unknown error";
-                case PythonErrorNumber.ENOTTY: return "Inappropriate I/O control operation";
-                case PythonErrorNumber.ENXIO: return "No such device or address";
-                case PythonErrorNumber.EPERM: return "Operation not permitted";
-                case PythonErrorNumber.EPIPE: return "Broken pipe";
-                case PythonErrorNumber.ERANGE: return "Result too large";
-                case PythonErrorNumber.EROFS: return "Read-only file system";
-                case PythonErrorNumber.ESPIPE: return "Invalid seek";
-                case PythonErrorNumber.ESRCH: return "No such process";
-                case PythonErrorNumber.EXDEV: return "Improper link";
-                default:
-                    return "Unknown error " + code;
-            }
         }
 
 #if FEATURE_PROCESS
@@ -1844,7 +1795,7 @@ namespace IronPython.Modules {
             Process? process;
             lock (_processToIdMapping) {
                 if (!_processToIdMapping.TryGetValue(pid, out process)) {
-                    throw PythonOps.OSError(PythonErrorNumber.ECHILD, "No child processes");
+                    throw GetOsError(PythonErrorNumber.ECHILD);
                 }
             }
 
@@ -2228,12 +2179,12 @@ the 'status' value."),
 #if FEATURE_NATIVE
 
         private static Exception GetLastUnixError(string? filename = null, string? filename2 = null)
-            => GetUnixError(Mono.Unix.Native.NativeConvert.FromErrno(Mono.Unix.Native.Syscall.GetLastError()), filename, filename2);
-
-        private static Exception GetUnixError(int error, string? filename = null, string? filename2 = null)
-            => PythonOps.OSError(error, strerror(error), filename, null, filename2);
+            => GetOsError(Mono.Unix.Native.NativeConvert.FromErrno(Mono.Unix.Native.Syscall.GetLastError()), filename, filename2);
 
 #endif
+
+        private static Exception GetOsError(int error, string? filename = null, string? filename2 = null)
+            => PythonOps.OSError(error, strerror(error), filename, null, filename2);
 
 #if FEATURE_NATIVE || FEATURE_CTYPES
 

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -1503,7 +1503,7 @@ namespace IronPython.Modules {
 
             int result = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                 Interop.Ucrtbase.strerror(code, buffer) :
-                Mono.Unix.Native.Syscall.strerror_r(Mono.Unix.Native.NativeConvert.ToErrno(code), buffer);
+                strerror_r(code, buffer);
 
             if (result == 0) {
                 var msg = buffer.ToString();
@@ -1514,6 +1514,12 @@ namespace IronPython.Modules {
 #endif
             return "Unknown error " + code;
         }
+
+#if FEATURE_NATIVE
+        // Isolate Mono.Unix from the rest of the method so that we don't try to load the Mono.Unix assembly on Windows.
+        private static int strerror_r(int code, StringBuilder buffer)
+            => Mono.Unix.Native.Syscall.strerror_r(Mono.Unix.Native.NativeConvert.ToErrno(code), buffer);
+#endif
 
 #if FEATURE_PROCESS
         [Documentation("system(command) -> int\nExecute the command (a string) in a subshell.")]

--- a/Src/IronPython/Interop/Windows/Ucrtbase/Interop.strerror.cs
+++ b/Src/IronPython/Interop/Windows/Ucrtbase/Interop.strerror.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+
+internal static partial class Interop {
+    internal static partial class Ucrtbase {
+        [DllImport(Libraries.Ucrtbase, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        [SupportedOSPlatform("windows")]
+        internal static extern int strerror_s([Out] StringBuilder buffer, nuint sizeInBytes, int errnum);
+
+        [SupportedOSPlatform("windows")]
+        internal static int strerror(int errnum, StringBuilder buf) {
+            return strerror_s(buf, (nuint)buf.Capacity + 1, errnum);
+        }
+    }
+}

--- a/Src/IronPython/Interop/Windows/Ucrtbase/Interop.strerror.cs
+++ b/Src/IronPython/Interop/Windows/Ucrtbase/Interop.strerror.cs
@@ -11,7 +11,7 @@ internal static partial class Interop {
     internal static partial class Ucrtbase {
         [DllImport(Libraries.Ucrtbase, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
         [SupportedOSPlatform("windows")]
-        internal static extern int strerror_s([Out] StringBuilder buffer, nuint sizeInBytes, int errnum);
+        private static extern int strerror_s([Out] StringBuilder buffer, nuint sizeInBytes, int errnum);
 
         [SupportedOSPlatform("windows")]
         internal static int strerror(int errnum, StringBuilder buf) {

--- a/Tests/modules/system_related/test_os.py
+++ b/Tests/modules/system_related/test_os.py
@@ -1,0 +1,32 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+import os
+
+from iptest import IronPythonTestCase, is_osx, is_linux, is_windows, run_test
+
+class OsTest(IronPythonTestCase):
+    def test_strerror(self):
+        if is_windows:
+            self.assertEqual(os.strerror(0), "No error")
+        elif is_linux:
+            self.assertEqual(os.strerror(0), "Success")
+        elif is_osx:
+            self.assertEqual(os.strerror(0), "Undefined error: 0")
+
+        if is_windows:
+            self.assertEqual(os.strerror(39), "No locks available")
+        elif is_linux:
+            self.assertEqual(os.strerror(39), "Directory not empty")
+        elif is_osx:
+            self.assertEqual(os.strerror(39), "Destination address required")
+
+        if is_windows:
+            self.assertEqual(os.strerror(40), "Function not implemented")
+        elif is_linux:
+            self.assertEqual(os.strerror(40), "Too many levels of symbolic links")
+        elif is_osx:
+            self.assertEqual(os.strerror(40), "Message too long")
+
+run_test(__name__)


### PR DESCRIPTION
Besides producing correct error message on Linux and macOS, the main benefit is the elimination of the switch on constants from `PythonErrorNumber`. The values in module `errno` vary depending on OS so cannot be implemented as constants.

On Windows, P/Invoke calls into _ucrtbase_, which may not be available on Windows 7 by default. I don't know if IronPython is still supposed to support Windows 7, if so, the the WIX installer may have to install _msvcrt_ on that system.

This PR also contains a few small fixes of `Mono.Unix` usage (ref. https://github.com/IronLanguages/ironpython3/pull/1490#issuecomment-1157003535)

On a side note: I'm wondering if it wouldn't be cleaner to factor module `posix` out of `nt` (and putting common functionality in an additional static class, e.g. `PythonOS`).