### PR TITLE
Fix AttributeError when subclassing property

### DIFF
--- a/Src/IronPython/Runtime/Descriptors.cs
+++ b/Src/IronPython/Runtime/Descriptors.cs
@@ -122,14 +122,15 @@ namespace IronPython.Runtime {
 
         public void __init__(object fget = null, object fset = null, object fdel = null, object doc = null) {
             _fget = fget; _fset = fset; _fdel = fdel; _doc = doc;
-            if (GetType() != typeof(PythonProperty) && _fget is PythonFunction) {
+
+            if (doc is null && GetType() != typeof(PythonProperty) && _fget is PythonFunction pfget) {
                 // http://bugs.python.org/issue5890
                 PythonDictionary dict = UserTypeOps.GetDictionary((IPythonObject)this);
-                if (dict == null) {
-                    throw PythonOps.AttributeError("{0} object has no __doc__ attribute", PythonOps.GetPythonTypeName(this));
+                if (dict is null) {
+                    throw PythonOps.AttributeError("'{0}' object attribute '__doc__' is read-only", PythonOps.GetPythonTypeName(this));
                 }
 
-                dict["__doc__"] = ((PythonFunction)_fget).__doc__;
+                dict["__doc__"] = pfget.__doc__;
             }
         }
 

--- a/Tests/test_property.py
+++ b/Tests/test_property.py
@@ -235,4 +235,17 @@ class PropertyTest(IronPythonTestCase):
         for attr in ['fdel', 'fget', 'fset']:
             self.assertRaisesMessage(AttributeError, "readonly attribute", lambda : setattr(x, attr, 'abc'))
 
+    def test_property_with_slots(self):
+        def getter(x): pass
+
+        class MyProperty(property):
+            __slots__ = ()
+            def __init__(self, getter, doc):
+                property.__init__(self, getter, doc=doc)
+
+        with self.assertRaises(AttributeError):
+            MyProperty(getter, None).__doc__
+
+        self.assertIs(MyProperty(getter, "anything").__doc__, None)
+
 run_test(__name__)


### PR DESCRIPTION
A subclass of `property` with `__slots__` can lead to an unexpected `AttributeError`. For example:
```py
def getter(x): pass

class MyProperty(property):
    __slots__ = ()
    def __init__(self, getter, doc):
         property.__init__(self, getter, doc=doc)

MyProperty(getter, "").__doc__
```
was raising:
> AttributeError: MyProperty object has no \_\_doc\_\_ attribute

Ran into this while trying to get the `google-cloud-storage` package working (note that it's failing on import even with the fix).