### PR TITLE
Resolve obscure super errors

### DIFF
--- a/Src/IronPython/Compiler/Ast/AstMethods.cs
+++ b/Src/IronPython/Compiler/Ast/AstMethods.cs
@@ -72,7 +72,7 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo MakeSet = GetMethod((Func<object[], SetCollection>)PythonOps.MakeSet);
         public static readonly MethodInfo MakeEmptySet = GetMethod((Func<SetCollection>)PythonOps.MakeEmptySet);
         public static readonly MethodInfo MakeHomogeneousDictFromItems = GetMethod((Func<object[], PythonDictionary>)PythonOps.MakeHomogeneousDictFromItems);
-        public static readonly MethodInfo CreateLocalContext = GetMethod((Func<CodeContext, MutableTuple, string[], CodeContext>)PythonOps.CreateLocalContext);
+        public static readonly MethodInfo CreateLocalContext = GetMethod((Func<CodeContext, MutableTuple, string[], int, int, CodeContext>)PythonOps.CreateLocalContext);
         public static readonly MethodInfo UpdateStackTrace = GetMethod((Action<Exception, CodeContext, FunctionCode, int>)PythonOps.UpdateStackTrace);
         public static readonly MethodInfo ForLoopDispose = GetMethod((Action<KeyValuePair<IEnumerator, IDisposable>>)PythonOps.ForLoopDispose);
         public static readonly MethodInfo GetClosureTupleFromContext = GetMethod((Func<CodeContext, MutableTuple>)PythonOps.GetClosureTupleFromContext);

--- a/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -145,7 +145,10 @@ namespace IronPython.Compiler.Ast {
         internal PythonVariable PythonVariable { get; set; }
 
         internal override bool ExposesLocalVariable(PythonVariable variable) {
-            return NeedsLocalsDictionary || (ContainsSuperCall && variable.Kind is VariableKind.Parameter);
+            return NeedsLocalsDictionary
+                || (ContainsSuperCall && variable.Kind is VariableKind.Parameter
+                        && _parameters is not null && _parameters.Length > 0
+                        && _parameters[0].PythonVariable == variable);
         }
 
         internal override FunctionAttributes Flags {
@@ -258,7 +261,7 @@ namespace IronPython.Compiler.Ast {
         
         internal override void FinishBind(PythonNameBinder binder) {
             foreach (var param in _parameters) {
-                _variableMapping[param.PythonVariable] = param.FinishBind(NeedsLocalsDictionary || ContainsSuperCall);
+                _variableMapping[param.PythonVariable] = param.FinishBind(forceClosureCell: ExposesLocalVariable(param.PythonVariable));
             }
             base.FinishBind(binder);
         }

--- a/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -145,7 +145,7 @@ namespace IronPython.Compiler.Ast {
         internal PythonVariable PythonVariable { get; set; }
 
         internal override bool ExposesLocalVariable(PythonVariable variable) {
-            return NeedsLocalsDictionary; 
+            return NeedsLocalsDictionary || (ContainsSuperCall && variable.Kind is VariableKind.Parameter);
         }
 
         internal override FunctionAttributes Flags {
@@ -258,7 +258,7 @@ namespace IronPython.Compiler.Ast {
         
         internal override void FinishBind(PythonNameBinder binder) {
             foreach (var param in _parameters) {
-                _variableMapping[param.PythonVariable] = param.FinishBind(NeedsLocalsDictionary);
+                _variableMapping[param.PythonVariable] = param.FinishBind(NeedsLocalsDictionary || ContainsSuperCall);
             }
             base.FinishBind(binder);
         }

--- a/Src/IronPython/Compiler/Ast/Parameter.cs
+++ b/Src/IronPython/Compiler/Ast/Parameter.cs
@@ -60,8 +60,8 @@ namespace IronPython.Compiler.Ast {
 
         internal PythonVariable PythonVariable { get; set; }
 
-        internal MSAst.Expression FinishBind(bool needsLocalsDictionary) {
-            if (PythonVariable.AccessedInNestedScope || needsLocalsDictionary) {
+        internal MSAst.Expression FinishBind(bool needsClosureCell) {
+            if (PythonVariable.AccessedInNestedScope || needsClosureCell) {
                 ParameterExpression = Expression.Parameter(typeof(object), Name);
                 var cell = Ast.Parameter(typeof(ClosureCell), Name);
                 return new ClosureExpression(PythonVariable, cell, ParameterExpression);

--- a/Src/IronPython/Compiler/Ast/Parameter.cs
+++ b/Src/IronPython/Compiler/Ast/Parameter.cs
@@ -60,8 +60,8 @@ namespace IronPython.Compiler.Ast {
 
         internal PythonVariable PythonVariable { get; set; }
 
-        internal MSAst.Expression FinishBind(bool needsClosureCell) {
-            if (PythonVariable.AccessedInNestedScope || needsClosureCell) {
+        internal MSAst.Expression FinishBind(bool forceClosureCell) {
+            if (PythonVariable.AccessedInNestedScope || forceClosureCell) {
                 ParameterExpression = Expression.Parameter(typeof(object), Name);
                 var cell = Ast.Parameter(typeof(ClosureCell), Name);
                 return new ClosureExpression(PythonVariable, cell, ParameterExpression);

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -851,13 +851,13 @@ namespace IronPython.Compiler.Ast {
         public override bool Walk(CallExpression node) {
             node.Parent = _currentScope;
 
-            if (node.Target is NameExpression nameExpr && nameExpr.Name == "super" && _currentScope is not ClassDefinition) {
-                _currentScope.Reference("__class__");
-                if (node.Args.Count == 0 && node.Kwargs.Count == 0) {
-                    _currentScope.ContainsSuperCall = true;
-                }
+            if (node.Target is NameExpression nameExpr && nameExpr.Name == "super"
+                && _currentScope is not ClassDefinition
+                && node.Args.Count == 0 && node.Kwargs.Count == 0) {
+
+                _currentScope.ContainsSuperCall = true;
             }
-            return base.Walk(node);
+            return true;
         }
 
         #endregion

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -851,10 +851,10 @@ namespace IronPython.Compiler.Ast {
         public override bool Walk(CallExpression node) {
             node.Parent = _currentScope;
 
-            if (node.Target is NameExpression nameExpr && nameExpr.Name == "super" && _currentScope is FunctionDefinition func) {
+            if (node.Target is NameExpression nameExpr && nameExpr.Name == "super" && _currentScope is not ClassDefinition) {
                 _currentScope.Reference("__class__");
-                if (node.Args.Count == 0 && node.Kwargs.Count == 0 && func.ParameterNames.Length > 0) {
-                    node.SetImplicitArgs(new NameExpression("__class__"), new NameExpression(func.ParameterNames[0]));
+                if (node.Args.Count == 0 && node.Kwargs.Count == 0) {
+                    _currentScope.ContainsSuperCall = true;
                 }
             }
             return base.Walk(node);

--- a/Src/IronPython/Compiler/Ast/PythonReference.cs
+++ b/Src/IronPython/Compiler/Ast/PythonReference.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace IronPython.Compiler.Ast {
     /// <summary>
     /// Represents a reference to a name.  A PythonReference is created for each name
@@ -14,6 +16,6 @@ namespace IronPython.Compiler.Ast {
 
         public string Name { get; }
 
-        internal PythonVariable PythonVariable { get; set; }
+        internal PythonVariable? PythonVariable { get; set; }
     }
 }

--- a/Src/IronPython/Compiler/Ast/ScopeStatement.cs
+++ b/Src/IronPython/Compiler/Ast/ScopeStatement.cs
@@ -96,7 +96,7 @@ namespace IronPython.Compiler.Ast {
         /// <summary>
         /// True if this scope contains a parameterless call to super().
         ///
-        /// It is used to ensure that the first argument is accessible though a closure cell.
+        /// It is used to ensure that the first argument is accessible through a closure cell.
         /// </summary>
         internal bool ContainsSuperCall{ get; set; }
 

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3622,10 +3622,10 @@ namespace IronPython.Runtime.Operations {
 
         #region Global Access
 
-        public static CodeContext/*!*/ CreateLocalContext(CodeContext/*!*/ outerContext, MutableTuple boxes, string[] args) {
+        public static CodeContext/*!*/ CreateLocalContext(CodeContext/*!*/ outerContext, MutableTuple boxes, string[] args, int numFreeVars, int numPosArgs) {
             return new CodeContext(
                 new PythonDictionary(
-                    new RuntimeVariablesDictionaryStorage(boxes, args)
+                    new RuntimeVariablesDictionaryStorage(boxes, args, numFreeVars, numPosArgs)
                 ),
                 outerContext.ModuleContext
             );

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -3622,10 +3622,10 @@ namespace IronPython.Runtime.Operations {
 
         #region Global Access
 
-        public static CodeContext/*!*/ CreateLocalContext(CodeContext/*!*/ outerContext, MutableTuple boxes, string[] args, int numFreeVars, int numPosArgs) {
+        public static CodeContext/*!*/ CreateLocalContext(CodeContext/*!*/ outerContext, MutableTuple boxes, string[] args, int numFreeVars, int arg0Idx) {
             return new CodeContext(
                 new PythonDictionary(
-                    new RuntimeVariablesDictionaryStorage(boxes, args, numFreeVars, numPosArgs)
+                    new RuntimeVariablesDictionaryStorage(boxes, args, numFreeVars, arg0Idx)
                 ),
                 outerContext.ModuleContext
             );

--- a/Src/IronPython/Runtime/RuntimeVariablesDictionaryStorage.cs
+++ b/Src/IronPython/Runtime/RuntimeVariablesDictionaryStorage.cs
@@ -14,16 +14,16 @@ namespace IronPython.Runtime {
         private readonly MutableTuple _boxes;
         private readonly string[] _args;
         private readonly int _numFreeVars;
-        private readonly int _numPosArgs;
+        private readonly int _arg0Idx;
 
-        public RuntimeVariablesDictionaryStorage(MutableTuple boxes, string[] args, int numFreevars, int numPosArgs) {
-            Debug.Assert(numFreevars >= 0 && numPosArgs >= 0);
-            Debug.Assert(numFreevars + numPosArgs <= args.Length);
+        public RuntimeVariablesDictionaryStorage(MutableTuple boxes, string[] args, int numFreeVars, int arg0Idx) {
+            Debug.Assert(0 <= numFreeVars && numFreeVars <= args.Length);
+            Debug.Assert(arg0Idx == -1 || numFreeVars <= arg0Idx && arg0Idx < args.Length);
 
             _boxes = boxes;
             _args = args;
-            _numFreeVars = numFreevars;
-            _numPosArgs = numPosArgs;
+            _numFreeVars = numFreeVars;
+            _arg0Idx = arg0Idx;
         }
 
         /// <summary>
@@ -44,17 +44,14 @@ namespace IronPython.Runtime {
         internal int NumFreeVars => _numFreeVars;
 
         /// <summary>
-        /// Number of positional parameter variables of the lambda.
-        /// Thus no keyword-only, *args, nor **kwargs.
-        /// If non-zero, cells for parameters are after the free variables in <see cref="Tuple"/>.
+        /// Index of the cell of the first positional parameter of the function call.
+        /// Value -1 means that information is not available.
         /// </summary>
         /// <remarks>
-        /// A zero value does not mean that the function doesn't have any positional arguments,
-        /// or that none of its argumets are lifted to a closure cell.
-        /// For performance reasons, NumPosArgs is only tracked when deemed necessary;
-        /// to ensure it is tracked in all cases, run IronPython with option FullFrames.
+        /// This information is intended to be consumed by a parameterless super() call.
+        /// For performance reasons, Arg0Idx is only tracked when deemed necessary to support super().
         /// </remarks>
-        internal int NumPosArgs => _numPosArgs;
+        internal int Arg0Idx => _arg0Idx;
 
         protected override IEnumerable<KeyValuePair<string, object>> GetExtraItems() {
             for (int i = 0; i < _args.Length; i++) {

--- a/Src/IronPython/Runtime/RuntimeVariablesDictionaryStorage.cs
+++ b/Src/IronPython/Runtime/RuntimeVariablesDictionaryStorage.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+
 using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
 
@@ -11,23 +13,48 @@ namespace IronPython.Runtime {
     internal class RuntimeVariablesDictionaryStorage : CustomDictionaryStorage {
         private readonly MutableTuple _boxes;
         private readonly string[] _args;
+        private readonly int _numFreeVars;
+        private readonly int _numPosArgs;
 
-        public RuntimeVariablesDictionaryStorage(MutableTuple boxes, string[] args) {
+        public RuntimeVariablesDictionaryStorage(MutableTuple boxes, string[] args, int numFreevars, int numPosArgs) {
+            Debug.Assert(numFreevars >= 0 && numPosArgs >= 0);
+            Debug.Assert(numFreevars + numPosArgs <= args.Length);
+
             _boxes = boxes;
             _args = args;
+            _numFreeVars = numFreevars;
+            _numPosArgs = numPosArgs;
         }
 
-        internal MutableTuple Tuple {
-            get {
-                return _boxes;
-            }
-        }
+        /// <summary>
+        /// Closure tuple.
+        /// </summary>
+        internal MutableTuple Tuple => _boxes;
 
-        internal string[] Names {
-            get {
-                return _args;
-            }
-        }
+        /// <summary>
+        /// Names of the variables in the closure.
+        /// Cell variables (not accessed in current scope) have null names.
+        /// </summary>
+        internal string[] Names => _args;
+
+        /// <summary>
+        /// Number of free variables in the closure.
+        /// If non-zero, cells for free variables are at the beginning of <see cref="Tuple"/>.
+        /// </summary>
+        internal int NumFreeVars => _numFreeVars;
+
+        /// <summary>
+        /// Number of positional parameter variables of the lambda.
+        /// Thus no keyword-only, *args, nor **kwargs.
+        /// If non-zero, cells for parameters are after the free variables in <see cref="Tuple"/>.
+        /// </summary>
+        /// <remarks>
+        /// A zero value does not mean that the function doesn't have any positional arguments,
+        /// or that none of its argumets are lifted to a closure cell.
+        /// For performance reasons, NumPosArgs is only tracked when deemed necessary;
+        /// to ensure it is tracked in all cases, run IronPython with option FullFrames.
+        /// </remarks>
+        internal int NumPosArgs => _numPosArgs;
 
         protected override IEnumerable<KeyValuePair<string, object>> GetExtraItems() {
             for (int i = 0; i < _args.Length; i++) {

--- a/Src/IronPython/Runtime/Super.cs
+++ b/Src/IronPython/Runtime/Super.cs
@@ -33,11 +33,11 @@ namespace IronPython.Runtime {
             var vars = context.Dict._storage as RuntimeVariablesDictionaryStorage;
 
             // Step 1: access arg[0]
-            if (vars is null || vars.NumPosArgs == 0) {
+            if (vars is null || vars.Arg0Idx < 0) {
                 throw PythonOps.RuntimeError("super(): no arguments");
             }
 
-            object? arg0 = vars.GetCell(vars.NumFreeVars).Value;
+            object? arg0 = vars.GetCell(vars.Arg0Idx).Value;
             if (arg0 == Uninitialized.Instance) {
                 throw PythonOps.RuntimeError("super(): arg[0] deleted");
             }

--- a/Tests/test_inheritance.py
+++ b/Tests/test_inheritance.py
@@ -1367,8 +1367,8 @@ class InheritanceTest(IronPythonTestCase):
 
         c = C()
 
-    def test_super_errors(self):
-        # Test that TyypeError is raised, rather than pass or SystemError: Object reference not set to an instance of an object.
+    def test_super_type_errors(self):
+        # Test that TypeError is raised, rather than pass or SystemError: Object reference not set to an instance of an object.
 
         with self.assertRaises(TypeError):
             super(None)

--- a/Tests/test_super.py
+++ b/Tests/test_super.py
@@ -321,7 +321,7 @@ class SuperTest(IronPythonTestCase):
         self.assertEqual(C().f().__thisclass__, C)
         self.assertEqual(C().f().__self_class__, C)
 
-        # A class using suped in a parameterles method still has a classcell
+        # A class using super in a parameterles method still has a classcell
         class C(metaclass=AssertHasClasscell):
             def f():
                 return super()
@@ -370,7 +370,7 @@ class SuperTest(IronPythonTestCase):
         # Similarly, super() in a generator expression does trigger classcell generation
         class C(metaclass=AssertHasClasscell):
             test = (super() for _ in range(1))
-        # The class creation succeeds because the generator is nor evaluated yet
+        # The class creation succeeds because the generator is not evaluated yet
         # but the generator fails when it is evaluated
         msg = "super(type, obj): obj must be an instance or subtype of type"
         if is_cli:
@@ -387,7 +387,7 @@ class SuperTest(IronPythonTestCase):
         self.assertEqual(C().f().__thisclass__, C)
         self.assertEqual(C().f().__self_class__, C)
 
-        # Using super though an alias does not trigger classcell generation, although the alias works OK
+        # Using super through an alias does not trigger classcell generation, although the alias works OK
         s_p_r = super
         class C(metaclass=AssertHasNoClasscell):
             def f(self):


### PR DESCRIPTION
It started when I looked into why `super()` generates `NameError`/`UnboundLocalError` while in CPython it is `RuntimeError` (tested for by StdLib). It turns out that the CPython's implementation hence behaviour is different in some corner cases. Specifically, 0-argument `super()` does not have default arguments `__class__` and `self` injected during compilation, but resolved during runtime. One of the consequences is that `__class__` is always resolved to a class cell rather than whatever the namebinder finds in the local scope.

As far as I can see, these are truly obscure cases that would lead to IronPython/CPython differences and almost always bad Python programming, but it was an interesting exercise and you never know what other consequences might be there.

For what I know, most IronPython/CPython differences are resolved now, the only few remaining are in some pathological and totally useless constructs, in which the error message (but not type) might be different. See the new tests for specifics.