### PR TITLE
return None instead of 0 in GetStdHandle

### DIFF
--- a/Src/IronPython.Modules/_winapi.cs
+++ b/Src/IronPython.Modules/_winapi.cs
@@ -207,8 +207,10 @@ namespace IronPython.Modules {
             return System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
         }
 
-        public static object GetStdHandle(int STD_OUTPUT_HANDLE) {
-            return GetStdHandlePI(STD_OUTPUT_HANDLE).ToPython();
+        public static object? GetStdHandle(int std_handle) {
+            var handle = GetStdHandlePI(std_handle);
+            if (handle == IntPtr.Zero) return null;
+            return handle.ToPython();
         }
 
         public static int GetVersion() {

--- a/Tests/modules/network_related/test__ssl.py
+++ b/Tests/modules/network_related/test__ssl.py
@@ -15,7 +15,7 @@ import unittest
 from iptest import IronPythonTestCase, is_cli, is_netcoreapp, retryOnFailure, run_test, skipUnlessIronPython
 
 SSL_URL      = "www.python.org"
-SSL_ISSUER   = "CN=GlobalSign Atlas R3 DV TLS CA 2022 Q3, O=GlobalSign nv-sa, C=BE"
+SSL_ISSUER   = "CN=GlobalSign Atlas R3 DV TLS CA 2023 Q2, O=GlobalSign nv-sa, C=BE"
 SSL_SERVER   = "www.python.org"
 SSL_PORT     = 443
 SSL_REQUEST  = b"GET /en-us HTTP/1.0\r\nHost: www.python.org\r\n\r\n"


### PR DESCRIPTION
Resolves an issue reported on gitter by @danabr:
> Hi. I have a mysterious issue with subprocess.Popen with stdout=subprocess.PIPE. It works fine from the IronPython console, and also when I run IronPython2 embedded in my application. However, when I use embedded IronPython3, I get: `OSError: [WinError 6] The handle is invalid`. Here is a stacktrace:
>
> ```
> File "myscript.py", line 137, in main
>     p = subprocess.Popen(commands, shell=True, stdout=subprocess.PIPE)
>   File "lib\subprocess.py", line 833, in __init__
>     (p2cread, p2cwrite,
>   File "lib\subprocess.py", line 1033, in _get_handles
>     p2cread = self._make_inheritable(p2cread)
>   File "lib\subprocess.py", line 1080, in _make_inheritable
>     h = _winapi.DuplicateHandle(
> ```
>
>The issue only occurs when I the stdin argument is not supplied or is set to None. The code in subprocess.py then tries to get the default stdin handle with _winapi.GetStdHandle(_winapi.STD_INPUT_HANDLE). That call returns 0 in this case.
>
>The code then goes on to compare the result with None, which seems wrong. From the docs of GetStdHandle:
>
>>    If an application does not have associated standard handles, such as a service running on an interactive desktop, and has not redirected them, the return value is NULL.