### PR TITLE
Use lowercase lib for StdLib dir name on non-Windows systems

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -24,7 +24,6 @@
     <StageDir>$(RootDir)Package\$(Configuration)\Stage\IronPython-$(PackageVersion)</StageDir>
     <PackageDir>$(RootDir)Package\$(Configuration)\Packages\IronPython-$(PackageVersion)</PackageDir>
     <StdLibDirName>lib</StdLibDirName>
-    <StdLibDirName Condition=" '$(OS)' == 'Windows_NT' ">Lib</StdLibDirName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Build.proj
+++ b/Build.proj
@@ -23,6 +23,8 @@
     <PackageVersion Condition="'$(ReleaseLevel)' != 'final' or '$(ReleaseSerial)' != '0'">$(MajorVersion).$(MinorVersion).$(MicroVersion)-$(ReleaseLevel)$(ReleaseSerial)</PackageVersion>
     <StageDir>$(RootDir)Package\$(Configuration)\Stage\IronPython-$(PackageVersion)</StageDir>
     <PackageDir>$(RootDir)Package\$(Configuration)\Packages\IronPython-$(PackageVersion)</PackageDir>
+    <StdLibDirName>lib</StdLibDirName>
+    <StdLibDirName Condition=" '$(OS)' == 'Windows_NT' ">Lib</StdLibDirName>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -105,7 +107,7 @@
 
   <Target Name="_CopyStdLib" DependsOnTargets="_MakeStageDir">
     <MSBuild Projects="$(RootDir)\Src\StdLib\StdLib.pyproj"
-             Properties="OutputPath=$(StageDir)"
+             Properties="OutputPath=$(StageDir);StdLibDirName=$(StdLibDirName)"
              Targets="Stage" />
   </Target>
 

--- a/Package/choco/IronPython.nuspec
+++ b/Package/choco/IronPython.nuspec
@@ -21,7 +21,7 @@
   <files>
     <file src="$STAGEDIR$\net462\*.dll;$STAGEDIR$\net462\*.exe" exclude="**\rowantest*.dll;**\IronPythonTest.dll" />
     <file src="$STAGEDIR$\net462\DLLs\**" target="DLLs" exclude="**\*.xml" />
-    <file src="$STAGEDIR$\Lib\**" target="Lib" />
+    <file src="$STAGEDIR$\lib\**" target="lib" />
     <file src="$STAGEDIR$\LICENSE;$STAGEDIR$\README.md" />
     <file src="tools\*" target="tools" />
   </files>

--- a/Package/deb/Deb.Packaging.targets
+++ b/Package/deb/Deb.Packaging.targets
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <StdLibFiles Include="$(StageDir)/Lib/**/*.*" />
+      <StdLibFiles Include="$(StageDir)/$(StdLibDirName)/**/*.*" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,7 +31,7 @@
           Replacement="$(PackageVersion)" />
 
     <ItemGroup>
-      <StdLibOutputFiles Include="$(StageDir)/Lib/**/*.py" />
+      <StdLibOutputFiles Include="$(StageDir)/$(StdLibDirName)/**/*.py" />
     </ItemGroup>
     <Exec Command="dos2unix %(StdLibOutputFiles.Identity)" />
     <Exec Command="dos2unix $(PackageTempFolder)/DEBIAN/control"/>

--- a/Package/msi/IronPython.Installer.wixproj
+++ b/Package/msi/IronPython.Installer.wixproj
@@ -35,7 +35,7 @@
       <Value>$(BuildDir)</Value>
     </WixConstant>
     <WixConstant Include="StdLibDir">
-      <Value>$(BindInputPaths)\Lib</Value>
+      <Value>$(BindInputPaths)\lib</Value>
     </WixConstant>
     <WixConstant Include="PlatformDir">
       <Value>$(BindInputPaths)\net462</Value>

--- a/Package/nuget/IronPython.StdLib.nuspec
+++ b/Package/nuget/IronPython.StdLib.nuspec
@@ -22,7 +22,7 @@
   </metadata>
   <files>
     <file src="StdLib.License.txt" />
-    <file src="Lib\**" target="contentFiles\any\any\Lib" />
-    <file src="Lib\**" target="content\Lib" />
+    <file src="lib\**" target="contentFiles\any\any\lib" />
+    <file src="lib\**" target="content\lib" />
   </files>
 </package>

--- a/Package/pkg/Pkg.Packaging.targets
+++ b/Package/pkg/Pkg.Packaging.targets
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <StdLibFiles Include="$(StageDir)/Lib/**/*.*" />
+      <StdLibFiles Include="$(StageDir)/$(StdLibDirName)/**/*.*" />
     </ItemGroup>
 
     <ItemGroup>
@@ -28,7 +28,7 @@
     <Exec Command="mkdir -p $(PackageTempFolder)" />
 
     <ItemGroup>
-      <StdLibOutputFiles Include="$(StageDir)/Lib/**/*.py" />
+      <StdLibOutputFiles Include="$(StageDir)/$(StdLibDirName)/**/*.py" />
     </ItemGroup>
 
     <!-- Change line endings of the .py files -->

--- a/Package/zip/Zip.Packaging.targets
+++ b/Package/zip/Zip.Packaging.targets
@@ -9,8 +9,8 @@
     <Zip Files="@(ZipFiles)" ZipFileName="$(PackageDir)\IronPython.$(PackageVersion).zip" WorkingDirectory="$(StageDir)" />
 
     <ItemGroup>
-      <StdLibFiles Include="$(StageDir)\Lib\**\*.*" />
+      <StdLibFiles Include="$(StageDir)\$(StdLibDirName)\**\*.*" />
     </ItemGroup>
-    <Zip Files="@(StdLibFiles)" ZipFileName="$(PackageDir)\IronPython.StdLib.$(PackageVersion).zip" WorkingDirectory="$(StageDir)\Lib"/>
+    <Zip Files="@(StdLibFiles)" ZipFileName="$(PackageDir)\IronPython.StdLib.$(PackageVersion).zip" WorkingDirectory="$(StageDir)\$(StdLibDirName)"/>
   </Target>
 </Project>

--- a/Src/IronPython/Hosting/PythonCommandLine.cs
+++ b/Src/IronPython/Hosting/PythonCommandLine.cs
@@ -296,8 +296,8 @@ namespace IronPython.Hosting {
                 }
 
                 prefix = pyvenv_prefix ?? prefix;
-                // Make sure there an IronPython Lib directory, and if not keep looking up
-                while (prefix != null && !File.Exists(Path.Combine(prefix, "Lib/os.py"))) {
+                // Make sure there an IronPython lib directory, and if not keep looking up
+                while (prefix != null && !File.Exists(Path.Combine(prefix, "lib", "os.py"))) {
                     prefix = Path.GetDirectoryName(prefix);
                 }
             }

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -35,10 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Lib\**\*.py">
+    <None Include="Lib\**\*.py" Link="lib\%(RecursiveDir)%(Filename)%(Extension)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\StdLib\Lib\os.py" Link="Lib\os.py">
+    <None Include="..\StdLib\Lib\os.py" Link="lib\os.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -220,7 +220,7 @@ namespace IronPython.Runtime {
                 // Can be null if called from unmanaged code (VS integration scenario)
                 // or in self-contained single file scenarios
                 if (entry != null) {
-                    string lib = Path.Combine(entry, "Lib");
+                    string lib = Path.Combine(entry, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Lib" : "lib");
                     path.append(lib);
 
                     // add DLLs directory for user-defined extention modules
@@ -1767,7 +1767,7 @@ namespace IronPython.Runtime {
             _initialExecutable = executable ?? "";
             InitialPrefix = prefix;
 
-            AddToPath(Path.Combine(prefix, "Lib"), 0);
+            AddToPath(Path.Combine(prefix, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Lib" : "lib"), 0);
 
             SetHostVariables(SystemState.__dict__);
         }

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -220,7 +220,7 @@ namespace IronPython.Runtime {
                 // Can be null if called from unmanaged code (VS integration scenario)
                 // or in self-contained single file scenarios
                 if (entry != null) {
-                    string lib = Path.Combine(entry, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Lib" : "lib");
+                    string lib = Path.Combine(entry, "lib");
                     path.append(lib);
 
                     // add DLLs directory for user-defined extention modules
@@ -1767,7 +1767,7 @@ namespace IronPython.Runtime {
             _initialExecutable = executable ?? "";
             InitialPrefix = prefix;
 
-            AddToPath(Path.Combine(prefix, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Lib" : "lib"), 0);
+            AddToPath(Path.Combine(prefix, "lib"), 0);
 
             SetHostVariables(SystemState.__dict__);
         }

--- a/Src/Scripts/Install-IronPython.ps1
+++ b/Src/Scripts/Install-IronPython.ps1
@@ -66,7 +66,7 @@ if (Test-Path $Path) {
 $unzipDir = Join-Path $Path "zip"
 
 Expand-Archive -Path $ZipFile -DestinationPath $unzipDir
-Move-Item -Path (Join-Path $unzipDir "Lib") -Destination $Path
+Move-Item -Path (Join-Path $unzipDir "lib") -Destination $Path
 Move-Item -Path (Join-Path $unzipDir "net6.0/*") -Destination $Path -Exclude "*.xml","*.dll.config"
 Remove-Item -Path $unzipDir -Recurse
 
@@ -78,6 +78,7 @@ dotnet (Join-Path $PSScriptRoot ipy.dll) @args
 '@
 if ($IsMacOS -or $IsLinux) {
     chmod +x $ipyPath
+    chmod +x (Join-Path $Path "ipy.sh")
 }
 
 # Add items that are missing in the zip file, directly from the bin directory

--- a/Src/StdLib/StdLib.pyproj
+++ b/Src/StdLib/StdLib.pyproj
@@ -10,6 +10,7 @@
     <Name>PyStdLib</Name>
     <RootNamespace>PyStdLib</RootNamespace>
     <StdLibPath>Lib</StdLibPath>
+    <StdLibDirName Condition=" '$(StdLibDirName)' == '' ">lib</StdLibDirName>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,12 +26,12 @@
 
   <ItemGroup>
     <Content Include="StdLib.License.txt" />
-    <Content Include="$(StdLibPath)\**\*.*" Exclude="$(ExcludedPackages)" />
+    <StdLibFiles Include="$(StdLibPath)\**\*.*" Exclude="$(ExcludedPackages)" />
   </ItemGroup>
 
   <Target Name="Stage">
     <Copy SourceFiles="@(Content)" DestinationFolder="$(OutputPath)\%(RelativeDir)" />
+    <Copy SourceFiles="@(StdLibFiles)" DestinationFolder="$(OutputPath)\$(StdLibDirName)\%(RecursiveDir)" />
   </Target>
 
 </Project>
-


### PR DESCRIPTION
Resolves #1471 using CPython approach, except that StdLib from NuGet always uses lowercase (i.e. incl. on Windows).