### PR TITLE
Avoid exceptions when loading importlib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Install tools
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get -yq install mono-vbnc dos2unix
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-20.04, macos-latest]
 
     steps:
     - name: Install tools

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -6,7 +6,7 @@ jobs:
   displayName: Windows
   timeoutInMinutes: 180
   pool:
-    vmImage: windows-2022
+    vmImage: windows-latest
   steps:
   - template: Build/steps.yml
     parameters:
@@ -18,7 +18,7 @@ jobs:
   displayName: Linux (Ubuntu)
   timeoutInMinutes: 180
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-20.04
   steps:
   - template: Build/steps.yml
     parameters:

--- a/Src/StdLib/Lib/importlib/_bootstrap.py
+++ b/Src/StdLib/Lib/importlib/_bootstrap.py
@@ -958,10 +958,7 @@ def _spec_from_module(module, loader=None, origin=None):
         location = None
     if origin is None:
         if location is None:
-            try:
-                origin = loader._ORIGIN
-            except AttributeError:
-                origin = None
+            origin = getattr(loader, '_ORIGIN', None) # ironpython: optimization to avoid KeyError exception
         else:
             origin = location
     try:
@@ -2355,6 +2352,7 @@ def _setup(sys_module, _imp_module):
 
     # Directly load the os module (needed during bootstrap).
     os_details = ('posix', ['/']), ('nt', ['\\', '/'])
+    if sys.platform == 'win32': os_details = reversed(os_details) # ironpython: optimization to avoid ImportError exception
     for builtin_os, path_separators in os_details:
         # Assumption made in _path_join()
         assert all(len(sep) == 1 for sep in path_separators)


### PR DESCRIPTION
Avoid exceptions when loading importlib. While the exceptions are normally caught, not having them occur in the first place makes for a more pleasant debugging experience. Related to https://github.com/IronLanguages/ironpython3/issues/1590