### PR TITLE
Update IronPython.nuspec

### DIFF
--- a/Package/nuget/IronPython.nuspec
+++ b/Package/nuget/IronPython.nuspec
@@ -20,7 +20,7 @@ This package contains the IronPython interpreter engine.</description>
     <dependencies>
       <group targetFramework="net462">
         <dependency id="DynamicLanguageRuntime" version="1.3.2" />
-        <dependency id="System.Memory" version="4.5.4" />
+        <dependency id="System.Memory" version="4.5.5" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="DynamicLanguageRuntime" version="1.3.2" />

--- a/Package/nuget/IronPython.nuspec
+++ b/Package/nuget/IronPython.nuspec
@@ -24,7 +24,7 @@ This package contains the IronPython interpreter engine.</description>
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="DynamicLanguageRuntime" version="1.3.2" />
-        <dependency id="System.Memory" version="4.5.4" />
+        <dependency id="System.Memory" version="4.5.5" />
         <dependency id="System.Text.Encoding.CodePages" version="4.6.0" />
         <dependency id="Microsoft.Win32.Registry" version="4.5.0" />
         <dependency id="Mono.Unix" version="7.1.0-final.1.21458.1" />


### PR DESCRIPTION
`System.Memory` was updated from 4.5.4 to 4.5.5 because of issue https://github.com/IronLanguages/ironpython3/issues/1562 and PR https://github.com/IronLanguages/ironpython3/pull/1565/
This change is to align the version in nuspec