### PR TITLE
Enable nullable annotations in Ast.Node

### DIFF
--- a/Src/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -138,16 +138,11 @@ namespace IronPython.Compiler.Ast {
             }
 
             // Try to bind in outer scopes, except the global scope
-            for (ScopeStatement? parent = Parent;
-                parent != null && !parent.IsGlobal;
-                parent = !parent.IsGlobal ? parent.Parent : null) {
+            if (TryBindOuterScopes(this, reference, out variable, stopAtGlobal: true)) {
+                // for implicit globals, fall back on dictionary behaviour
+                if (variable.Kind is VariableKind.Global) return null;
 
-                if (parent.TryBindOuter(this, reference, out PythonVariable? outerVariable)) {
-                    // for implicit globals, fall back on dictionary behaviour
-                    if (outerVariable.Kind is VariableKind.Global) return null;
-
-                    return outerVariable;
-                }
+                return variable;
             }
 
             return null;

--- a/Src/IronPython/Compiler/Ast/Comprehension.cs
+++ b/Src/IronPython/Compiler/Ast/Comprehension.cs
@@ -290,7 +290,7 @@ namespace IronPython.Compiler.Ast {
             }
 
             // then try to bind in outer scopes
-            for (ScopeStatement parent = Parent; parent != null; parent = parent.Parent) {
+            for (ScopeStatement parent = Parent; parent != null; parent = !parent.IsGlobal ? parent.Parent : null) {
                 if (parent.TryBindOuter(this, reference, out variable)) {
                     return variable;
                 }

--- a/Src/IronPython/Compiler/Ast/Comprehension.cs
+++ b/Src/IronPython/Compiler/Ast/Comprehension.cs
@@ -290,10 +290,8 @@ namespace IronPython.Compiler.Ast {
             }
 
             // then try to bind in outer scopes
-            for (ScopeStatement parent = Parent; parent != null; parent = !parent.IsGlobal ? parent.Parent : null) {
-                if (parent.TryBindOuter(this, reference, out variable)) {
-                    return variable;
-                }
+            if (TryBindOuterScopes(this, reference, out variable, stopAtGlobal: false)) {
+                return variable;
             }
 
             return null;

--- a/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -239,13 +239,8 @@ namespace IronPython.Compiler.Ast {
 
             // Try to bind in outer scopes
             bool stopAtGlobal = variable?.Kind == VariableKind.Nonlocal;
-            for (ScopeStatement parent = Parent;
-                parent != null && !(stopAtGlobal && parent.IsGlobal);
-                parent = !parent.IsGlobal ? parent.Parent : null) {
-
-                if (parent.TryBindOuter(this, reference, out variable)) {
-                    return variable;
-                }
+            if (TryBindOuterScopes(this, reference, out variable, stopAtGlobal)) {
+                return variable;
             }
 
             return null;

--- a/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -239,7 +239,10 @@ namespace IronPython.Compiler.Ast {
 
             // Try to bind in outer scopes
             bool stopAtGlobal = variable?.Kind == VariableKind.Nonlocal;
-            for (ScopeStatement parent = Parent; parent != null && !(stopAtGlobal && parent.IsGlobal); parent = parent.Parent) {
+            for (ScopeStatement parent = Parent;
+                parent != null && !(stopAtGlobal && parent.IsGlobal);
+                parent = !parent.IsGlobal ? parent.Parent : null) {
+
                 if (parent.TryBindOuter(this, reference, out variable)) {
                     return variable;
                 }

--- a/Src/IronPython/Compiler/Ast/Node.cs
+++ b/Src/IronPython/Compiler/Ast/Node.cs
@@ -52,17 +52,18 @@ namespace IronPython.Compiler.Ast {
         /// </remarks>
         public ScopeStatement Parent {
             get => _parent ?? throw new InvalidOperationException("Node.Parent is not defined before the start of namebinding.");
-            set => _parent = value ?? throw new ArgumentNullException(nameof(value));
+            set => _parent = value ?? throw new ArgumentNullException(nameof(Parent));
         }
 
         public void SetLoc(PythonAst globalParent, int start, int end) {
-            IndexSpan = new IndexSpan(start, end > start ? end - start : start);
-            Parent = globalParent;
+            SetLoc(globalParent, new IndexSpan(start, end > start ? end - start : start));
         }
 
         public void SetLoc(PythonAst globalParent, IndexSpan span) {
             IndexSpan = span;
-            Parent = globalParent;
+            if (!ReferenceEquals(_parent, globalParent)) {
+                Parent = globalParent;
+            }
         }
 
         public IndexSpan IndexSpan { get; set; }

--- a/Src/IronPython/Compiler/Ast/Node.cs
+++ b/Src/IronPython/Compiler/Ast/Node.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Microsoft.Scripting;
 
 using MSAst = System.Linq.Expressions;
@@ -35,11 +37,23 @@ namespace IronPython.Compiler.Ast {
         private static readonly ParameterExpression _lineNumberUpdated = Ast.Variable(typeof(bool), "$lineUpdated");
         private static readonly ParameterExpression _lineNoVar = Ast.Parameter(typeof(int), "$lineNo");
 
+        private ScopeStatement? _parent;
+
         protected Node() { }
 
         #region Public API
 
-        public ScopeStatement Parent { get; set; }
+        /// <summary>
+        /// The directly encompassing scope in which the node is defined.
+        /// For the root node (<see cref="PythonAst"/>), the parent is itself.
+        /// </summary>
+        /// <remarks>
+        /// This property is undefined and inaccessible until the start of namebinding.
+        /// </remarks>
+        public ScopeStatement Parent {
+            get => _parent ?? throw new InvalidOperationException("Node.Parent is not defined before the start of namebinding.");
+            set => _parent = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         public void SetLoc(PythonAst globalParent, int start, int end) {
             IndexSpan = new IndexSpan(start, end > start ? end - start : start);
@@ -138,8 +152,7 @@ namespace IronPython.Compiler.Ast {
         internal PythonAst GlobalParent {
             get {
                 Node cur = this;
-                while (!(cur is PythonAst)) {
-                    Debug.Assert(cur != null);
+                while (cur is not PythonAst) {
                     cur = cur.Parent;
                 }
                 return (PythonAst)cur;
@@ -152,7 +165,7 @@ namespace IronPython.Compiler.Ast {
 
         internal bool Optimize => GlobalParent.PyContext.PythonOptions.Optimize;
 
-        internal virtual string GetDocumentation(Statement/*!*/ stmt) {
+        internal virtual string? GetDocumentation(Statement/*!*/ stmt) {
             if (StripDocStrings) {
                 return null;
             }
@@ -181,8 +194,8 @@ namespace IronPython.Compiler.Ast {
         }
 
 
-        internal static MSAst.Expression TransformOrConstantNull(Expression expression, Type/*!*/ type) {
-            if (expression == null) {
+        internal static MSAst.Expression TransformOrConstantNull(Expression? expression, Type/*!*/ type) {
+            if (expression is null) {
                 return AstUtils.Constant(null, type);
             } else {
                 return AstUtils.Convert(expression, type);
@@ -190,7 +203,7 @@ namespace IronPython.Compiler.Ast {
         }
 
         internal MSAst.Expression TransformAndDynamicConvert(Expression expression, Type/*!*/ type) {
-            Debug.Assert(expression != null);
+            Assert.NotNull(expression);
             
             MSAst.Expression res = expression;
 
@@ -204,20 +217,22 @@ namespace IronPython.Compiler.Ast {
                 }
                 
                 // Add conversion step to the AST
-                MSAst.DynamicExpression ae = reduced as MSAst.DynamicExpression;
-                ReducableDynamicExpression rde = reduced as ReducableDynamicExpression;
+                MSAst.DynamicExpression? ae = reduced as MSAst.DynamicExpression;
+                ReducableDynamicExpression? rde = reduced as ReducableDynamicExpression;
 
-                if ((ae != null && ae.Binder is PythonBinaryOperationBinder) ||
-                    (rde != null && rde.Binder is PythonBinaryOperationBinder)) {
+                if ((ae?.Binder is PythonBinaryOperationBinder) ||
+                    (rde?.Binder is PythonBinaryOperationBinder)) {
                     // create a combo site which does the conversion
                     PythonBinaryOperationBinder binder;
                     IList<MSAst.Expression> args;
-                    if (ae != null) {
-                        binder = (PythonBinaryOperationBinder)ae.Binder;
+                    if (ae?.Binder is PythonBinaryOperationBinder aebinder) {
+                        binder = aebinder;
                         args = ArrayUtils.ToArray(ae.Arguments);
-                    } else {
-                        binder = (PythonBinaryOperationBinder)rde.Binder;
+                    } else if (rde?.Binder is PythonBinaryOperationBinder rdebinder) {
+                        binder = rdebinder;
                         args = rde.Args;
+                    } else {
+                        throw Assert.Unreachable;
                     }
 
                     ParameterMappingInfo[] infos = new ParameterMappingInfo[args.Count];
@@ -251,7 +266,7 @@ namespace IronPython.Compiler.Ast {
             => to.IsAssignableFrom(from) && (to.IsValueType == from.IsValueType);
 
         internal static MSAst.Expression/*!*/ ConvertIfNeeded(MSAst.Expression/*!*/ expression, Type/*!*/ type) {
-            Debug.Assert(expression != null);
+            Assert.NotNull(expression);
             // Do we need conversion?
             if (!CanAssign(type, expression.Type)) {
                 // Add conversion step to the AST
@@ -307,11 +322,11 @@ namespace IronPython.Compiler.Ast {
         /// Removes the frames from generated code for when we're compiling the tracing delegate
         /// which will track the frames it's self.
         /// </summary>
-        internal static MSAst.Expression RemoveFrame(MSAst.Expression expression)
+        internal static MSAst.Expression? RemoveFrame(MSAst.Expression expression)
             => new FramedCodeVisitor().Visit(expression);
 
         private class FramedCodeVisitor : ExpressionVisitor {
-            public override MSAst.Expression Visit(MSAst.Expression node) {
+            public override MSAst.Expression? Visit(MSAst.Expression? node) {
                 if (node is FramedCodeExpression framedCode) {
                     return framedCode.Body;
                 }
@@ -346,7 +361,7 @@ namespace IronPython.Compiler.Ast {
                 ).Finally(
                     Ast.Call(
                         FunctionStackVariable,
-                        typeof(List<FunctionStack>).GetMethod("RemoveAt"),
+                        typeof(List<FunctionStack>).GetMethod(nameof(List<FunctionStack>.RemoveAt))!,
                         Ast.Add(
                             Ast.Property(
                                 FunctionStackVariable,
@@ -399,7 +414,7 @@ namespace IronPython.Compiler.Ast {
                 return pyGlobal.Delete();
             }
 
-            return Ast.Assign(expression, Ast.Field(null, typeof(Uninitialized).GetField(nameof(Uninitialized.Instance))));
+            return Ast.Assign(expression, Ast.Field(null, typeof(Uninitialized).GetField(nameof(Uninitialized.Instance))!));
         }
 
         #endregion

--- a/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
+++ b/Src/IronPython/Compiler/Ast/PythonNameBinder.cs
@@ -778,6 +778,9 @@ namespace IronPython.Compiler.Ast {
 
         // PythonAst
         public override bool Walk(PythonAst node) {
+            Debug.Assert(_currentScope == node);
+            node.Parent = _currentScope;
+
             node.DocVariable = DefineName("__doc__");
             if (node.IsModule) {
                 node.NameVariable = DefineName("__name__");
@@ -797,7 +800,7 @@ namespace IronPython.Compiler.Ast {
             // Do not add the global suite to the list of processed nodes,
             // the publishing must be done after the class local binding.
             Debug.Assert(_currentScope == node);
-            _currentScope = _currentScope.Parent;
+            Debug.Assert(_currentScope == _currentScope.Parent);
             _finallyCount.RemoveAt(_finallyCount.Count - 1);
         }
 

--- a/Src/IronPython/Compiler/Ast/ScopeStatement.cs
+++ b/Src/IronPython/Compiler/Ast/ScopeStatement.cs
@@ -266,6 +266,16 @@ namespace IronPython.Compiler.Ast {
             return false;
         }
 
+        private protected bool TryBindOuterScopes(ScopeStatement from, PythonReference reference, [NotNullWhen(true)] out PythonVariable? variable, bool stopAtGlobal) {
+            for (ScopeStatement? parent = from.Parent; parent != null && !(stopAtGlobal && parent.IsGlobal); parent = !parent.IsGlobal ? parent.Parent : null) {
+                if (parent.TryBindOuter(from, reference, out variable)) {
+                    return true;
+                }
+            }
+            variable = null;
+            return false;
+        }
+
         internal abstract PythonVariable? BindReference(PythonNameBinder binder, PythonReference reference);
 
         internal virtual void Bind(PythonNameBinder binder) {

--- a/Src/IronPython/Compiler/Ast/TryStatement.cs
+++ b/Src/IronPython/Compiler/Ast/TryStatement.cs
@@ -95,6 +95,7 @@ namespace IronPython.Compiler.Ast {
 
             // We have else clause, must generate guard around it
             if (@else != null) {
+                Debug.Assert(lineUpdated != null);
                 Debug.Assert(runElse != null);
                 Debug.Assert(previousExceptionContext != null && exception != null && @catch != null);
 
@@ -112,7 +113,7 @@ namespace IronPython.Compiler.Ast {
                     Ast.Block(
                         Ast.Assign(runElse, AstUtils.Constant(true)),
                         // save existing line updated, we could choose to do this only for nested exception handlers.
-                        PushLineUpdated(false, lineUpdated),
+                        PushLineUpdated(false, lineUpdated!),
                         LightExceptions.RewriteExternal(
                             AstUtils.Try(
                                 Parent.AddDebugInfo(AstUtils.Empty(), new SourceSpan(Span.Start, GlobalParent.IndexToLocation(HeaderIndex))),
@@ -123,7 +124,7 @@ namespace IronPython.Compiler.Ast {
                                 Ast.Assign(runElse, AstUtils.Constant(false)),
                                 @catch,
                                 // restore existing line updated after exception handler completes
-                                PopLineUpdated(lineUpdated),
+                                PopLineUpdated(lineUpdated!),
                                 Ast.Assign(exception, Ast.Constant(null, typeof(Exception))),
                                 AstUtils.Constant(null)
                             )
@@ -141,6 +142,7 @@ namespace IronPython.Compiler.Ast {
                 //      ... catch handling ...
                 //  }
                 //
+                Debug.Assert(lineUpdated != null);
                 Debug.Assert(previousExceptionContext != null && exception != null);
 
                 result =
@@ -148,14 +150,14 @@ namespace IronPython.Compiler.Ast {
                         AstUtils.Try(
                             GlobalParent.AddDebugInfo(AstUtils.Empty(), new SourceSpan(Span.Start, GlobalParent.IndexToLocation(HeaderIndex))),
                             // save existing line updated
-                            PushLineUpdated(false, lineUpdated),
+                            PushLineUpdated(false, lineUpdated!),
                             Ast.Assign(previousExceptionContext, Ast.Call(AstMethods.SaveCurrentException)),
                             body,
                             AstUtils.Constant(null)
                         ).Catch(exception,
                             @catch,
                             // restore existing line updated after exception handler completes
-                            PopLineUpdated(lineUpdated),
+                            PopLineUpdated(lineUpdated!),
                             Ast.Assign(exception, Ast.Constant(null, typeof(Exception))),
                             AstUtils.Constant(null)
                         )


### PR DESCRIPTION
Point of interest: `Node.Parent`.

This property is initialized to `null` upon construction and stays `null` up to the beginning of the first namebinding phase. So technically its type is nullable (may be null). However, it is used a lot during and after namebinding and during namebinding it is guaranteed to be non-null by `PythonNameBinder`, while it should not be accessed at all beforehand. So a non-nullable type is a better fit. This is what I chose then with some guards around it.

One caveat: previously, the was one exception the rule above: the root node (`PythonAst`) had `Parent` set to `null` at all times. I've changed this so that the root node is its own parent. This makes the nullability of the property consistent with other node types and allows safe and well defined meaning of expressions like `Parent.Parent...` (I remember I wished to had that when I was working on comprehensions; this is currently not used anywhere).

As a result, the test `node.Parent == null` is no longer a valid test to detect the root node. The canonical form of this test remains `node.IsGlobal` (although at one place I saw an equivalent of `node is PythonAst`, which works too).

----

Something else: `Debug.Assert(x != null)` has an unpleasant side effect that the nullability analyzer assumes that `x` may be null after such statement, even if `x` was determined as non-null before. A workaround is to use `Assert.NotNull(x)`, which pushes `Debug.Assert` one level deeper thus does not suffer from this phenomenon. Unfortunately, after `Assert.NotNull` the analyser still may assume `x` being nullable if it was nullable before. It would be better if `Assert.NotNull` had `[NotNull]` declared on its parameter, but `Assert` is in the DLR, which does not refer to the DLL containing the nullability attributes. Perhaps it may be worth defining something like `PythonAssert.NotNull` with the proper attributes on the parameters?