### PR TITLE
docs: fix simple typo, indentify -> identify

### DIFF
--- a/Src/StdLib/Lib/multiprocessing/managers.py
+++ b/Src/StdLib/Lib/multiprocessing/managers.py
@@ -51,7 +51,7 @@ if view_types[0] is not list:       # only needed in Py3.0
 
 class Token(object):
     '''
-    Type to uniquely indentify a shared object
+    Type to uniquely identify a shared object
     '''
     __slots__ = ('typeid', 'address', 'id')
 


### PR DESCRIPTION
There is a small typo in Src/StdLib/Lib/multiprocessing/managers.py.

Should read `identify` rather than `indentify`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md