### PR TITLE
Prevent closing of standard descriptors through file objects

### DIFF
--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -334,8 +334,8 @@ namespace IronPython.Modules {
         public static void close(CodeContext/*!*/ context, int fd) {
             PythonFileManager fileManager = context.LanguageContext.FileManager;
             if (fileManager.TryGetFileFromId(fd, out PythonIOModule.FileIO? file)) {
-                file.closefd = true;
-                file.close(context);
+                file.CloseStreams(fileManager);
+                fileManager.RemoveObjectOnId(fd);
             } else {
                 Stream stream = fileManager.GetStreamFromId(fd);
                 fileManager.RemoveObjectOnId(fd);

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -358,7 +358,7 @@ namespace IronPython.Modules {
 
             object obj = fileManager.GetObjectFromId(fd); // OSError if fd not valid
             if (obj is PythonIOModule.FileIO file) {
-                var file2 = new PythonIOModule.FileIO(context, file.fileno(context));
+                var file2 = new PythonIOModule.FileIO(context, file.fileno(context)) { closefd = false };
                 int fd2 = fileManager.AddFile(file2);
                 fileManager.EnsureRef(file._readStream);
                 fileManager.AddRef(file2._readStream);
@@ -391,7 +391,7 @@ namespace IronPython.Modules {
             // TODO: race condition: `open` or `dup` on another thread may occupy fd2 
 
             if (obj is PythonIOModule.FileIO file) {
-                var file2 = new PythonIOModule.FileIO(context, file.fileno(context));
+                var file2 = new PythonIOModule.FileIO(context, file.fileno(context)) { closefd = false };
                 fileManager.AddFile(fd2, file2);
                 fileManager.EnsureRef(file._readStream);
                 fileManager.AddRef(file2._readStream);
@@ -909,8 +909,8 @@ namespace IronPython.Modules {
         public static PythonTuple pipe(CodeContext context) {
             var pipeStreams = CreatePipeStreams();
 
-            var inFile = new PythonIOModule.FileIO(context, pipeStreams.Item1);
-            var outFile = new PythonIOModule.FileIO(context, pipeStreams.Item2);
+            var inFile = new PythonIOModule.FileIO(context, pipeStreams.Item1) { closefd = false };
+            var outFile = new PythonIOModule.FileIO(context, pipeStreams.Item2) { closefd = false };
 
             return PythonTuple.MakeTuple(
                 context.LanguageContext.FileManager.AddFile(inFile),

--- a/Tests/modules/io_related/test_fd.py
+++ b/Tests/modules/io_related/test_fd.py
@@ -257,8 +257,15 @@ class FdTest(IronPythonTestCase):
                 self.assertEqual(file.fileno(), fd)
                 self.assertFalse(file.buffer.raw.closefd)
                 with open(fd, mode=mode, closefd=True) as file2:
+                    # this fails in CPython if standard I/O is redirected
                     self.assertFalse(file2.buffer.raw.closefd)
                 with open(fd, mode=mode, closefd=True) as file3:
                     self.assertFalse(file3.buffer.raw.closefd)
+
+                fd2 = os.dup(fd)
+                self.assertNotEqual(fd2, fd)
+                with open(fd2, mode=mode, closefd=True) as file4:
+                    self.assertFalse(file4.buffer.raw.closefd)
+                os.close(fd2)
 
 run_test(__name__)

--- a/Tests/modules/io_related/test_fd.py
+++ b/Tests/modules/io_related/test_fd.py
@@ -251,4 +251,14 @@ class FdTest(IronPythonTestCase):
         os.close(fd)
         os.unlink(test_filename)
 
+    def test_stdio_fd(self):
+        for file, fd, mode in [(sys.stdin, 0, 'r'), (sys.stdout, 1, 'w'), (sys.stderr, 2, 'w')]:
+            with self.subTest(fd=fd):
+                self.assertEqual(file.fileno(), fd)
+                self.assertFalse(file.buffer.raw.closefd)
+                with open(fd, mode=mode, closefd=True) as file2:
+                    self.assertFalse(file2.buffer.raw.closefd)
+                with open(fd, mode=mode, closefd=True) as file3:
+                    self.assertFalse(file3.buffer.raw.closefd)
+
 run_test(__name__)


### PR DESCRIPTION
Now that I know where to look for `closefd`… This addresses https://github.com/IronLanguages/ironpython3/pull/1711#issuecomment-1636935329.

It is still not exactly like CPython, because it will prevent closing of the descriptors even when redirected but perhaps this is good enough. I cannot imagine when this would be desirable, but there isn't a valid use case. Anyway, note that a determined programmer may still force close a standard descriptor by `os.close(fd)`. This is likely not a good idea anyway since it will crash the CPython process on any attempt to use stdio, and those descriptors cannot be reopened.