### PR TITLE
Make IPv6 SSL test passing

### DIFF
--- a/Src/IronPython.Modules/_ssl.cs
+++ b/Src/IronPython.Modules/_ssl.cs
@@ -452,7 +452,12 @@ namespace IronPython.Modules {
                         }
                         _sslStream.AuthenticateAsServer(_cert, _certsMode == PythonSsl.CERT_REQUIRED, enabledSslProtocols, false);
                     } else {
-                        _sslStream.AuthenticateAsClient(server_hostname ?? _socket._hostName, context._cert_store, enabledSslProtocols, false);
+                        string hostname = server_hostname ?? _socket._hostName ?? _socket._socket.RemoteEndPoint switch {
+                            System.Net.IPEndPoint ipEP => ipEP.Address.ToString(),
+                            System.Net.DnsEndPoint dnsEP => dnsEP.Host,
+                            _ => string.Empty,
+                        };
+                        _sslStream.AuthenticateAsClient(hostname, context._cert_store, enabledSslProtocols, false);
                     }
                 } catch (AuthenticationException e) {
                     ((IDisposable)_socket._socket).Dispose();

--- a/Src/IronPython.Modules/_ssl.cs
+++ b/Src/IronPython.Modules/_ssl.cs
@@ -401,7 +401,11 @@ namespace IronPython.Modules {
             }
 
             private void ValidateCertificate(X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) {
-                Debug.Assert(chain.ChainStatus.Length > 0);
+                if (chain.ChainStatus.Length == 0) {
+                    ValidationError(sslPolicyErrors);
+                    return;
+                }
+
                 foreach (var elem in chain.ChainStatus) {
                     if (elem.Status == X509ChainStatusFlags.UntrustedRoot) {
                         bool isOk = false;

--- a/Tests/test_ssl_stdlib.py
+++ b/Tests/test_ssl_stdlib.py
@@ -81,11 +81,11 @@ def load_tests(loader, standard_tests, pattern):
         suite.addTest(test.test_ssl.MemoryBIOTests('test_error_types'))
         suite.addTest(test.test_ssl.MemoryBIOTests('test_pending'))
         suite.addTest(test.test_ssl.MemoryBIOTests('test_read_write'))
-        suite.addTest(unittest.expectedFailure(test.test_ssl.NetworkedTests('test_get_server_certificate_ipv6'))) # TypeError (ArgumentNullException for targetHost in call to AuthenticateAsClient in _ssl.cs)
+        suite.addTest(test.test_ssl.NetworkedTests('test_get_server_certificate_ipv6'))
         suite.addTest(test.test_ssl.NetworkedTests('test_timeout_connect_ex'))
         suite.addTest(unittest.expectedFailure(test.test_ssl.SSLErrorTests('test_lib_reason'))) # AttributeError: 'SSLContext' object has no attribute 'load_dh_params'
         suite.addTest(unittest.expectedFailure(test.test_ssl.SSLErrorTests('test_str'))) # AssertionError: '[Errno 1] foo' != 'foo'
-        suite.addTest(unittest.expectedFailure(test.test_ssl.SSLErrorTests('test_subclass'))) # TypeError: Value cannot be null.
+        #suite.addTest(unittest.expectedFailure(test.test_ssl.SSLErrorTests('test_subclass'))) # hangs indefinitely: wrapped SSLSocket resets timeout to None
         #suite.addTest(test.test_ssl.SimpleBackgroundTests('test_bio_handshake'))
         #suite.addTest(test.test_ssl.SimpleBackgroundTests('test_bio_read_write_data'))
         #suite.addTest(test.test_ssl.SimpleBackgroundTests('test_ciphers'))
@@ -123,7 +123,7 @@ def load_tests(loader, standard_tests, pattern):
         #suite.addTest(test.test_ssl.ThreadedTests('test_echo'))
         #suite.addTest(test.test_ssl.ThreadedTests('test_getpeercert')) # blocking
         suite.addTest(test.test_ssl.ThreadedTests('test_getpeercert_enotconn'))
-        suite.addTest(unittest.expectedFailure(test.test_ssl.ThreadedTests('test_handshake_timeout'))) # TypeError: Value cannot be null.
+        #suite.addTest(unittest.expectedFailure(test.test_ssl.ThreadedTests('test_handshake_timeout'))) # hangs indefinitely: wrapped SSLSocket resets timeout to None
         #suite.addTest(test.test_ssl.ThreadedTests('test_no_shared_ciphers'))
         #suite.addTest(test.test_ssl.ThreadedTests('test_nonblocking_send'))
         #suite.addTest(test.test_ssl.ThreadedTests('test_npn_protocols'))
@@ -136,7 +136,7 @@ def load_tests(loader, standard_tests, pattern):
         #suite.addTest(test.test_ssl.ThreadedTests('test_read_write_after_close_raises_valuerror')) # blocking
         #suite.addTest(unittest.expectedFailure(test.test_ssl.ThreadedTests('test_recv_send'))) # NotImplementedError: keyfile
         #suite.addTest(test.test_ssl.ThreadedTests('test_recv_zero'))
-        suite.addTest(unittest.expectedFailure(test.test_ssl.ThreadedTests('test_rude_shutdown'))) # TypeError: Value cannot be null.
+        suite.addTest(test.test_ssl.ThreadedTests('test_rude_shutdown'))
         #suite.addTest(test.test_ssl.ThreadedTests('test_selected_alpn_protocol'))
         #suite.addTest(test.test_ssl.ThreadedTests('test_selected_alpn_protocol_if_server_uses_alpn'))
         #suite.addTest(test.test_ssl.ThreadedTests('test_selected_npn_protocol'))


### PR DESCRIPTION
Since I do have IPv6 connectivity, I decided to look into `test_get_server_certificate_ipv6` that is being skipped on CI but fails locally.

The good new is that my solution I tried during #1507 turned out to be the right way, despite causing now some other tests (that were previously failing) to hang indefinitely. The change unblocked those tests to advance and hit another, unrelated problem.

The bad news is that I had to comment them out to let the whole test suite pass, rather than have them as _expected failure_. I also think I got to the root cause of the problem: creating a socket using a descriptor of another existing socket resets the timeout of the existing socket to default (infinite by default). This is because creating a socket around an existing descriptor does not actually create a new system socket, it merely shares it. I see no obvious solution to it so I will file a separate issue where it can be discussed it more detail.