### PR TITLE
Enable some tests from test_class in StdLib

### DIFF
--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -190,7 +190,7 @@ Reason=SystemError: The stream does not support seeking
 [CPython.test_cgitb] # Module will be removed in 3.13 - https://github.com/IronLanguages/ironpython3/issues/1352
 Ignore=true
 
-[CPython.test_class]
+[CPython.test_class] # IronPython.test_class_stdlib
 IsolationLevel=ENGINE
 MaxRecursion=100
 Ignore=true

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -8,6 +8,10 @@ Timeout=120000 # 2 minute timeout
 RunCondition=NOT $(IS_MONO)
 Reason=Exception on adding DocTestSuite
 
+[IronPython.test_class_stdlib]
+IsolationLevel=ENGINE
+MaxRecursion=100 # tests stack overflow handling
+
 [IronPython.test_cliclass]
 IsolationLevel=PROCESS # TODO: figure out - wpf fails to load otherwise
 

--- a/Tests/test_class_stdlib.py
+++ b/Tests/test_class_stdlib.py
@@ -1,0 +1,36 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+##
+## Run selected tests from test_class from StdLib
+##
+
+import unittest
+import sys
+
+from iptest import run_test
+
+import test.test_class
+
+def load_tests(loader, standard_tests, pattern):
+    if sys.implementation.name == 'ironpython':
+        suite = unittest.TestSuite()
+        suite.addTest(test.test_class.ClassTests('testBadTypeReturned'))
+        suite.addTest(test.test_class.ClassTests('testBinaryOps'))
+        suite.addTest(test.test_class.ClassTests('testDel'))
+        suite.addTest(unittest.expectedFailure(test.test_class.ClassTests('testForExceptionsRaisedInInstanceGetattr2'))) # https://github.com/IronLanguages/ironpython3/issues/1530
+        suite.addTest(test.test_class.ClassTests('testGetSetAndDel'))
+        suite.addTest(test.test_class.ClassTests('testHashComparisonOfMethods'))
+        suite.addTest(test.test_class.ClassTests('testHashStuff'))
+        suite.addTest(test.test_class.ClassTests('testInit'))
+        suite.addTest(test.test_class.ClassTests('testListAndDictOps'))
+        suite.addTest(test.test_class.ClassTests('testMisc'))
+        suite.addTest(test.test_class.ClassTests('testSFBug532646')) # requires MaxRecursion set
+        suite.addTest(test.test_class.ClassTests('testUnaryOps'))
+        return suite
+
+    else:
+        return loader.loadTestsFromModule(test.test_class, pattern)
+
+run_test(__name__)


### PR DESCRIPTION
Unfortunately, one test is not passing (#1530), which necessitates `test_class_stdlib`.

3.6 adds two more tests to `test_class`, both pass.