### PR TITLE
Improve handling of NUL file on Windows

### DIFF
--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -437,15 +437,25 @@ namespace IronPython.Modules {
         [LightThrowing]
         public static object fstat(CodeContext/*!*/ context, int fd) {
             PythonContext pythonContext = context.LanguageContext;
-            if (pythonContext.FileManager.TryGetFileFromId(pythonContext, fd, out PythonIOModule.FileIO file)) {
+            pythonContext.FileManager.TryGetObjectFromId(pythonContext, fd, out object obj);
+            if (obj is PythonIOModule.FileIO file) {
                 if (file.IsConsole) return new stat_result(8192);
-                if (file._readStream is PipeStream) return new stat_result(4096);
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                    if (IsUnixStream(file._readStream)) return new stat_result(4096);
-                }
+                if (StatStream(file._readStream) is not null and var res) return res;
                 if (file.name is string strName) return lstat(strName, new Dictionary<string, object>(1));
+            } else if (obj is Stream stream && StatStream(stream) is not null and var res) {
+                return res;
             }
-            throw PythonOps.OSError(9, "Bad file descriptor");
+            return LightExceptions.Throw(PythonOps.OSError(9, "Bad file descriptor"));
+
+            static stat_result? StatStream(Stream stream) {
+                if (stream is PipeStream) return new stat_result(4096);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                    if (ReferenceEquals(stream, Stream.Null)) return new stat_result(8192);
+                } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                    if (IsUnixStream(stream)) return new stat_result(4096);
+                }
+                return null;
+            }
 
             static bool IsUnixStream(Stream stream) {
                 return stream is Mono.Unix.UnixStream;
@@ -843,8 +853,7 @@ namespace IronPython.Modules {
                 FileAccess access = FileAccessFromFlags(flags);
                 FileOptions options = FileOptionsFromFlags(flags);
                 Stream fs;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && string.Equals(path, "nul", StringComparison.OrdinalIgnoreCase)
-                   || (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && path == "/dev/null") {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && IsNulFile(path)) {
                     fs = Stream.Null;
                 } else if (access == FileAccess.Read && (fileMode == FileMode.CreateNew || fileMode == FileMode.Create || fileMode == FileMode.Append)) {
                     // .NET doesn't allow Create/CreateNew w/ access == Read, so create the file, then close it, then
@@ -1427,7 +1436,9 @@ namespace IronPython.Modules {
                     int mode = 0;
                     long size;
 
-                    if (Directory.Exists(path)) {
+                    if (IsNulFile(path)) {
+                        return new stat_result(0x2000);
+                    } else if (Directory.Exists(path)) {
                         size = 0;
                         mode = 0x4000 | S_IEXEC;
                     } else if (File.Exists(path)) {
@@ -2336,6 +2347,13 @@ the 'status' value."),
         private static void VerifyPath(string path, string functionName, string argName) {
             if (path.IndexOf((char)0) != -1) throw PythonOps.ValueError($"{functionName}: embedded null character in {argName}");
         }
+
+        [SupportedOSPlatform("windows")]
+        private static bool IsNulFile(string path)
+            => path.StartsWith("nul", StringComparison.OrdinalIgnoreCase)
+                && (path.Length == 3
+                 || path.Length == 4 && path[3] == ':'
+                 || path.Length == 5 && path[3] == ':' && path[4] == ':');
 
         #endregion
     }

--- a/Tests/modules/io_related/test_fd.py
+++ b/Tests/modules/io_related/test_fd.py
@@ -71,10 +71,7 @@ class FdTest(IronPythonTestCase):
         self.assertTrue(is_open(fd + 2))
 
         # Verify that dup2 closes the previous occupant of a fd.
-        if is_cli:
-            self.assertEqual(os.open(os.devnull, os.O_WRONLY, 0o600), fd + 1)
-        else:
-            self.assertEqual(os.open(os.devnull, os.O_RDWR, 0o600), fd + 1)
+        self.assertEqual(os.open(os.devnull, os.O_RDWR, 0o600), fd + 1)
         self.assertEqual(os.dup2(fd + 1, fd), fd if is_cli or sys.version_info >= (3,7) else None)
         # null can not be stated on windows - but writes are ok
         self.assertTrue(is_open_nul(fd))

--- a/Tests/modules/system_related/test_nt.py
+++ b/Tests/modules/system_related/test_nt.py
@@ -64,6 +64,20 @@ class NtTest(IronPythonTestCase):
         else:
             self.assertRaisesNumber(WindowsError, 22, nt.stat, 'bad?path.txt')
 
+    def test_stat_nul(self):
+        st_arg = [0] * nt.stat_result.n_sequence_fields
+        st_arg[0] = 0x2000
+        st_res = nt.stat_result(st_arg)
+        for name in ["nul", "nul:", "nul::", "NUL", "NUL:", "NUL::"]:
+            with self.subTest(name=name):
+                self.assertEqual(nt.stat(name), st_res)
+                self.assertEqual(nt.lstat(name), st_res)
+                fd = nt.open(name, os.O_RDWR)
+                self.assertEqual(nt.fstat(fd), st_res)
+                nt.close(fd)
+        self.assertRaises(WindowsError, nt.stat, "nul:::")
+
+
     # stat should accept bytes as argument
     def test_stat_cp34910(self):
         self.assertEqual(nt.stat('/'), nt.stat(b'/'))


### PR DESCRIPTION
`NUL` file is now `stat`-able. The special handling of `/dev/null` is removed since this system file is supported by the OS and can be treated like any other file.