### PR TITLE
Don't use sys/next/iter in yield from AST

### DIFF
--- a/Src/IronPython/Compiler/Ast/YieldFromExpression.cs
+++ b/Src/IronPython/Compiler/Ast/YieldFromExpression.cs
@@ -28,9 +28,10 @@ namespace IronPython.Compiler.Ast {
         public Expression Expression { get; }
 
         private static readonly Modules._ast.AST yieldFromAst = (Modules._ast.AST)Modules.Builtin.compile(Runtime.DefaultContext.Default, @"
-__yieldfromprefix_i = iter(__yieldfromprefix_EXPR)
+from builtins import iter as __yieldfromprefix_iter, next as __yieldfromprefix_next
+__yieldfromprefix_i = __yieldfromprefix_iter(__yieldfromprefix_EXPR)
 try:
-    __yieldfromprefix_y = next(__yieldfromprefix_i)
+    __yieldfromprefix_y = __yieldfromprefix_next(__yieldfromprefix_i)
 except StopIteration as __yieldfromprefix_e:
     __yieldfromprefix_r = __yieldfromprefix_e.value
 else:
@@ -46,8 +47,8 @@ else:
                 __yieldfromprefix_m()
             raise __yieldfromprefix_e
         except BaseException as __yieldfromprefix_e:
-            import sys
-            __yieldfromprefix_x = sys.exc_info()
+            from sys import exc_info as __yieldfromprefix_exc_info
+            __yieldfromprefix_x = __yieldfromprefix_exc_info()
             try:
                 __yieldfromprefix_m = __yieldfromprefix_i.throw
             except AttributeError:
@@ -61,7 +62,7 @@ else:
         else:
             try:
                 if __yieldfromprefix_s is None:
-                    __yieldfromprefix_y = next(__yieldfromprefix_i)
+                    __yieldfromprefix_y = __yieldfromprefix_next(__yieldfromprefix_i)
                 else:
                     __yieldfromprefix_y = __yieldfromprefix_i.send(__yieldfromprefix_s)
             except StopIteration as __yieldfromprefix_e:

--- a/Src/StdLib/Lib/heapq.py
+++ b/Src/StdLib/Lib/heapq.py
@@ -360,14 +360,12 @@ def merge(*iterables):
     _heappop, _heapreplace, _StopIteration = heappop, heapreplace, StopIteration
     _len = len
 
-    # ironpython: renamed next to next_ due to https://github.com/IronLanguages/ironpython3/issues/547
-
     h = []
     h_append = h.append
     for itnum, it in enumerate(map(iter, iterables)):
         try:
-            next_ = it.__next__
-            h_append([next_(), itnum, next_])
+            next = it.__next__
+            h_append([next(), itnum, next])
         except _StopIteration:
             pass
     heapify(h)
@@ -375,17 +373,17 @@ def merge(*iterables):
     while _len(h) > 1:
         try:
             while True:
-                v, itnum, next_ = s = h[0]
+                v, itnum, next = s = h[0]
                 yield v
-                s[0] = next_()              # raises StopIteration when exhausted
+                s[0] = next()               # raises StopIteration when exhausted
                 _heapreplace(h, s)          # restore heap condition
         except _StopIteration:
             _heappop(h)                     # remove empty iterator
     if h:
         # fast case when only a single iterator remains
-        v, itnum, next_ = h[0]
+        v, itnum, next = h[0]
         yield v
-        yield from next_.__self__
+        yield from next.__self__
 
 # Extend the implementations of nsmallest and nlargest to use a key= argument
 _nsmallest = nsmallest

--- a/Src/StdLib/Lib/xml/etree/ElementPath.py
+++ b/Src/StdLib/Lib/xml/etree/ElementPath.py
@@ -102,13 +102,13 @@ def prepare_child(next, token):
                     yield e
     return select
 
-def prepare_star(next_, token): # https://github.com/IronLanguages/ironpython3/issues/547
+def prepare_star(next, token):
     def select(context, result):
         for elem in result:
             yield from elem
     return select
 
-def prepare_self(next_, token): # https://github.com/IronLanguages/ironpython3/issues/547
+def prepare_self(next, token):
     def select(context, result):
         yield from result
     return select


### PR DESCRIPTION
Resolves https://github.com/IronLanguages/ironpython3/issues/547 by using mangled names. Still not a proper yield from implementation but should at least avoid name conflicts with iter/next/sys.