### PR TITLE
Enable PythonOps.PrintException on basic console builds

### DIFF
--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1998,7 +1998,6 @@ namespace IronPython.Runtime.Operations {
             pc.CallWithContext(context, dispHook, value);
         }
 
-#if FEATURE_FULL_CONSOLE
         internal static void PrintException(CodeContext/*!*/ context, Exception/*!*/ exception, object? console = null) {
             PythonContext pc = context.LanguageContext;
             PythonTuple exInfo = GetExceptionInfoLocal(context, exception);
@@ -2008,14 +2007,18 @@ namespace IronPython.Runtime.Operations {
 
             object exceptHook = pc.GetSystemStateValue("excepthook");
             if (exceptHook is BuiltinFunction bf && bf.DeclaringType == typeof(SysModule) && bf.Name == "excepthook") {
-                // builtin except hook, display it to the console which may do nice coloring
+                // builtin except hook
+#if FEATURE_FULL_CONSOLE
                 if (console is IConsole con) {
+                    // display it to the console which may do nice coloring
                     con.WriteLine(pc.FormatException(exception), Style.Error);
-                } else {
+                } else
+#endif
+                {
                     PrintWithDest(context, pc.SystemStandardError, pc.FormatException(exception));
                 }
             } else {
-                // user defined except hook or no console
+                // user defined except hook
                 try {
                     PythonCalls.Call(context, exceptHook, exInfo[0], exInfo[1], exInfo[2]);
                 } catch (Exception e) {
@@ -2028,7 +2031,6 @@ namespace IronPython.Runtime.Operations {
                 }
             }
         }
-#endif
 
         #endregion
 


### PR DESCRIPTION
This change makes IronPython 3 buildable without `FEATURE_FULL_CONSOLE` (except for `IronPythonConsole` and `IronPythonWindow`). Such a build behaves properly in LinqPad without a need for stdio redirecting (i.e. like IronPython 2).