### PR TITLE
Remove app.config

### DIFF
--- a/Src/IronPythonConsole/App.config
+++ b/Src/IronPythonConsole/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
-  </runtime>
-</configuration>

--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -471,7 +471,6 @@ NotParallelSafe=true # Creates/deletes a directory with static name 'xx'
 
 [CPython.test_glob]
 RunCondition=NOT $(IS_POSIX) # TODO: figure out
-IsolationLevel=PROCESS # use app.config - https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.6-4.6.2#changes-in-path-normalization
 
 [CPython.test_grp]
 RunCondition=$(IS_POSIX)


### PR DESCRIPTION
The `AppContextSwitchOverrides` for path handling is no longer relevant now that we target .NET 4.6.2.