### PR TITLE
Fix issue with timestamp timezone

### DIFF
--- a/Src/IronPython.Modules/_datetime.cs
+++ b/Src/IronPython.Modules/_datetime.cs
@@ -1036,7 +1036,7 @@ namespace IronPython.Modules {
 
             public double timestamp() {
                 if (tzinfo is null) {
-                    return PythonTime.TicksToTimestamp(_dateTime.Ticks);
+                    return PythonTime.TicksToTimestamp(_dateTime.ToUniversalTime().Ticks);
                 }
                 else {
                     return (this - new datetime(new DateTime(1970, 1, 1), timezone.utc)).total_seconds();

--- a/Tests/test_datetime.py
+++ b/Tests/test_datetime.py
@@ -126,6 +126,11 @@ class TestDatetime(unittest.TestCase):
         ts = 5399410716.777882
         self.assertEqual(datetime.datetime.fromtimestamp(ts).microsecond, 777882)
 
+    def test_timestamp(self):
+        # https://github.com/IronLanguages/ironpython3/pull/1740
+        dt = datetime.datetime(2000, 1, 1)
+        self.assertEqual(datetime.datetime.fromtimestamp(dt.timestamp()), dt)
+
     @skipUnlessIronPython()
     def test_System_DateTime_conversion(self):
         import clr


### PR DESCRIPTION
Expecting timestamp to roundtrip:
```py
d = datetime.datetime(2000,1,1)
assert datetime.datetime.fromtimestamp(d.timestamp()) == d
```