### PR TITLE
Stage Mono.Unix

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -100,6 +100,18 @@
           DestinationFolder="$(StageDir)\%(RecursiveDir)" />
   </Target>
 
+  <Target Name="_CopyMonoUnixReferences" DependsOnTargets="_MakeStageDir">
+    <ItemGroup>
+      <MonoUnixReferenceFiles
+          Include="$(BinDir)\$(Configuration)\*\Mono.Unix.dll" />
+      <MonoUnixReferenceFiles
+          Include="$(BinDir)\$(Configuration)\*\runtimes\**" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(MonoUnixReferenceFiles)"
+          DestinationFolder="$(StageDir)\%(RecursiveDir)" />
+  </Target>
+
   <Target Name="_CopyMainStageFiles" DependsOnTargets="_MakeStageDir">
     <Copy SourceFiles="@(MainStageFiles)" DestinationFolder="$(StageDir)" />
   </Target>
@@ -115,6 +127,7 @@
       _MakeStageDir;
       _PlatformStage;
       _CopyDlrMainReferences;
+      _CopyMonoUnixReferences;
       _CopyMainStageFiles;
       _CopyStdLib;
     </StageDependsOn>


### PR DESCRIPTION
This makes the zip archive usable on all supported platforms and systems.

The size of the archive is increased by 5 MB. Apparently no file-deduplication takes place. If we want deduplication, I suppose this would need to be manually handled by hacking the "Zip" task snippet. It would save ca. 2.5 MB. Frankly, I don't think it is worth the effort.