### PR TITLE
Use CommonDictionaryStorage for class variables

### DIFF
--- a/Src/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -259,7 +259,7 @@ namespace IronPython.Compiler.Ast {
             }
         }
 
-        private MSAst.Expression SeLocalName(string name, MSAst.Expression expression)
+        private MSAst.Expression SetLocalName(string name, MSAst.Expression expression)
             => Ast.Call(AstMethods.SetName, LocalContext, Ast.Constant(name), expression);
 
         private Microsoft.Scripting.Ast.LightExpression<Func<CodeContext, CodeContext>> MakeClassBody() {
@@ -282,7 +282,7 @@ namespace IronPython.Compiler.Ast {
             init.Add(Ast.Assign(LocalCodeContextVariable, createLocal));
 
             // __module__ = __name__
-            MSAst.Expression modStmt = SeLocalName("__module__", AstUtils.Convert(GetVariableExpression(ModuleNameVariable!), typeof(object)));
+            MSAst.Expression modStmt = SetLocalName("__module__", AstUtils.Convert(GetVariableExpression(ModuleNameVariable!), typeof(object)));
 
             // TODO: set __qualname__
 
@@ -290,7 +290,7 @@ namespace IronPython.Compiler.Ast {
             MSAst.Expression? docStmt = null;
             string doc = GetDocumentation(Body);
             if (doc is not null) {
-                docStmt = SeLocalName("__doc__", Ast.Constant(doc, typeof(object)));
+                docStmt = SetLocalName("__doc__", Ast.Constant(doc, typeof(object)));
             }
 
             // Create the body

--- a/Src/IronPython/Compiler/Ast/VariableKind.cs
+++ b/Src/IronPython/Compiler/Ast/VariableKind.cs
@@ -35,6 +35,15 @@ namespace IronPython.Compiler.Ast {
         ///
         /// Provides a by-reference access to a local variable in an outer scope.
         /// </summary>
-        Nonlocal
+        Nonlocal,
+
+        /// <summary>
+        /// Attrribute variable.
+        ///
+        /// Like a local variable, but is stored directly in the context dictionary,
+        /// rather than a closure cell.
+        /// Should only appear in a class lambda.
+        /// </summary>
+        Attribute
     }
 }

--- a/Tests/test_metaclass.py
+++ b/Tests/test_metaclass.py
@@ -323,7 +323,7 @@ class MetaclassTest(IronPythonTestCase):
 
         if is_cli:
             # TODO: Use MyDict as the namespace for the class body lambda
-            self.assertEqual(attributes, ['__doc__', '__module__', 'getclass', '__classcell__'])
+            self.assertEqual(set(attributes), {'__module__', '__doc__', 'getclass', '__classcell__'})
         else:
             self.assertEqual(attributes, ['__module__', '__qualname__', '__doc__', 'getclass', '__classcell__'])
 

--- a/Tests/test_super.py
+++ b/Tests/test_super.py
@@ -2,13 +2,14 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 #
-# Copyright (c) Michael van der Kolff
+# Copyright (c) Michael van der Kolff and contributors
 #
 
 ##
 ## Test whether super() behaves as expected
 ##
 
+import sys
 import warnings
 from test.support import check_warnings
 


### PR DESCRIPTION
Part of #20.

Because it effectively changes the name lookup mechanism in a class body lambda, I was curious what performance impact this may have. The old mechanism uses `RuntimeVariableDictionaryStorage`, which is backed by a fixed length array and a linear lookup. In the new code, only `__class__` goes there, all other variables are stored in `CommonDictionaryStorage`, which grows dynamically.  Since the new mechanism is only required for classes created by user metaclasses, it is possible to fall back on the old mechanism if no metaclass is specified, thus maintaining the existing performance profile in most cases.

Intuitively, the old mechanism should be better for small (few methods) classes, while the new approach should outperform for very large classes. But the question was where the break-even is and how much gain/loss it entails.

Here are best-case test results for classes of various sizes. _N_ is the number of methods (with empty body). On top of that, each class has a method `g` returning `__self__`, which adds symbols `g`, `__class__`, `__classcell__`. Plus every class has the mandatory `__module__`. (CPython classes also have `__qualname__`).

|  _N_ | CPython* |    New |    Old |
| ---: | ------: | -----: | -----: |
|    0 |  4.8 μs | 3.2 μs | 3.1 μs |
|   10 |  6.4 μs | 5.1 μs | 5.1 μs |
|  100 |   17 μs |  24 μs |  23 μs |
|  500 |   66 μs | 120 μs | 154 μs |

*CPython is for reference only, runs with GC disabled.
Standard deviation was in the order of 0.5 μs at the low end, 5 μs around _N_=100, and approx. 10 μs for _N_=500.

What it tells me that any differences between the two algorithms are negligible for any sensibly-sized class. The bulk of time is probably spend on parsing and namebinding, and the choice of storage is not a significant factor.