### PR TITLE
DeprecationWarning on failed __classcell__ propagation

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1471,12 +1471,13 @@ namespace IronPython.Runtime.Operations {
                 return PythonType.__new__(parentContext, TypeCache.PythonType, name, bases, vars, selfNames);
             }
 
+            CodeContext classContext = func(parentContext);
+            // If __classcell__ is defined, verify later that it makes all the way to type.__new__
+            var classCell = (ClosureCell?)classContext.Dict.get("__classcell__");
+
             // Prepare classdict
             // TODO: prepared classdict should be used by `func` (PEP 3115)
-            object? classdict = CallPrepare(parentContext, metaclass, name, bases, keywords, func(parentContext).Dict);
-
-            // If __classcell__ is defined, verify later that it makes all the way to type.__new__
-            var classCell = (ClosureCell?)(classdict as PythonDictionary)?.get("__classcell__");
+            object? classdict = CallPrepare(parentContext, metaclass, name, bases, keywords, classContext.Dict);
 
             // Dispatch to the metaclass to do class creation and initialization
             // metaclass could be simply a callable, eg:

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -2689,7 +2689,26 @@ class ClassTest(IronPythonTestCase):
         with warnings.catch_warnings(record=True) as ws:
             warnings.simplefilter("always")
 
-            with self.assertWarnsRegex(DeprecationWarning, r"^__class__ not set defining 'bar' as <class '__main__.*\.gez'>\. Was __classcell__ propagated to type\.__new__\?$"):
+            with self.assertWarnsRegex(DeprecationWarning, r"^__class__ not set defining 'MyClass' as <class '.*\.MyClass'>\. Was __classcell__ propagated to type\.__new__\?$"):
+                class MyDict(dict):
+                    def __setitem__(self, key, value):
+                        pass
+
+                class MetaClass(type):
+                    @classmethod
+                    def __prepare__(metacls, name, bases):
+                        return MyDict()
+
+                class MyClass(metaclass=MetaClass):
+                    def test(self):
+                        return __class__
+
+        self.assertEqual(len(ws), 0) # no unchecked warnings
+
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+
+            with self.assertWarnsRegex(DeprecationWarning, r"^__class__ not set defining 'bar' as <class '.*\.gez'>\. Was __classcell__ propagated to type\.__new__\?$"):
                 class gez: pass
 
                 def foo(*args):

--- a/Tests/test_class.py
+++ b/Tests/test_class.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import unittest
+import warnings
 
 from iptest import IronPythonTestCase, is_cli, is_mono, myint, big, run_test, skipUnlessIronPython
 
@@ -2621,6 +2622,84 @@ class ClassTest(IronPythonTestCase):
         self.assertEqual(x.__bases__, (object, ))
         self.assertEqual(x.__name__, 'x')
 
+    def test_class_attribute(self):
+        class C:
+            def f(self):
+                return self.__class__
+            def g(self):
+                return __class__
+            def h():
+                return __class__
+            @staticmethod
+            def j():
+                return __class__
+            @classmethod
+            def k(cls):
+                return __class__
+
+        self.assertEqual(C().f(), C)
+        self.assertEqual(C().g(), C)
+        self.assertEqual(C.h(), C)
+        self.assertEqual(C.j(), C)
+        self.assertEqual(C.k(), C)
+        self.assertEqual(C().k(), C)
+
+        # Test that a metaclass implemented as a function sets __class__ at a proper moment
+        def makeclass(name, bases, attrs):
+            attrNames = set(attrs.keys())
+            self.assertRaisesMessage(NameError, "free variable '__class__' referenced before assignment in enclosing scope", attrs['getclass'], None)
+            if (is_cli or sys.version_info >= (3, 6)):
+                self.assertIn('__classcell__', attrNames)
+
+            t = type(name, bases, attrs)
+
+            if (is_cli or sys.version_info >= (3, 6)):
+                self.assertEqual(t.getclass(None), t) # __class__ is set right after the type is created
+            else: # CPython 3.5-
+                self.assertRaisesMessage(NameError, "free variable '__class__' referenced before assignment in enclosing scope", attrs['getclass'], None)
+            if not is_cli:
+                self.assertEqual(set(attrs.keys()), attrNames) # set of attrs is not modified by type creation
+            else:
+                # TODO: prevent modification of attrs in IronPython
+                self.assertEqual(set(attrs.keys()) | {'__classcell__'}, attrNames | {'__class__'})
+
+            return t
+
+        class A(metaclass=makeclass):
+            def getclass(self):
+                return __class__
+
+        self.assertEquals(A.getclass(None), A)
+        self.assertEquals(A().getclass(), A)
+
+        dirA = dir(A)
+        self.assertIn('getclass', dirA)
+        self.assertIn('getclass', A.__dict__)
+        self.assertIn('__class__', dirA)
+        self.assertNotIn('__class__', A.__dict__)
+        if not is_cli:
+            self.assertNotIn('__classcell__', dirA)
+            self.assertNotIn('__classcell__', A.__dict__)
+        else:
+            # TODO: filter out __classcell__ in IronPython
+            self.assertIn('__classcell__', dirA)
+            self.assertIn('__classcell__', A.__dict__)
+
+    def test_classcell_propagation(self):
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+
+            with self.assertWarnsRegex(DeprecationWarning, r"^__class__ not set defining 'bar' as <class '__main__.*\.gez'>\. Was __classcell__ propagated to type\.__new__\?$"):
+                class gez: pass
+
+                def foo(*args):
+                    return gez
+
+                class bar(metaclass=foo):
+                    def barfun(self):
+                        return __class__
+
+        self.assertEqual(len(ws), 0) # no unchecked warnings
 
     def test_issubclass(self):
         # first argument doesn't need to be new-style or old-style class if it defines __bases__


### PR DESCRIPTION
Part of #20.

`test__ssl` fails but not fixing here since a fix is already in the pipeline of #1516.