### PR TITLE
Fix fileno parameter handling for socket class

### DIFF
--- a/Tests/test_socket_stdlib.py
+++ b/Tests/test_socket_stdlib.py
@@ -49,6 +49,10 @@ def load_tests(loader, standard_tests, pattern):
             failing_tests += [
                 test.test_socket.GeneralModuleTests('test_idna'), # TODO: figure out
             ]
+        if is_posix: # https://github.com/IronLanguages/ironpython3/pull/1638#discussion_r1059535867
+            failing_tests += [
+                test.test_socket.GeneralModuleTests('test_socket_fileno_requires_socket_fd'),
+            ]
 
         skip_tests = [
             test.test_socket.UnbufferedFileObjectClassTestCase('testWriteNonBlocking') # fails intermittently during CI


### PR DESCRIPTION
This adds the expected `fileno` parameter handling for the `socket.socket` class (See #1507). It now throws the expected errors before creating the socket instance.

It also backports tests for the `fileno` parameter from Python 3.11. `os_helper` and `socket_helper` get shimmed by classes with the used attributes from the respective module file if they cannot be imported.

Closes #1509