### PR TITLE
Do not stage IronPythonTest products

### DIFF
--- a/Build/After.targets
+++ b/Build/After.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Choose>
-    <When Condition=" '$(OutputType)' == 'Library' ">
+    <When Condition=" '$(OutputType)' == 'Library' AND '$(PreventStaging)' != 'true' ">
       <ItemGroup>
         <StageItem Include="$(TargetPath)" />
         <StageItem Include="$(DocumentationFile)" />
@@ -10,7 +10,7 @@
         <StageItem Include="$(TargetDir)$(TargetName).pdb" Condition=" Exists('$(TargetDir)$(TargetName).pdb') " />
       </ItemGroup>
     </When>
-    <When Condition=" '$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe' ">
+    <When Condition=" ('$(OutputType)' == 'Exe' OR '$(OutputType)' == 'WinExe') AND '$(PreventStaging)' != 'true' ">
       <ItemGroup>
         <StageItem Include="$(TargetPath)" />
         <StageItem Include="$(TargetPath).config" Condition=" Exists('$(TargetPath).config') " />
@@ -29,7 +29,7 @@
 
   <Target Name="_LateStage"
           DependsOnTargets="CoreBuild"
-          Condition=" '$(Staging)' == 'true' ">
+          Condition=" '$(Staging)' == 'true' AND '$(PreventStaging)' != 'true' ">
     <CreateItem Include="@(LateStageItem)">
         <Output TaskParameter="Include" ItemName="StageItem" />
     </CreateItem>
@@ -50,4 +50,3 @@
 
   <Target Name="Stage" DependsOnTargets="_LateStage;_MainStage;_StoreInDLLs" />
 </Project>
-

--- a/Package/deb/Deb.Packaging.targets
+++ b/Package/deb/Deb.Packaging.targets
@@ -13,7 +13,7 @@
 
     <ItemGroup>
       <ApplicationFiles Include="$(StageDir)/net462/*.exe" />
-      <ApplicationFiles Include="$(StageDir)/net462/**/*.dll" Exclude="IronPythonTest.dll" />
+      <ApplicationFiles Include="$(StageDir)/net462/**/*.dll" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Package/dotnettool/IronPython.Console.csproj
+++ b/Package/dotnettool/IronPython.Console.csproj
@@ -45,7 +45,7 @@ This package contains a standalone Python interpreter, invokable from the comman
   <ItemGroup>
     <ToolFiles Include="$(StageDir)\$(TargetFramework)\ipy.deps.json" />
     <ToolFiles Include="$(StageDir)\$(TargetFramework)\ipy.dll" />
-    <ToolFiles Include="$(StageDir)\$(TargetFramework)\IronPython*.dll" Exclude="$(StageDir)\$(TargetFramework)\IronPythonTest.dll" />
+    <ToolFiles Include="$(StageDir)\$(TargetFramework)\IronPython*.dll" />
     <ToolFiles Include="$(StageDir)\$(TargetFramework)\**\DLLs\*.dll" />
   </ItemGroup>
 

--- a/Package/pkg/Pkg.Packaging.targets
+++ b/Package/pkg/Pkg.Packaging.targets
@@ -16,7 +16,7 @@
 
     <ItemGroup>
       <ApplicationFiles Include="$(StageDir)/net462/*.exe" />
-      <ApplicationFiles Include="$(StageDir)/net462/*.dll" Exclude="IronPythonTest.dll" />
+      <ApplicationFiles Include="$(StageDir)/net462/*.dll" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Package/zip/Zip.Packaging.targets
+++ b/Package/zip/Zip.Packaging.targets
@@ -4,7 +4,7 @@
     <MakeDir Directories="$(PackageDir)" Condition="!Exists('$(PackageDir)')"/>
 
     <ItemGroup>
-      <ZipFiles Include="$(StageDir)\**\*.*" Exclude="$(StageDir)\**\IronPythonTest.*;$(StageDir)\**\*.pdb;$(StageDir)\netcoreapp2.1\**\*;$(StageDir)\net7.0*\**\*" />
+      <ZipFiles Include="$(StageDir)\**\*.*" Exclude="$(StageDir)\**\*.pdb;$(StageDir)\netcoreapp2.1\**\*;$(StageDir)\net7.0*\**\*" />
     </ItemGroup>
     <Zip Files="@(ZipFiles)" ZipFileName="$(PackageDir)\IronPython.$(PackageVersion).zip" WorkingDirectory="$(StageDir)" />
 

--- a/Src/IronPythonTest/IronPythonTest.csproj
+++ b/Src/IronPythonTest/IronPythonTest.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <!-- EOL netcoreapp2.1 is used to test netstandard2.0 assemblies -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <PreventStaging>true</PreventStaging>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is staging directory cleanup. There is no reason to stage anything from IronPythonTest and then pollute the packaging targets with explicit exclusions.