### PR TITLE
Clean up choco packaging project

### DIFF
--- a/Package/choco/IronPython.nuspec
+++ b/Package/choco/IronPython.nuspec
@@ -7,22 +7,24 @@
     <version>3.4.0</version>
     <packageSourceUrl>https://github.com/IronLanguages/ironpython3/tree/master/Package/choco</packageSourceUrl>
     <title>IronPython</title>
-    <authors>IronPython Contributors,Microsoft</authors>
+    <authors>IronPython Contributors, Microsoft</authors>
+    <copyright>© IronPython Contributors</copyright>
     <owners>IronPython Community</owners>
     <projectUrl>https://ironpython.net</projectUrl>
     <licenseUrl>https://github.com/IronLanguages/ironpython3/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>IronPython is an open-source implementation of the Python programming language which is tightly integrated with the .NET Framework. IronPython can use the .NET Framework and Python libraries, and other .NET languages can use Python code just as easily.</description>
-    <summary>IronPython is an open-source implementation of the Python programming language which is tightly integrated with the .NET Framework.</summary>
+    <description>IronPython is an open-source implementation of the Python programming language that is tightly integrated with the .NET Framework. IronPython can use the .NET Framework and Python libraries, and other .NET languages can use Python code just as easily.</description>
+    <summary>IronPython is an open-source implementation of the Python programming language that is tightly integrated with the .NET Framework.</summary>
     <language>en-US</language>
     <tags>ironpython python dynamic dlr</tags>
     <mailingListUrl>https://ironpython.groups.io/g/users</mailingListUrl>
   </metadata>
   <files>
-    <file src="$STAGEDIR$\net462\*.dll;$STAGEDIR$\net462\*.exe" exclude="**\rowantest*.dll;**\IronPythonTest.dll" />
+    <file src="$STAGEDIR$\net462\*.dll;$STAGEDIR$\net462\*.exe" />
     <file src="$STAGEDIR$\net462\DLLs\**" target="DLLs" exclude="**\*.xml" />
     <file src="$STAGEDIR$\lib\**" target="lib" />
-    <file src="$STAGEDIR$\LICENSE;$STAGEDIR$\README.md" />
+    <file src="$STAGEDIR$\LICENSE" />
+    <file src="README.md" />
     <file src="tools\*" target="tools" />
   </files>
 </package>

--- a/Package/choco/README.md
+++ b/Package/choco/README.md
@@ -3,7 +3,7 @@ IronPython Console
 
 IronPython is an open-source implementation of the Python programming language that is tightly integrated with the .NET Framework. IronPython can use the .NET Framework and Python libraries, and other .NET languages can use Python code just as easily.
 
-This package contains a standalone Python interpreter, invokable from the command line as `ipy`. It also includes the Python Standard Library released by the Python project, but slightly modified to work better with IronPython and .NET.
+This package contains a standalone Python interpreter runing on .NET Framework, invokable from the command line as `ipy`. It also includes the Python Standard Library released by the Python project, but slightly modified to work better with IronPython and .NET.
 
 The current target is Python 3.4, although features and behaviors from later versions may be included. Refer to the [source code repository](https://github.com/IronLanguages/ironpython3) for list of features from each version of CPython that have been implemented.
 

--- a/Package/nuget/README.md
+++ b/Package/nuget/README.md
@@ -24,4 +24,4 @@ System.Console.WriteLine(greetings("world"));
 While compatibility with CPython is one of our main goals with IronPython 3, there are still some differences that may cause issues. See [Differences from CPython](https://github.com/IronLanguages/ironpython3/blob/master/Documentation/differences-from-c-python.md) for details.
 
 ## Package compatibility
-See the [Package compatibility](https://github.com/IronLanguages/ironpython3/blob/master/Documentation/package-compatibility.md) document for information on compatibility with popular packages. Note that to run most packages, IronPython Standard Library must be present.
+See the [Package compatibility](https://github.com/IronLanguages/ironpython3/blob/master/Documentation/package-compatibility.md) document for information on compatibility with popular Python packages. Note that to run most packages, IronPython Standard Library must be present.


### PR DESCRIPTION
I forgot this one when preparing #1580. 

I haven't removed the "obsolete" nuspec metadata, because the declaration of their obsolescence was for _NuGet_, maybe _Chocolatey_ still uses them.

The `README.md` is now aligned with the .NET tool, rather than the GitHub project frontpage .