### PR TITLE
Don't use Optimized when loading importlib

### DIFF
--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -304,7 +304,7 @@ namespace IronPython.Runtime {
 
                 PythonModule LoadModuleFromResource(string name, string resourceName) {
                     var sourceUnit = CreateSourceUnit(new ResourceStreamContentProvider(resourceName), null, DefaultEncoding, SourceCodeKind.File);
-                    var moduleOptions = ModuleOptions.Initialize | ModuleOptions.Optimized;
+                    var moduleOptions = ModuleOptions.Initialize;
                     var scriptCode = GetScriptCode(sourceUnit, name, moduleOptions);
                     var scope = scriptCode.CreateScope();
                     return InitializeModule(null, ((PythonScopeExtension)scope.GetExtension(ContextId)).ModuleContext, scriptCode, moduleOptions);


### PR DESCRIPTION
Loading a module with `ModuleOptions.Optimized` makes it uncollectable and so `importlib` ends up keeping all imported modules alive. Might resolve https://github.com/IronLanguages/ironpython3/issues/1658...