### PR TITLE
Performance improvements of reading and writing through StreamBox

### DIFF
--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -1802,13 +1802,12 @@ namespace IronPython.Modules {
 
         public static int write(CodeContext/*!*/ context, int fd, [NotNone] IBufferProtocol data) {
             try {
+                using var buffer = data.GetBuffer();
                 PythonContext pythonContext = context.LanguageContext;
                 var streams = pythonContext.FileManager.GetStreams(fd);
-                using var buffer = data.GetBuffer();
-                var bytes = buffer.AsReadOnlySpan();
                 if (!streams.WriteStream.CanWrite) throw PythonOps.OSError(9, "Bad file descriptor");
 
-                return streams.Write(bytes);
+                return streams.Write(buffer);
             } catch (Exception e) {
                 throw ToPythonException(e);
             }

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -351,14 +351,7 @@ namespace IronPython.Modules {
 
                 _checkClosed();
 
-                var span = pythonBuffer.AsSpan();
-                for (int i = 0; i < span.Length; i++) {
-                    int b = _streams.ReadStream.ReadByte();
-                    if (b == -1) return i;
-                    span[i] = (byte)b;
-                }
-
-                return span.Length;
+                return _streams.ReadInto(pythonBuffer);
             }
 
             public override BigInteger readinto(CodeContext/*!*/ context, object buf) {
@@ -444,10 +437,9 @@ namespace IronPython.Modules {
             public override BigInteger write(CodeContext/*!*/ context, object b) {
                 var bufferProtocol = Converter.Convert<IBufferProtocol>(b);
                 using var buffer = bufferProtocol.GetBuffer();
-                var bytes = buffer.AsReadOnlySpan();
 
                 EnsureWritable();
-                return _streams.Write(bytes);
+                return _streams.Write(buffer);
             }
 
             #endregion


### PR DESCRIPTION
This PR is intended to improve performance on .NET Framework and Mono. .NET (Core), with its `Span`-aware API does not have those performance issues. The main use case is `bytearray` as the buffer. AFAICS, this addition should cover all built-in types plus .NET types, except for `array.array`.

The unsafe `IPythoBuffer` helpers will do their best to extract the underlying CLI-array, to avoid a data copy or the wicked loop spin (see https://github.com/IronLanguages/ironpython3/pull/1729#discussion_r1299501437). This code path may perhaps be not the most popular one, but I thought I saw "opportunities" like this in other places too. At least this will serve as a sample solution.