### PR TITLE
Fix function compatibility

### DIFF
--- a/Src/IronPython/Runtime/PythonFunction.cs
+++ b/Src/IronPython/Runtime/PythonFunction.cs
@@ -286,9 +286,9 @@ namespace IronPython.Runtime {
 
         internal bool NeedsCodeTest {
             get {
-                return NormalArgumentCount >= 0x3ff
-                    || Defaults.Length >= 0x3ff
-                    || KeywordOnlyArgumentCount >= 0x1ff;
+                return NormalArgumentCount > 0x3ff
+                    || Defaults.Length > 0x3ff
+                    || KeywordOnlyArgumentCount > 0x1ff;
             }
         }
 

--- a/Src/IronPython/Runtime/PythonFunction.cs
+++ b/Src/IronPython/Runtime/PythonFunction.cs
@@ -33,6 +33,8 @@ namespace IronPython.Runtime {
         public readonly MutableTuple Closure;
 
         private object[]/*!*/ _defaults;                // the default parameters of the method
+        private PythonDictionary _kwdefaults;           // the keyword-only arguments defaults for the method
+
         internal PythonDictionary _dict;                // a dictionary to story arbitrary members on the function object
         private object _module;                         // the module name
 
@@ -89,7 +91,7 @@ namespace IronPython.Runtime {
 
             _context = context;
             _defaults = defaults ?? ArrayUtils.EmptyObjects;
-            __kwdefaults__ = kwdefaults;
+            _kwdefaults = kwdefaults;
             _code = funcInfo;
             _doc = funcInfo._initialDoc;
             _name = funcInfo.co_name;
@@ -145,8 +147,13 @@ namespace IronPython.Runtime {
             }
         }
 
-        // TODO: update CalculatedCachedCompat?
-        public PythonDictionary __kwdefaults__ { get; set; }
+        public PythonDictionary __kwdefaults__ {
+            get => _kwdefaults;
+            set {
+                _kwdefaults = value;
+                FunctionCompatibility = CalculatedCachedCompat();
+            }
+        }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public object __closure__ {
@@ -277,6 +284,14 @@ namespace IronPython.Runtime {
         /// </summary>
         internal int FunctionCompatibility { get; private set; }
 
+        internal bool NeedsCodeTest {
+            get {
+                return NormalArgumentCount >= 0x3ff
+                    || Defaults.Length >= 0x3ff
+                    || KeywordOnlyArgumentCount >= 0x1ff;
+            }
+        }
+
         /// <summary>
         /// Calculates the _compat value which is used for call-compatibility checks
         /// for simple calls.  Whenver any of the dependent values are updated this
@@ -289,20 +304,20 @@ namespace IronPython.Runtime {
         ///     expand dict/list - based on nparams and flags, both read-only
         ///     
         /// Bits are allocated as:
-        ///     000000ff - Normal argument count
-        ///     0000ff00 - Default count
-        ///     007f0000 - Keyword-only argument count
-        ///     3f800000 - Keyword-only defaults count
+        ///     000003ff - Normal argument count
+        ///     000ffc00 - Default count
+        ///     1ff00000 - Keyword-only argument count
+        ///     20000000 - has keyword-only defaults
         ///     40000000 - expand list
         ///     80000000 - expand dict
         ///     
         /// Enforce recursion is added at runtime.
         /// </summary>
         private int CalculatedCachedCompat() {
-            return (NormalArgumentCount) |
-                (Defaults.Length << 8) |
-                (KeywordOnlyArgumentCount << 16) |
-                ((__kwdefaults__?.Count ?? 0) << 23) |
+            return NormalArgumentCount |
+                (Defaults.Length << 10) |
+                (KeywordOnlyArgumentCount << 20) |
+                (__kwdefaults__ is not null ? 0x20000000 : 0) |
                 ((ExpandListPosition != -1) ? 0x40000000 : 0) |
                 ((ExpandDictPosition != -1) ? unchecked((int)0x80000000) : 0);
         }

--- a/Tests/modules/network_related/test__ssl.py
+++ b/Tests/modules/network_related/test__ssl.py
@@ -15,7 +15,7 @@ import unittest
 from iptest import IronPythonTestCase, is_cli, is_netcoreapp, retryOnFailure, run_test, skipUnlessIronPython
 
 SSL_URL      = "www.python.org"
-SSL_ISSUER   = "CN=GlobalSign Atlas R3 DV TLS CA H2 2021, O=GlobalSign nv-sa, C=BE"
+SSL_ISSUER   = "CN=GlobalSign Atlas R3 DV TLS CA 2022 Q3, O=GlobalSign nv-sa, C=BE"
 SSL_SERVER   = "www.python.org"
 SSL_PORT     = 443
 SSL_REQUEST  = b"GET /en-us HTTP/1.0\r\nHost: www.python.org\r\n\r\n"

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1683,4 +1683,22 @@ plistlib.loads(plistlib.dumps({})) # check that this does not fail
             self.assertEqual(seq * m, 23)
             self.assertEqual(seq + m, 64)
 
+    def test_ipy3_gh1515(self):
+        # Because function compatibility for simple calls was defined as:
+        #   "number of args" + "number of defaults" << 8 + ...
+        # we got a conflict between 1 arg with default and 257 args.
+
+        # 1 arg with default
+        def d01(a=1): pass
+
+        d01(*(1,))
+
+        # 2.7 fails with 16385 args
+        # 3.4.0-beta fails with 257 args
+        for i in range(16):
+            size = (1<<i) + 1
+            d = {}
+            exec('def f(' + ','.join('a{0}'.format(i) for i in range(size)) + '): pass', d)
+            d["f"](*range(size)) # just make sure this runs successfully
+
 run_test(__name__)


### PR DESCRIPTION
Resolves an invalid `TypeError` when defining/calling certain functions. See https://github.com/IronLanguages/ironpython3/issues/1515 for details.

---
Grammar failure occurs when run after `test_function`:
> .\make.ps1 -f net462 test-"IronPython.test_function|test_grammar_stdlib"

Failure appears to be (note that this only works with CPython 3.7+ since older versions don't accept > 255 arguments):
```py
# from test_function
size = 257
d = {}
exec('def f(' + ','.join(f'a{i}' for i in range(size)) + '): pass', d)
exec('f(*(' + ', '.join(map(str, range(size))) + '))', d)

# from test_grammar
def d01(a=1): pass

d01(*(1,))
```

Broke in https://github.com/IronLanguages/ironpython3/pull/447

_Originally posted by @slozier in https://github.com/IronLanguages/ironpython3/issues/1515#issuecomment-1191722994_