### PR TITLE
Remove PYTHONVERBOSE from help

### DIFF
--- a/Src/IronPython/Hosting/PythonOptionsParser.cs
+++ b/Src/IronPython/Hosting/PythonOptionsParser.cs
@@ -335,7 +335,7 @@ namespace IronPython.Hosting {
                 { "-S",                     "Don't imply 'import site' on initialization" },
                 { "-u",                     "Unbuffered stdout & stderr" },
 #if !IRONPYTHON_WINDOW
-                { "-v",                     "Verbose (trace import statements) (also PYTHONVERBOSE=x)" },
+                { "-v",                     "Verbose (trace import statements)" },
 #endif
                 { "-V",                     "print the Python version number and exit (also --version)\nwhen given twice, print more information about the build" },
                 { "-W arg",                 "Warning control (arg is action:message:category:module:lineno) also IRONPYTHONWARNINGS=arg" },

--- a/Src/StdLib/Lib/site.py
+++ b/Src/StdLib/Lib/site.py
@@ -509,7 +509,7 @@ def execsitecustomize():
     except ImportError:
         pass
     except Exception as err:
-        if os.environ.get("PYTHONVERBOSE"):
+        if sys.flags.verbose:
             sys.excepthook(*sys.exc_info())
         else:
             sys.stderr.write(
@@ -525,7 +525,7 @@ def execusercustomize():
     except ImportError:
         pass
     except Exception as err:
-        if os.environ.get("PYTHONVERBOSE"):
+        if sys.flags.verbose:
             sys.excepthook(*sys.exc_info())
         else:
             sys.stderr.write(


### PR DESCRIPTION
Removes PYTHONVERBOSE from the cli help (since it doesn't do anything). Use of flags.verbose in site.py is from 3.6.

Related to https://github.com/IronLanguages/ironpython3/issues/1694

