### PR TITLE
Handle __class__ pathologies

### DIFF
--- a/Src/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -128,6 +128,7 @@ namespace IronPython.Compiler.Ast {
             if (TryGetVariable(reference.Name, out variable)) {
                 if (variable.Kind is VariableKind.Global) {
                     AddReferencedGlobal(reference.Name);
+                    return variable;
                 } else if (variable.Kind is VariableKind.Local) {
                     // TODO: This results in doing a dictionary lookup to get/set the local,
                     // when it should probably be an uninitialized check / global lookup for gets

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1498,7 +1498,7 @@ namespace IronPython.Runtime.Operations {
 
             // If __class__ is used, verify that it has been set
             if (vars._storage is RuntimeVariablesDictionaryStorage storage) {
-                int pos = Array.IndexOf(storage.Names, "__class__");
+                int pos = Array.IndexOf(storage.Names, "__class__", storage.NumFreeVars, storage.Names.Length - storage.NumFreeVars);
                 if (pos >= 0) {
                     ClosureCell classCell = storage.GetCell(pos);
                     if (!ReferenceEquals(classCell.Value, obj)) {

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -887,7 +887,7 @@ Ignore=true
 Reason=ImportError: No module named _msi
 
 [CPython.test_super]
-Ignore=true
+Ignore=false # will have to be ignored again in 3.6
 
 [CPython.test_support]
 RunCondition=NOT $(IS_POSIX) # TODO: debug


### PR DESCRIPTION
Fully resolves #1250.

I have enabled `test_super` from StdLib, but 3.6 adds more tests there, of which one (`test___class___mro`) fails with: _NotImplementedError: Overriding type.mro is not implemented_. Other new tests related to `__class__` pass.