### PR TITLE
Update Parser.cs

### DIFF
--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -3090,7 +3090,10 @@ namespace IronPython.Compiler {
             while (true) {
                 if (MaybeEat(TokenKind.EndOfFile)) break;
                 if (MaybeEatNewLine()) continue;
-
+                if (l.Count == 0)
+                {
+                    l.Add(new EmptyStatement());
+                }
                 Statement s = ParseStmt();
                 l.Add(s);
             }


### PR DESCRIPTION
In the DebugInfoRewriter class within Microsoft.Dynamic.dll, the VisitParameter method adds debugging information starting from the second Expression. This causes the first line of code to lack debugging information, making it undebuggable.