### PR TITLE
Redesign PythonFileManager

### DIFF
--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -147,8 +147,8 @@ namespace IronPython.Modules {
                     _offset = offset;
 
                     PythonContext pContext = context.LanguageContext;
-                    if (pContext.FileManager.TryGetFileFromId(fileno, out PythonIOModule.FileIO fileio)) {
-                        if ((_sourceStream = fileio._readStream as FileStream) == null) {
+                    if (pContext.FileManager.TryGetStreams(fileno, out StreamBox streams)) {
+                        if ((_sourceStream = streams.ReadStream as FileStream) == null) {
                             throw WindowsError(PythonExceptions._OSError.ERROR_INVALID_HANDLE);
                         }
                     } else {

--- a/Src/IronPython.Modules/msvcrt.cs
+++ b/Src/IronPython.Modules/msvcrt.cs
@@ -65,7 +65,7 @@ to os.fdopen() to create a file object.
         public static int open_osfhandle(CodeContext context, BigInteger os_handle, int flags) {
             if ((flags & O_TEXT) != 0) throw new NotImplementedException();
             FileStream stream = new FileStream(new SafeFileHandle(new IntPtr((long)os_handle), true), FileAccess.ReadWrite);
-            return context.LanguageContext.FileManager.AddStream(stream);
+            return context.LanguageContext.FileManager.Add(new(stream));
         }
 
         private static bool TryGetFileHandle(Stream stream, out object handle) {
@@ -96,11 +96,10 @@ to os.fdopen() to create a file object.
 Return the file handle for the file descriptor fd. Raises IOError
 if fd is not recognized.")]
         public static object get_osfhandle(CodeContext context, int fd) {
-            // TODO: handle other FileManager types?
-            var pfile = context.LanguageContext.FileManager.GetFileFromId(fd);
+            var sbox = context.LanguageContext.FileManager.GetStreams(fd);
 
             object handle;
-            if (TryGetFileHandle(pfile._readStream, out handle)) return handle;
+            if (TryGetFileHandle(sbox.ReadStream, out handle)) return handle;
 
             return -1;
         }

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -351,9 +351,8 @@ namespace IronPython.Modules {
             PythonFileManager fileManager = context.LanguageContext.FileManager;
 
             StreamBox streams = fileManager.GetStreams(fd); // OSError if fd not valid
-            var stream = streams.ReadStream;
-            fileManager.EnsureRef(stream);
-            fileManager.AddRef(stream);
+            fileManager.EnsureRefStreams(streams);
+            fileManager.AddRefStreams(streams);
             return fileManager.Add(new(streams));
         }
 
@@ -376,9 +375,8 @@ namespace IronPython.Modules {
 
             // TODO: race condition: `open` or `dup` on another thread may occupy fd2 
 
-            var stream = streams.ReadStream;
-            fileManager.EnsureRef(stream);
-            fileManager.AddRef(stream);
+            fileManager.EnsureRefStreams(streams);
+            fileManager.AddRefStreams(streams);
             return fileManager.Add(fd2, new(streams));
         }
 

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -38,33 +38,30 @@ namespace IronPython.Modules {
 
             private static readonly int DEFAULT_BUF_SIZE = 32;
 
-            internal Stream _readStream;
-            private Stream _writeStream;
+            private StreamBox _streams;
             private bool _closed, _closefd;
-            internal int _fd = -1;
             private WeakRefTracker _tracker;
             private PythonContext _context;
+
             public object name;
-            private ConsoleStreamType _consoleStreamType;
 
             internal FileIO(CodeContext/*!*/ context, Stream stream)
+                : this(context, new StreamBox(stream)) {
+            }
+
+            internal FileIO(CodeContext/*!*/ context, StreamBox streams)
                 : base(context) {
                 _context = context.LanguageContext;
+
+                Stream stream = streams.ReadStream;
                 string mode;
                 if (stream.CanRead && stream.CanWrite) mode = "w+";
                 else if (stream.CanWrite) mode = "w";
                 else mode = "r";
                 this.mode = mode;
-                _writeStream = stream;
-                _readStream = stream;
-                _closefd = true;
-            }
 
-            internal FileIO(CodeContext/*!*/ context, Stream stream, ConsoleStreamType consoleStreamType)
-                : this(context, stream) {
-                IsConsole = true;
-                _consoleStreamType = consoleStreamType;
-                _closefd= false;
+                _streams = streams;
+                _closefd = !streams.IsConsoleStream();
             }
 
             public FileIO(CodeContext/*!*/ context, int fd, string mode = "r", bool closefd = true, object opener = null)
@@ -76,24 +73,11 @@ namespace IronPython.Modules {
                 _context = context.LanguageContext;
                 this.mode = NormalizeMode(mode, out _);
 
-                object fileObject = _context.FileManager.GetObjectFromId(fd); // OSError here if no such fd
+                _streams = _context.FileManager.GetStreams(fd); // OSError here if no such fd
 
-                // FileManager interface guarantees fileObject is
-                // one of these two types
-                if (fileObject is FileIO file) {
-                    name = file.name ?? fd;
-                    _readStream = file._readStream;
-                    _writeStream = file._writeStream;
-                } else if (fileObject is Stream stream) {
-                    name = fd;
-                    _readStream = stream;
-                    _writeStream = stream;
-                } else {
-                    Debug.Fail($"{nameof(fileObject)} is of unexpected type {fileObject.GetType().Name}");
-                }
+                name = fd;
 
-                _fd = fd;
-                _closefd = closefd && !SharedIO.IsConsoleStream(_readStream);
+                _closefd = closefd && !_streams.IsConsoleStream();
             }
 
             public FileIO(CodeContext/*!*/ context, string name, string mode = "r", bool closefd = true, object opener = null)
@@ -111,33 +95,34 @@ namespace IronPython.Modules {
                 if (opener is null) {
                     switch (this.mode) {
                         case "rb":
-                            _readStream = _writeStream = OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                            _streams = new(OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
                             break;
                         case "wb":
-                            _readStream = _writeStream = OpenFile(context, pal, name, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
+                            _streams = new(OpenFile(context, pal, name, FileMode.Create, FileAccess.Write, FileShare.ReadWrite));
                             break;
                         case "xb":
-                            _readStream = _writeStream = OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite);
+                            _streams = new(OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite));
                             break;
                         case "ab":
-                            _readStream = _writeStream = OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-                            _readStream.Seek(0L, SeekOrigin.End);
+                            _streams = new(OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite));
+                            _streams.ReadStream.Seek(0L, SeekOrigin.End);
                             break;
                         case "rb+":
-                            _readStream = _writeStream = OpenFile(context, pal, name, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+                            _streams = new(OpenFile(context, pal, name, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite));
                             break;
                         case "wb+":
-                            _readStream = _writeStream = OpenFile(context, pal, name, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+                            _streams = new(OpenFile(context, pal, name, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
                             break;
                         case "xb+":
-                            _readStream = _writeStream = OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
+                            _streams = new(OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite));
                             break;
                         case "ab+":
-                            // Opening _writeStream before _readStream will create the file if it does not exist
-                            _writeStream = OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-                            _readStream = OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                            _readStream.Seek(0L, SeekOrigin.End);
-                            _writeStream.Seek(0L, SeekOrigin.End);
+                            // Opening writeStream before readStream will create the file if it does not exist
+                            var writeStream = OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+                            var readStream = OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                            readStream.Seek(0L, SeekOrigin.End);
+                            writeStream.Seek(0L, SeekOrigin.End);
+                            _streams = new(readStream, writeStream);
                             break;
                         default:
                             throw new InvalidOperationException();
@@ -150,13 +135,7 @@ namespace IronPython.Modules {
                             throw PythonOps.ValueError("opener returned {0}", fd);
                         }
 
-                        if (_context.FileManager.TryGetFileFromId(fd, out FileIO file)) {
-                            _readStream = file._readStream;
-                            _writeStream = file._writeStream;
-                        } else if (_context.FileManager.TryGetStreamFromId(fd, out Stream stream)) {
-                            _readStream = stream;
-                            _writeStream = stream;
-                        } else {
+                        if (!_context.FileManager.TryGetStreams(fd, out _streams)) {
                             throw PythonOps.OSError(9, "Bad file descriptor");
                         }
                     } else {
@@ -256,8 +235,6 @@ namespace IronPython.Modules {
 
             #endregion
 
-            internal bool IsConsole { get; }
-
             #region Public API
 
             [Documentation("close() -> None.  Close the file.\n\n"
@@ -278,31 +255,7 @@ namespace IronPython.Modules {
                 _closed = true;
 
                 if (_closefd) {
-                    PythonFileManager myManager = _context.RawFileManager;
-
-                    if (_fd >= 0) {
-                        myManager?.RemoveObjectOnId(_fd);
-                    }
-
-                    CloseStreams(myManager);
-                }
-            }
-
-            internal void CloseStreams(PythonFileManager manager) {
-                bool readStreamClosed = true;
-                if (_readStream is not null) {
-                    if (manager is not null) {
-                        readStreamClosed = manager.DerefAndCloseIfLast(_readStream);
-                        if (readStreamClosed) {
-                            manager.Remove(_readStream);
-                        }
-                    } else {
-                        _readStream.Close();
-                    }
-                }
-                if (_writeStream is not null && !ReferenceEquals(_readStream, _writeStream) && readStreamClosed) {
-                    _writeStream.Close();
-                    manager?.Remove(_writeStream);
+                    _streams.CloseStreams(_context.RawFileManager);
                 }
             }
 
@@ -313,10 +266,7 @@ namespace IronPython.Modules {
                 }
             }
 
-            public bool closefd {
-                get => _closefd;
-                internal set => _closefd = value;
-            }
+            public bool closefd => _closefd;
 
             [Documentation("fileno() -> int. \"file descriptor\".\n\n"
                 + "This is needed for lower-level file interfaces, such as the fcntl module."
@@ -324,10 +274,7 @@ namespace IronPython.Modules {
             public override int fileno(CodeContext/*!*/ context) {
                 _checkClosed();
 
-                if (_fd < 0) {
-                    _fd = _context.FileManager.GetOrAssignId(this);
-                }
-                return _fd;
+                return _context.FileManager.GetOrAssignId(_streams);
             }
 
             [Documentation("Flush write buffers, if applicable.\n\n"
@@ -336,46 +283,14 @@ namespace IronPython.Modules {
             public override void flush(CodeContext/*!*/ context) {
                 _checkClosed();
 
-                if (_writeStream != null && _writeStream.CanWrite) {
-                    _writeStream.Flush();
-                }
+                _streams.Flush();
             }
 
             [Documentation("isatty() -> bool.  True if the file is connected to a tty device.")]
             public override bool isatty(CodeContext/*!*/ context) {
                 _checkClosed();
 
-                if (Environment.OSVersion.Platform == PlatformID.Unix) {
-                    return isattyUnix();
-                }
-
-                return IsConsole && !isRedirected();
-
-                // Isolate Mono.Unix from the rest of the method so that we don't try to load the Mono.Unix assembly on Windows.
-                bool isattyUnix() {
-                    if (IsConsole) {
-                        if (_consoleStreamType == ConsoleStreamType.Input) {
-                            return Mono.Unix.Native.Syscall.isatty(0);
-                        }
-                        if (_consoleStreamType == ConsoleStreamType.Output) {
-                            return Mono.Unix.Native.Syscall.isatty(1);
-                        }
-                        Debug.Assert(_consoleStreamType == ConsoleStreamType.ErrorOutput);
-                        return Mono.Unix.Native.Syscall.isatty(2);
-                    }
-                    return false;
-                }
-            }
-
-            private bool isRedirected() {
-                if (_consoleStreamType == ConsoleStreamType.Output) {
-                    return Console.IsOutputRedirected;
-                }
-                if (_consoleStreamType == ConsoleStreamType.Input) {
-                    return Console.IsInputRedirected;
-                }
-                Debug.Assert(_consoleStreamType == ConsoleStreamType.ErrorOutput);
-                return Console.IsErrorRedirected;
+                return _streams.IsConsoleStream();
             }
 
             [Documentation("String giving the file mode")]
@@ -393,18 +308,14 @@ namespace IronPython.Modules {
                 }
                 EnsureReadable();
 
-                byte[] buffer = new byte[sizeInt];
-                int bytesRead = _readStream.Read(buffer, 0, sizeInt);
-
-                Array.Resize(ref buffer, bytesRead);
-                return Bytes.Make(buffer);
+                return Bytes.Make(_streams.Read(sizeInt));
             }
 
             [Documentation("readable() -> bool.  True if file was opened in a read mode.")]
             public override bool readable(CodeContext/*!*/ context) {
                 _checkClosed();
 
-                return _readStream.CanRead;
+                return _streams.ReadStream.CanRead;
             }
 
             [Documentation("readall() -> bytes.  read all data from the file, returned as bytes.\n\n"
@@ -419,7 +330,7 @@ namespace IronPython.Modules {
                 int totalBytes = 0;
 
                 for (var bytesRead = -1; bytesRead != 0;) {
-                    bytesRead = _readStream.Read(buffer, totalBytes, bufSize - totalBytes);
+                    bytesRead = _streams.ReadStream.Read(buffer, totalBytes, bufSize - totalBytes);
                     totalBytes += bytesRead;
                     if (totalBytes >= bufSize) {
                         bufSize = bufSize * 2;
@@ -442,7 +353,7 @@ namespace IronPython.Modules {
 
                 var span = pythonBuffer.AsSpan();
                 for (int i = 0; i < span.Length; i++) {
-                    int b = _readStream.ReadByte();
+                    int b = _streams.ReadStream.ReadByte();
                     if (b == -1) return i;
                     span[i] = (byte)b;
                 }
@@ -466,7 +377,7 @@ namespace IronPython.Modules {
             public override BigInteger seek(CodeContext/*!*/ context, BigInteger offset, [Optional] object whence) {
                 _checkClosed();
 
-                return _readStream.Seek((long)offset, (SeekOrigin)GetInt(whence));
+                return _streams.ReadStream.Seek((long)offset, (SeekOrigin)GetInt(whence));
             }
 
             public BigInteger seek(double offset, [Optional] object whence) {
@@ -479,24 +390,20 @@ namespace IronPython.Modules {
             public override bool seekable(CodeContext/*!*/ context) {
                 _checkClosed();
 
-                return _readStream.CanSeek;
+                return _streams.ReadStream.CanSeek;
             }
 
             [Documentation("tell() -> int.  Current file position")]
             public override BigInteger tell(CodeContext/*!*/ context) {
                 _checkClosed();
 
-                return _readStream.Position;
+                return _streams.ReadStream.Position;
             }
 
             public BigInteger truncate(BigInteger size) {
                 EnsureWritable();
 
-                long pos = _readStream.Position;
-                _writeStream.SetLength((long)size);
-                _readStream.Seek(pos, SeekOrigin.Begin);
-
-                return size;
+                return _streams.Truncate((long)size);
             }
 
             public BigInteger truncate(double size) {
@@ -527,7 +434,7 @@ namespace IronPython.Modules {
             public override bool writable(CodeContext/*!*/ context) {
                 _checkClosed();
 
-                return _writeStream.CanWrite;
+                return _streams.WriteStream.CanWrite;
             }
 
             [Documentation("write(b: bytes) -> int.  Write bytes b to file, return number written.\n\n"
@@ -540,11 +447,7 @@ namespace IronPython.Modules {
                 var bytes = buffer.AsReadOnlySpan();
 
                 EnsureWritable();
-                _writeStream.Write(bytes);
-                _writeStream.Flush(); // FileIO is not supposed to buffer so we need to call Flush.
-                SeekToEnd();
-
-                return bytes.Length;
+                return _streams.Write(bytes);
             }
 
             #endregion
@@ -619,19 +522,7 @@ namespace IronPython.Modules {
                 _checkWritable("File not open for writing");
             }
 
-            private void SeekToEnd() {
-                if (!object.ReferenceEquals(_readStream, _writeStream)) {
-                    _readStream.Seek(_writeStream.Position, SeekOrigin.Begin);
-                }
-            }
-
             #endregion
         }
-
-#if !NETCOREAPP
-        private static void Write(this Stream stream, ReadOnlySpan<byte> buffer) {
-            stream.Write(buffer.ToArray(), 0, buffer.Length);
-        }
-#endif
     }
 }

--- a/Src/IronPython/Modules/_io.cs
+++ b/Src/IronPython/Modules/_io.cs
@@ -2890,24 +2890,27 @@ namespace IronPython.Modules {
             return res;
         }
 
-        internal static TextIOWrapper CreateConsole(PythonContext context, SharedIO io, ConsoleStreamType type, string name, out FileIO fio) {
+        internal static TextIOWrapper CreateConsole(PythonContext context, SharedIO io, ConsoleStreamType type, string name, out StreamBox sio) {
             var cc = context.SharedContext;
             if (type == ConsoleStreamType.Input) {
                 var encoding = StringOps.GetEncodingName(io.InputEncoding);
-                fio = new FileIO(cc, io.GetStreamProxy(type), type) { name = name };
+                sio = new StreamBox(io.GetStreamProxy(type), type);
+                var fio = new FileIO(cc, sio) { name = name };
                 var buffer = BufferedReader.Create(cc, fio, DEFAULT_BUFFER_SIZE);
                 return TextIOWrapper.Create(cc, buffer, encoding, null, null, true);
             }
             else if (type == ConsoleStreamType.Output) {
                 var encoding = StringOps.GetEncodingName(io.OutputEncoding);
-                fio = new FileIO(cc, io.GetStreamProxy(type), type) { name = name };
+                sio = new StreamBox(io.GetStreamProxy(type), type);
+                var fio = new FileIO(cc, sio) { name = name };
                 var buffer = BufferedWriter.Create(cc, fio, DEFAULT_BUFFER_SIZE, null);
                 return TextIOWrapper.Create(cc, buffer, encoding, null, null, true);
             }
             else {
                 Debug.Assert(type == ConsoleStreamType.ErrorOutput);
                 var encoding = StringOps.GetEncodingName(io.ErrorEncoding);
-                fio = new FileIO(cc, io.GetStreamProxy(type), type) { name = name };
+                sio = new StreamBox(io.GetStreamProxy(type), type);
+                var fio = new FileIO(cc, sio) { name = name };
                 var buffer = BufferedWriter.Create(cc, fio, DEFAULT_BUFFER_SIZE, null);
                 return TextIOWrapper.Create(cc, buffer, encoding, "backslashreplace", null, true);
             }

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1869,19 +1869,19 @@ namespace IronPython.Runtime {
         private void SetStandardIO() {
             SharedIO io = DomainManager.SharedIO;
 
-            var stdin = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.Input, "<stdin>", out PythonIOModule.FileIO fstdin);
-            var stdout = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.Output, "<stdout>", out PythonIOModule.FileIO fstdout);
-            var stderr = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.ErrorOutput, "<stderr>", out PythonIOModule.FileIO fstderr);
+            var stdin = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.Input, "<stdin>", out StreamBox sstdin);
+            var stdout = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.Output, "<stdout>", out StreamBox sstdout);
+            var stderr = PythonIOModule.CreateConsole(this, io, ConsoleStreamType.ErrorOutput, "<stderr>", out StreamBox sstderr);
 
-            FileManager.AddFile(0, fstdin);
+            FileManager.Add(0, sstdin);
             SetSystemStateValue("__stdin__", stdin);
             SetSystemStateValue("stdin", stdin);
 
-            FileManager.AddFile(1, fstdout);
+            FileManager.Add(1, sstdout);
             SetSystemStateValue("__stdout__", stdout);
             SetSystemStateValue("stdout", stdout);
 
-            FileManager.AddFile(2, fstderr);
+            FileManager.Add(2, sstderr);
             SetSystemStateValue("__stderr__", stderr);
             SetSystemStateValue("stderr", stderr);
         }

--- a/Src/IronPython/Runtime/PythonFileManager.cs
+++ b/Src/IronPython/Runtime/PythonFileManager.cs
@@ -7,17 +7,142 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
+using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 
-using IronPython.Runtime.Exceptions;
-using System.Diagnostics.CodeAnalysis;
 using IronPython.Runtime.Operations;
 
 namespace IronPython.Runtime {
+
     /// <summary>
-    /// Emulates a file descriptor table for <see cref="Modules.PythonIOModule.FileIO"/> and <see cref="System.IO.Stream"/> objects.
+    /// Lightweight version of FileIO.
+    /// </summary>
+    internal sealed class StreamBox {
+        private int _id = -1;
+        private Stream _readStream;
+        private Stream _writeStream;
+
+        public StreamBox(Stream readStream, Stream writeStream) {
+            _readStream = readStream;
+            _writeStream = writeStream;
+        }
+
+        public StreamBox(Stream stream) : this(stream, stream) { }
+
+        public StreamBox(StreamBox streams) : this(streams._readStream, streams._writeStream) {
+            StreamType = streams.StreamType;
+        }
+
+        public StreamBox(Stream stream, ConsoleStreamType streamType) : this(stream) {
+            StreamType = streamType;
+        }
+
+        public Stream ReadStream => _readStream;
+        public Stream WriteStream => _writeStream;
+
+        public int Id {
+            get => _id;
+            set {
+                // Only PythonFileManager should set Id, and only once
+                if (value < 0) throw new ArgumentException("File descriptor must be non-negative.");
+                if (_id >= 0) throw new InvalidOperationException("File descriptor already set");
+                _id = value;
+            }
+        }
+
+        public bool IsSingleStream => ReferenceEquals(_readStream, _writeStream);
+
+        public ConsoleStreamType? StreamType { get; private set; }
+
+        /// <summary>
+        /// Is this stdin, stdout, or stderr?
+        /// </summary>
+        /// <returns></returns>
+        public bool IsStandardIOStream() {
+            return SharedIO.IsConsoleStream(_readStream);
+        }
+
+        /// <summary>
+        /// Is this stdin, stdout, or stderr, connected to a console?
+        /// </summary>
+        /// <returns></returns>
+        public bool IsConsoleStream() {
+            if (Environment.OSVersion.Platform == PlatformID.Unix) {
+                return isattyUnix();
+            }
+
+            if (!SharedIO.IsConsoleStream(_readStream)) return false;
+            return StreamType switch {
+                ConsoleStreamType.Input => !Console.IsInputRedirected,
+                ConsoleStreamType.Output => !Console.IsOutputRedirected,
+                ConsoleStreamType.ErrorOutput => !Console.IsErrorRedirected,
+                _ => false
+            };
+
+            // Isolate Mono.Unix from the rest of the method so that we don't try to load the Mono.Unix assembly on Windows.
+            bool isattyUnix() {
+                // TODO: console streams may be dupped to differend FD numbers, do not use hard-coded 0, 1, 2
+                return StreamType switch {
+                    ConsoleStreamType.Input => Mono.Unix.Native.Syscall.isatty(0),
+                    ConsoleStreamType.Output => Mono.Unix.Native.Syscall.isatty(1),
+                    ConsoleStreamType.ErrorOutput => Mono.Unix.Native.Syscall.isatty(2),
+                    _ => false
+                };
+            }
+        }
+
+        public long Truncate(long  size) {
+            long pos = _readStream.Position;
+            _writeStream.SetLength(size);
+            _readStream.Seek(pos, SeekOrigin.Begin);
+            return size;
+        }
+
+        public byte[] Read(int count) {
+            byte[] buffer = new byte[count];
+            int bytesRead = _readStream.Read(buffer, 0, count);
+            Array.Resize(ref buffer, bytesRead);
+            return buffer;
+        }
+
+        public int Write(ReadOnlySpan<byte> bytes) {
+#if NETCOREAPP
+            _writeStream.Write(bytes);
+#else
+            _writeStream.Write(bytes.ToArray(), 0, bytes.Length);
+#endif
+            _writeStream.Flush(); // IO at this level is not supposed to buffer so we need to call Flush.
+            if (!IsSingleStream) {
+                _readStream.Seek(_writeStream.Position, SeekOrigin.Begin);
+            }
+            return bytes.Length;
+        }
+
+        public void Flush() {
+            if (_writeStream.CanWrite) {
+                _writeStream.Flush();
+            }
+        }
+
+        public void CloseStreams(PythonFileManager? manager) {
+            bool readStreamClosed = true;
+            if (manager is not null && Id >= 0) {
+                manager.Remove(this);
+                readStreamClosed = manager.DerefAndCloseIfLast(_readStream);
+            } else {
+                _readStream.Close();
+            }
+            if (readStreamClosed && !IsSingleStream) {
+                _writeStream.Close();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emulates a file descriptor table.
     /// </summary>
     /// <remarks>
     /// PythonFileManager emulates a file descriptor table. On Windows, .NET uses Win32 API which uses file handles
@@ -28,20 +153,16 @@ namespace IronPython.Runtime {
     /// through relevant API calls. Therefore the ordering of assigned descriptors in IronPython may be different than in CPython.
     /// This should not be a problem since assumptions on descriptor ordering are not good programming practice.
     ///
-    /// Open filesystem files are represented in the manager as lower level Stream objects, and higher level FileIO objects.
-    /// FileIO basically encapsulates one of two Streams (one for reading and one for writing, which may be the same).
+    /// Open filesystem files are represented in the manager as StreamBox objects, which
+    /// basically encapsulate one or two Streams (one for reading and one for writing, which may be the same).
     ///
     /// There are two levels of sharing that are supported. On the higher level, several different FileIO objects may share the same
-    /// file descriptor. In such case, all of those FileIO objects maintain references to the same underlying Stream object(s)
-    /// and the manager maintains a mapping between the descriptor and only one of those FileIO objects (the first one opened).
+    /// file descriptor. In such case, all of those FileIO objects maintain references to the same underlying StreamBox object.
     /// In such situations, only one of the FileIO may be opened with flag `closefd` (CPython rule).
-    ///
-    /// If a filesystem file is opened without a corresponding FileIO (i.e. a bare file descriptor), the manager maintains a hidden FileIO
-    /// for itself to manage the mapping. This object is not exposed to Python and only used for opening/closing/dup etc. purposes.
     ///
     /// The second lever of sharing of open files is below the file descriptor level. A file descriptor can be duplicated using dup/dup2,
     /// but the duplicated descriptor is still refering to the same open file in the filesystem. In such case, the manager maintains
-    /// a separate FileIO for the duplicated descriptor, but the FileIOs for both descriptors share the underlying Streams.
+    /// a separate StreamBox for the duplicated descriptor, but the StreamBoxes for both descriptors share the underlying Streams.
     /// Both such descriptors have to be closed independently by the user code (either explicitly by os.close(fd) or through close()
     /// on the FileIO objects), but the underlying shared streams are closed only when all such duplicated descriptors are closed.
     /// To facilitate that, the manager uses rudimentary reference counting. This ref-counting is only used for streams
@@ -54,65 +175,52 @@ namespace IronPython.Runtime {
         public const int LIMIT_OFILE = 0x100000; // hard limit on Linux
 
         private readonly object _synchObject = new();
-        private readonly Dictionary<int, object> _objects = new();
+        private readonly Dictionary<int, StreamBox> _table = new();
         private const int _offset = 3; // number of lowest keys that are not automatically allocated
         private int _current = _offset; // lowest potentially unused key in _objects at or above _offset
         private readonly ConcurrentDictionary<Stream, int> _refs = new();
 
-        public int AddFile(int id, Modules.PythonIOModule.FileIO file) {
-            file._fd = Add(id, file);
-            return file._fd;
-        }
-
-        public int AddStream(int id, Stream stream) => Add(id, stream);
-
-        // Public API controls which types are allowed to be added
-        private int Add(int id, object obj) {
-            ContractUtils.RequiresNotNull(obj, nameof(obj));
+        public int Add(int id, StreamBox streams) {
+            ContractUtils.RequiresNotNull(streams, nameof(streams));
+            ContractUtils.Requires(streams.Id < 0, nameof(streams));
             ContractUtils.Requires(id >= 0, nameof(id));
             lock (_synchObject) {
-                if (_objects.ContainsKey(id)) {
+                if (_table.ContainsKey(id)) {
                     throw PythonOps.OSError(9, "Bad file descriptor", id.ToString());
                 }
-                _objects.Add(id, obj);
+                streams.Id = id;
+                _table.Add(id, streams);
                 return id;
             }
         }
 
-        public int AddFile(Modules.PythonIOModule.FileIO file) {
-            file._fd = Add(file);
-            return file._fd;
-        }
-
-        public int AddStream(Stream stream) => Add(stream);
-
-        // Public API controls which types are allowed to be added
-        private int Add(object obj) {
-            ContractUtils.RequiresNotNull(obj, nameof(obj));
+        public int Add(StreamBox streams) {
+            ContractUtils.RequiresNotNull(streams, nameof(streams));
+            ContractUtils.Requires(streams.Id < 0, nameof(streams));
             lock (_synchObject) {
-                while (_objects.ContainsKey(_current)) {
+                while (_table.ContainsKey(_current)) {
                     _current++;
                     if (_current >= LIMIT_OFILE)
                         throw PythonOps.OSError(24, "Too many open files");
                 }
-                _objects.Add(_current, obj);
+                streams.Id = _current;
+                _table.Add(_current, streams);
                 return _current++;
             }
         }
 
-        public bool Remove(object obj) {
+        public bool Remove(StreamBox streams) {
             lock (_synchObject) {
-                int id = GetIdFromObject(obj);
-                if (id >= 0) {
-                    return RemoveObjectOnId(id);
+                if (streams.Id >= 0) {
+                    return Remove(streams.Id);
                 }
                 return false;
             }
         }
 
-        public bool RemoveObjectOnId(int id) {
+        public bool Remove(int id) {
             lock (_synchObject) {
-                bool removed = _objects.Remove(id);
+                bool removed = _table.Remove(id);
                 if (id < _current && id >= _offset) {
                     _current = id;
                 }
@@ -120,43 +228,27 @@ namespace IronPython.Runtime {
             }
         }
 
-        public bool TryGetObjectFromId(int id, [NotNullWhen(true)] out object? obj) {
+        public bool TryGetStreams(int id, [NotNullWhen(true)] out StreamBox? streams) {
             lock (_synchObject) {
-                return _objects.TryGetValue(id, out obj);
+                return _table.TryGetValue(id, out streams);
             }
         }
 
-        public bool TryGetFileFromId(int id, [NotNullWhen(true)] out Modules.PythonIOModule.FileIO? file) {
-            TryGetObjectFromId(id, out object? obj);
-            file = obj as Modules.PythonIOModule.FileIO;
-            return file is not null;
-        }
-
-        public bool TryGetStreamFromId(int id, [NotNullWhen(true)] out Stream? stream) {
-            TryGetObjectFromId(id, out object? obj);
-            stream = obj as Stream;
-            return stream is not null;
-        }
-
-        public object GetObjectFromId(int id) {
-            if (TryGetObjectFromId(id, out object? obj)) {
-               return obj;
+        public StreamBox GetStreams(int id) {
+            if (TryGetStreams(id, out StreamBox? streams)) {
+               return streams;
             }
             throw PythonOps.OSError(9, "Bad file descriptor");
         }
 
-        public Modules.PythonIOModule.FileIO GetFileFromId(int id) {
-            if (TryGetFileFromId(id, out Modules.PythonIOModule.FileIO? file)) {
-                return file;
+        public int GetOrAssignId(StreamBox streams) {
+            lock (_synchObject) {
+                int res = streams.Id;
+                if (res == -1) {
+                    res = Add(streams);
+                }
+                return res;
             }
-            throw PythonOps.OSError(9, "Bad file descriptor");
-        }
-
-        public Stream GetStreamFromId(int id) {
-            if (TryGetStreamFromId(id, out Stream? stream)) {
-                return stream;
-            }
-            throw PythonOps.OSError(9, "Bad file descriptor");
         }
 
         public void EnsureRef(Stream stream) {
@@ -175,27 +267,6 @@ namespace IronPython.Runtime {
                 return true;
             }
             return false;
-        }
-
-        public int GetOrAssignId(object obj) {
-            lock (_synchObject) {
-                int res = GetIdFromObject(obj);
-                if (res == -1) {
-                    res = Add(obj);
-                }
-                return res;
-            }
-        }
-
-        public int GetIdFromObject(object obj) {
-            lock (_synchObject) {
-                foreach (KeyValuePair<int, object> kvp in _objects) {
-                    if (ReferenceEquals(kvp.Value, obj)) {
-                        return kvp.Key;
-                    }
-                }
-            }
-            return -1;
         }
 
         public bool ValidateFdRange(int fd) {


### PR DESCRIPTION
This is the second pass of redesign of `PythonFileManager` and `FileIO`. There should be no functional changes (except for some small increase in compatibility with CPython). Basically, a part of `FileIO` has been factored out into `StreamBox`. This has several benefits:

* It simplifies the API of `PythonFileManager`, which now contains only one type of objects and the API becomes strongly typed. The callers do not need to wrestle with downcasting and having different code paths for different type object, which was not done consistently. Indeed, in some places, only one type of objects was handled.
* `StreamBox`, unlike `FileIO`, is not disposable and does not have a finalizer. This should reduce the pressure on the GC, esp. when files are opened using the `PyhonNT` API. 
* It sets the stage to finally implement `dup2` correctly, which is currently half-broken.

The handling and detection of TTY/Console streams remains tricky, not to a small extent because it is not always clear to me what the expected/desired/CPython behaviour is in all cases across all OSes, various console support levels, IO piping/redirecting, combined with reassigned (or not) IO in embedding scenarios. All I can say is that the current behaviour should not have changed much, and where it did, it's more in line with CPython's.