### PR TITLE
Update Install-IronPython and pack in zipfile

### DIFF
--- a/Package/zip/README.md
+++ b/Package/zip/README.md
@@ -13,6 +13,14 @@ After unpacking the archive, move or copy one of the `net` directories matching 
 
 If access to the Python Standard Library is desired from IronPython, move or copy the whole `lib` directory **into** the moved/copied directory from the previous step. The `lib` directory has to be in the same directory as `IronPython.dll`.
 
+The `scripts` subdirectory contains an installation script that facilitates the installation. Example:
+
+```powershell
+PS> ./scripts/Install-IronPython.ps1 ~/.local/share/ironpython
+```
+
+Run `help ./scripts/Install-IronPython` in PowerShell for more information about supported options.
+
 ## Command-line Usage
 
 To start a command-line interpreter on Windows run `ipy.exe` (for .NET Framework) or `ipy.bat` (for .NET). On Posix systems, run `ipy.sh`. `ipy.sh` may be renamed to simply `ipy` for convenience.

--- a/Package/zip/Zip.Packaging.targets
+++ b/Package/zip/Zip.Packaging.targets
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
  <Target Name="ZipPackage" DependsOnTargets="Stage" AfterTargets="Package" Outputs="$(PackageDir)\IronPython.$(PackageVersion).zip;$(PackageDir)\IronPython.StdLib.$(PackageVersion).zip">
     <MakeDir Directories="$(PackageDir)" Condition="!Exists('$(PackageDir)')"/>
 
     <ItemGroup>
       <ZipFiles Include="$(StageDir)\**\*.*" Exclude="$(StageDir)\README.md;$(StageDir)\**\*.pdb;$(StageDir)\netcoreapp2.1\**\*;$(StageDir)\net7.0*\**\*" />
       <ZipFiles Include="README.md" Link="$(MSBuildThisFileDirectory)README.md" />
+      <ZipFiles Include="scripts/Enter-IronPythonEnvironment.ps1" Link="$(RootDir)Src\Scripts\Enter-IronPythonEnvironment.ps1" />
+      <ZipFiles Include="scripts/Install-IronPython.ps1" Link="$(RootDir)Src\Scripts\Install-IronPython.ps1" />
     </ItemGroup>
     <Zip Files="@(ZipFiles)" ZipFileName="$(PackageDir)\IronPython.$(PackageVersion).zip" WorkingDirectory="$(StageDir)" />
 

--- a/Src/Scripts/Install-IronPython.ps1
+++ b/Src/Scripts/Install-IronPython.ps1
@@ -114,6 +114,15 @@ dotnet (Join-Path $PSScriptRoot ipy.dll) @args
         Move-Item -Path (Join-Path $Path "ipy.sh") -Destination (Join-Path $Path "ipy")
         Remove-Item -Path (Join-Path $Path "ipy.bat")
     }
+} elseif ($IsMacOS -or $IsLinux) { # Mono
+    $ipyPath = Join-Path $Path "ipy"
+    Set-Content -Path $ipyPath -Value @'
+#!/bin/sh
+BASEDIR=$(dirname "$0")
+ABS_PATH=$(cd "$BASEDIR"; pwd)
+mono "$ABS_PATH/ipy.exe" "$@"
+'@
+    chmod +x $ipyPath
 }
 
 # Install additional scripts

--- a/Src/Scripts/Install-IronPython.ps1
+++ b/Src/Scripts/Install-IronPython.ps1
@@ -5,36 +5,48 @@
 
 <#
 .SYNOPSIS
-    Install IronPython 3 for .NET 6 from an official zip file distributable.
+    Install IronPython 3 from an official zip file distributable.
 
 .DESCRIPTION
-    This script facilitates installation of IronPython on .NET 6 binaries from a zip file. The zip file is assumed to have content as published on the IronPython's download page. The zip file is produced by IronPython's "package" build target.
+    This script facilitates installation of IronPython binaries from a zip file. The zip file is assumed to have content as published on the IronPython's download page. The zip file is produced by IronPython's "package" build target.
 
 .EXAMPLE
+
+    PS>Invoke-WebRequest -Uri https://github.com/IronLanguages/ironpython3/releases/download/v3.4.0-beta1/IronPython.3.4.0-beta1.zip -OutFile IronPython.3.4.0-beta1.zip
+    PS>Expand-Archive -Path IronPython.3.4.0-beta1.zip -DestinationPath IronPython-unzipped
+    PS>./IronPython-unzipped/scripts/Install-IronPython -Path ~/ipyenv/v3.4.0-beta1
+
+    The official binaries are downloaded from GitHub to the current directory, unzipped, and then the installation proceeds using the script from the unzipped directory. IronPython is installed into ~/ipyenv/v3.4.0-beta1.
+
+.EXAMPLE
+
+    PS>Invoke-WebRequest -Uri https://github.com/IronLanguages/ironpython3/releases/download/v3.4.0-beta1/IronPython.3.4.0-beta1.zip -OutFile IronPython.3.4.0-beta1.zip
+    PS>Install-IronPython -Path ~/ipyenv/v3.4.0-beta1 -ZipFile IronPython.3.4.0-beta1.zip -Framework net462 -Force
+
+    The official binaries are downloaded from GitHub to the current directory and then the installation proceeds using the downloaded zip file. IronPython is installed into ~/ipyenv/v3.4.0-beta1, overwriting any previous installation in that location. IronPython binaries running on .NET Framework 4.6.2 are used during the installation.
+    This example assumes that the installation script is in a directory on the search path ($env:PATH).
+
+.EXAMPLE
+
     PS>./make
     PS>./make package
     PS>./Src/Scripts/Install-IronPython.ps1 env
 
     These commands should be issued on a Powershell prompt with the current directory set to the project root.
-    The project is first built, then packaged, and finally the script uses the zipfile produced during packaging to install IronPython in directory "env"
+    The project is first built, then packaged, and finally the script uses the zipfile produced during packaging to install IronPython in directory "env".
 
-.EXAMPLE
-
-    PS>Invoke-WebRequest -Uri https://github.com/IronLanguages/ironpython3/releases/download/v3.4.0-beta1/IronPython.3.4.0-beta1.zip -OutFile IronPython.3.4.0-beta1.zip
-    PS>Install-IronPython -Path ~/ipyenv/v3.4.0-beta1 -ZipFile IronPython.3.4.0-beta1.zip -Force
-
-    The official binaries are downloaded from GitHub to the current directory and then the installation proceeds using the downloaded zip file. IronPython is installed into ~/ipyenv/v3.4.0-beta1, overwriting any previous installation in that location.
-    This example assumes that the installation script is in a directory on the search path ($env:PATH).
 #>
 [CmdletBinding()]
 Param(
     # Target directory to which IronPython is to be installed.
     [Parameter(Position=0, Mandatory)]
-    [SupportsWildcards()]
     [string] $Path,
 
     # The path to the downloaded zip file with IronPython binaries. If empty, the script will try to grab the package directly produced by the local build.
     [string] $ZipFile,
+
+    # The moniker of the .NET platform to install for.
+    [string] $Framework = "net6.0",
 
     # If the target path exists, it will be wiped clean beforehand.
     [switch] $Force
@@ -42,15 +54,30 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-$defaultVersion = "3.4.0-beta1"
-
 if (-not $ZipFile) {
-    # If zipfile path not given, assume that the script is in the standard location within the source tree
-    # and locate the zip archive in the standard location of the package target.
-    $projectRoot = $PSScriptRoot | Split-Path | Split-Path
-    $ZipFile = Join-Path $projectRoot "Package/Release/Packages/IronPython-$defaultVersion/IronPython.$defaultVersion.zip"
+    # If zipfile path not given, try to locate it
+    $splitPSScriptRoot = $PSScriptRoot -split "\$([IO.Path]::DirectorySeparatorChar)"
+    if ($splitPSScriptRoot[-2] -eq "Src" -and $splitPSScriptRoot[-1] -eq "Scripts") {
+        # Script run from within a checked out code base
+        # Locate the zip archive in the standard location of the package target
+        $projectRoot = $PSScriptRoot | Split-Path | Split-Path
+        $ZipFile = @(Resolve-Path (Join-Path $projectRoot "Package/Release/Packages/IronPython-*/IronPython.3.*.zip"))
+        if ($ZipFile.Count -gt 1) {
+            Write-Error "Ambiguous implicit project zip file: $ZipFile"
+        } elseif ($ZipFile.Count -lt 1) {
+            Write-Error "Missing zip file. Have you run './make package'?"
+        }
+    } elseif ($splitPSScriptRoot[-1] -eq "scripts") {
+        # Script run from within already expanded zip file
+        $unzipDir = $PSScriptRoot | Split-Path
+    } else {
+        Write-Error "Cannot locate implicit zip file. Provide path to the zip file using '-ZipFile <path>'."
+    }
+} elseif (-not (Test-Path $ZipFile)) {
+    Write-Error "ZipFile not found: $ZipFile"
 }
 
+# Prepare destination path
 if (Test-Path $Path) {
     if ($Force) {
         if ((Resolve-Path $Path).Count -gt 1) {
@@ -61,45 +88,41 @@ if (Test-Path $Path) {
         Write-Error "Path already exists: $Path"
     }
 }
+New-Item $Path -ItemType Directory | Out-Null
 
-# Unzip archive and move files into place
-$unzipDir = Join-Path $Path "zip"
+# Unzip archive
+if (-not $unzipDir) {
+    $unzipDir = Join-Path $Path "unzipped"
+    Expand-Archive -Path $ZipFile -DestinationPath $unzipDir
+    $unzipped = $true
+}
 
-Expand-Archive -Path $ZipFile -DestinationPath $unzipDir
-Move-Item -Path (Join-Path $unzipDir "lib") -Destination $Path
-Move-Item -Path (Join-Path $unzipDir "net6.0/*") -Destination $Path -Exclude "*.xml","*.dll.config"
-Remove-Item -Path $unzipDir -Recurse
+# Copy files into place
+Copy-Item -Path (Join-Path $unzipDir $Framework "*") -Destination $Path -Recurse
+Copy-Item -Path (Join-Path $unzipDir "lib") -Destination $Path
 
-# Create a startup script
-$ipyPath = Join-Path $Path "ipy.ps1"
-Set-Content -Path $ipyPath -Value @'
+# Prepare startup scripts
+if ($Framework -notlike "net4*") {
+    $ipyPath = Join-Path $Path "ipy.ps1"
+    Set-Content -Path $ipyPath -Value @'
 #!/usr/bin/env pwsh
 dotnet (Join-Path $PSScriptRoot ipy.dll) @args
 '@
-if ($IsMacOS -or $IsLinux) {
-    chmod +x $ipyPath
-    chmod +x (Join-Path $Path "ipy.sh")
+    if ($IsMacOS -or $IsLinux) {
+        chmod +x $ipyPath
+        chmod +x (Join-Path $Path "ipy.sh")
+        Move-Item -Path (Join-Path $Path "ipy.sh") -Destination (Join-Path $Path "ipy")
+        Remove-Item -Path (Join-Path $Path "ipy.bat")
+    }
 }
 
-# Add items that are missing in the zip file, directly from the bin directory
-if ($projectRoot) {
-    $binPath = Join-Path $projectRoot "bin/Release/net6.0"
-    Copy-Item (Join-Path $projectRoot "Src/Scripts/Enter-IronPythonEnvironment.ps1") $Path
-    if ($IsWindows){
-        Copy-Item (Join-Path $binPath "ipy.exe") $Path
-    } else {
-        Copy-Item (Join-Path $binPath "ipy") $Path
-        Copy-Item (Join-Path $binPath "Mono.Unix.dll") $Path
-        $arch = uname -m
-        switch ($arch) {
-            "x86_64" { $arch = "x64" }
-        }
-        if ($IsMacOS) {
-            $os = "osx"
-        } else {
-            $os = "linux"
-        }
-        $libs = Join-Path $binPath "runtimes" "$os-$arch" "native/*" -Resolve
-        Copy-Item $libs $Path
-    }
+# Install additional scripts
+Copy-Item -Path (Join-Path $unzipDir "scripts/Enter-IronPythonEnvironment.ps1") -Destination $Path
+if ($IsMacOS -or $IsLinux) {
+    chmod -x (Join-Path $Path "Enter-IronPythonEnvironment.ps1")
+}
+
+# Clean up unzipped files
+if ($unzipped) {
+    Remove-Item -Path $unzipDir -Recurse
 }

--- a/Src/Scripts/Install-IronPython.ps1
+++ b/Src/Scripts/Install-IronPython.ps1
@@ -57,7 +57,10 @@ $ErrorActionPreference = "Stop"
 if (-not $ZipFile) {
     # If zipfile path not given, try to locate it
     $splitPSScriptRoot = $PSScriptRoot -split "\$([IO.Path]::DirectorySeparatorChar)"
-    if ($splitPSScriptRoot[-2] -eq "Src" -and $splitPSScriptRoot[-1] -eq "Scripts") {
+    if ($splitPSScriptRoot[-1] -eq "scripts" -and (Test-Path (Join-Path (Split-Path $PSScriptRoot) "lib"))) {
+        # Script run from within already expanded zip file
+        $unzipDir = $PSScriptRoot | Split-Path
+    } elseif ($splitPSScriptRoot[-2] -eq "Src" -and $splitPSScriptRoot[-1] -eq "Scripts") {
         # Script run from within a checked out code base
         # Locate the zip archive in the standard location of the package target
         $projectRoot = $PSScriptRoot | Split-Path | Split-Path
@@ -67,9 +70,6 @@ if (-not $ZipFile) {
         } elseif ($ZipFile.Count -lt 1) {
             Write-Error "Missing zip file. Have you run './make package'?"
         }
-    } elseif ($splitPSScriptRoot[-1] -eq "scripts") {
-        # Script run from within already expanded zip file
-        $unzipDir = $PSScriptRoot | Split-Path
     } else {
         Write-Error "Cannot locate implicit zip file. Provide path to the zip file using '-ZipFile <path>'."
     }


### PR DESCRIPTION
`Install-IronPython` now can facilitate installation from within the zip file.

`Enter-IronPythonEnvironment` is also being distributed in the zip file.