### PR TITLE
Enable nullable annotations in StringDictionaryStorage

### DIFF
--- a/Src/IronPython/Runtime/StringDictionaryStorage.cs
+++ b/Src/IronPython/Runtime/StringDictionaryStorage.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
@@ -12,49 +15,50 @@ using Microsoft.Scripting.Runtime;
 namespace IronPython.Runtime {
     [Serializable]
     internal class StringDictionaryStorage : DictionaryStorage {
-        private Dictionary<string, object> _data;
+        private Dictionary<string, object?>? _data;
+        private static readonly object _nullkey = new();
 
         public StringDictionaryStorage() {
         }
 
         public StringDictionaryStorage(int count) {
-            _data = new Dictionary<string, object>(count, StringComparer.Ordinal);
+            _data = new Dictionary<string, object?>(count, StringComparer.Ordinal);
         }
 
-        public override void Add(ref DictionaryStorage storage, object key, object value) {
+        public override void Add(ref DictionaryStorage storage, object? key, object? value) {
             Add(key, value);
         }
 
-        public void Add(object key, object value) {
+        public void Add(object? key, object? value) {
             lock (this) {
                 AddNoLock(key, value);
             }
         }
 
-        public override void AddNoLock(ref DictionaryStorage storage, object key, object value) {
+        public override void AddNoLock(ref DictionaryStorage storage, object? key, object? value) {
             AddNoLock(key, value);
         }
 
-        public void AddNoLock(object key, object value) {
+        public void AddNoLock(object? key, object? value) {
             EnsureData();
 
-            if (key is string strKey) {
+            if (key is string strKey && strKey.Length != 0) {
                 _data[strKey] = value;
             } else {
-                GetObjectDictionary()[key] = value;
+                GetObjectDictionary()[ToNonNullKey(key)] = value;
             }
         }
 
-        public override bool Contains(object key) {
-            if (_data == null) return false;
+        public override bool Contains(object? key) {
+            if (_data is null) return false;
 
             lock (this) {
-                if (key is string strKey) {
+                if (key is string strKey && strKey.Length != 0) {
                     return _data.ContainsKey(strKey);
                 } else {
-                    Dictionary<object, object> dict = TryGetObjectDictionary();
-                    if (dict != null) {
-                        return dict.ContainsKey(key);
+                    Dictionary<object, object?>? dict = TryGetObjectDictionary();
+                    if (dict is not null) {
+                        return dict.ContainsKey(ToNonNullKey(key));
                     }
 
                     return false;
@@ -62,20 +66,20 @@ namespace IronPython.Runtime {
             }
         }
 
-        public override bool Remove(ref DictionaryStorage storage, object key) {
+        public override bool Remove(ref DictionaryStorage storage, object? key) {
             return Remove(key);
         }
 
-        public bool Remove(object key) {
-            if (_data == null) return false;
+        public bool Remove(object? key) {
+            if (_data is null) return false;
 
             lock (this) {
-                if (key is string strKey) {
+                if (key is string strKey && strKey.Length != 0) {
                     return _data.Remove(strKey);
                 } else {
-                    Dictionary<object, object> dict = TryGetObjectDictionary();
-                    if (dict != null) {
-                        return dict.Remove(key);
+                    Dictionary<object, object?>? dict = TryGetObjectDictionary();
+                    if (dict is not null) {
+                        return dict.Remove(ToNonNullKey(key));
                     }
 
                     return false;
@@ -83,17 +87,16 @@ namespace IronPython.Runtime {
             }
         }
 
-        public override bool TryGetValue(object key, out object value) {
-            if (_data != null) {
+        public override bool TryGetValue(object? key, out object? value) {
+            if (_data is not null) {
                 lock (this) {
-                    if (key is string strKey) {
+                    if (key is string strKey && strKey.Length != 0) {
                         return _data.TryGetValue(strKey, out value);
                     }
 
-                    Dictionary<object, object> dict = TryGetObjectDictionary();
-
-                    if (dict != null) {
-                        return dict.TryGetValue(key, out value);
+                    Dictionary<object, object?>? dict = TryGetObjectDictionary();
+                    if (dict is not null) {
+                        return dict.TryGetValue(ToNonNullKey(key), out value);
                     }
                 }
             }
@@ -104,14 +107,14 @@ namespace IronPython.Runtime {
 
         public override int Count {
             get {
-                if (_data == null) return 0;
+                if (_data is null) return 0;
 
                 lock (this) {
-                    if (_data == null) return 0;
+                    if (_data is null) return 0;
 
                     int count = _data.Count;
-                    Dictionary<object, object> dict = TryGetObjectDictionary();
-                    if (dict != null) {
+                    Dictionary<object, object?>? dict = TryGetObjectDictionary();
+                    if (dict is not null) {
                         // plus the object keys, minus the object dictionary key
                         count += dict.Count - 1;
                     }
@@ -124,21 +127,21 @@ namespace IronPython.Runtime {
             _data = null;
         }
 
-        public override List<KeyValuePair<object, object>> GetItems() {
-            List<KeyValuePair<object, object>> res = new List<KeyValuePair<object, object>>();
+        public override List<KeyValuePair<object?, object?>> GetItems() {
+            var res = new List<KeyValuePair<object?, object?>>();
 
-            if (_data != null) {
+            if (_data is not null) {
                 lock (this) {
-                    foreach (KeyValuePair<string, object> kvp in _data) {
-                        if (string.IsNullOrEmpty(kvp.Key)) continue;
+                    foreach (KeyValuePair<string, object?> kvp in _data) {
+                        if (kvp.Key.Length == 0) continue;
 
-                        res.Add(new KeyValuePair<object, object>(kvp.Key, kvp.Value));
+                        res.Add(new KeyValuePair<object?, object?>(kvp.Key, kvp.Value));
                     }
 
-                    Dictionary<object, object> dataDict = TryGetObjectDictionary();
-                    if (dataDict != null) {
-                        foreach (KeyValuePair<object, object> kvp in GetObjectDictionary()) {
-                            res.Add(kvp);
+                    Dictionary<object, object?>? dataDict = TryGetObjectDictionary();
+                    if (dataDict is not null) {
+                        foreach (KeyValuePair<object, object?> kvp in GetObjectDictionary()) {
+                            res.Add(new KeyValuePair<object?, object?>(FromNonNullKey(kvp.Key), kvp.Value));
                         }
                     }
                 }
@@ -148,12 +151,12 @@ namespace IronPython.Runtime {
         }
 
         public override bool HasNonStringAttributes() {
-            if (_data != null) {
+            if (_data is not null) {
                 lock (this) {
-                    Dictionary<object, object> dataDict = TryGetObjectDictionary();
-                    if (dataDict != null) {
+                    Dictionary<object, object?>? dataDict = TryGetObjectDictionary();
+                    if (dataDict is not null) {
                         foreach (object o in dataDict.Keys) {
-                            if (!(o is Extensible<string>)) {
+                            if (o is not Extensible<string> and not string) {
                                 return true;
                             }
                         }
@@ -164,35 +167,39 @@ namespace IronPython.Runtime {
             return false;
         }
 
-        private Dictionary<object, object> TryGetObjectDictionary() {
-            if (_data != null) {
-                if (_data.TryGetValue(string.Empty, out object dict)) {
-                    return (Dictionary<object, object>)dict;
+        private Dictionary<object, object?>? TryGetObjectDictionary() {
+            if (_data is not null) {
+                if (_data.TryGetValue(string.Empty, out object? dict)) {
+                    Debug.Assert(dict is not null);
+                    return (Dictionary<object, object?>?)dict;
                 }
             }
 
             return null;
         }
 
-        private Dictionary<object, object> GetObjectDictionary() {
+        private Dictionary<object, object?> GetObjectDictionary() {
             lock (this) {
                 EnsureData();
 
-                if (_data.TryGetValue(string.Empty, out object dict)) {
-                    return (Dictionary<object, object>)dict;
+                if (_data.TryGetValue(string.Empty, out object? dict) && dict is not null) {
+                    return (Dictionary<object, object?>)dict;
                 }
 
-                var res = new Dictionary<object, object>();
+                var res = new Dictionary<object, object?>();
                 _data[string.Empty] = res;
 
                 return res;
             }
         }
 
+        [MemberNotNull(nameof(_data))]
         private void EnsureData() {
-            if (_data == null) {
-                _data = new Dictionary<string, object>();
-            }
+            _data ??= new Dictionary<string, object?>(StringComparer.Ordinal);
         }
+
+        private object ToNonNullKey(object? key) => key is null ? _nullkey : key;
+
+        private object? FromNonNullKey(object key) => key == _nullkey? null : key;
     }
 }


### PR DESCRIPTION
Also fixes handling of entries with null or empty string keys.

Frankly, I struggle to see any benefit of `StringDictionaryStorage` over e.g. `CommonDictionaryStorage`. The one thing that `StringDictionaryStorage` does better is the fast test `HasNonStringAttributes`, but since the keys have to be enumerated anyway to match keyword arguments to parameter names, any check against non-strings could be done at that moment, with no extra cost. This is how CPython handles it, I believe.

Perhaps `Dictionary<string, object?>` is faster than the buckets of `CommonDictionaryStorage`. If so, I wonder if `ConcurrentDictionary<string, object?>` wouldn't be even better, but I haven't done any performance measurements. All theses implementations do not preserve order, but order preservation is needed for 3.6, so a new design is needed anyway.