### PR TITLE
Update Parser.cs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest-large]
+
+    steps:
+    - name: Install tools
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get -yq install mono-vbnc dos2unix
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '3.1.x'
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    - name: Version Information
+      run: |
+        dotnet --info
+        try { msbuild -version } catch { }
+        try { mono --version } catch { }
+      shell: pwsh
+    - name: Build
+      run: pwsh make.ps1
+    - name: Package
+      run: pwsh make.ps1 package
+    - uses: actions/upload-artifact@v4
+      with:
+        name: packages-${{ matrix.os }}
+        path: Package/Release/Packages
+    - name: Test (net462)
+      run: ./make.ps1 -frameworks net462 test-all
+      shell: pwsh
+    - name: Test (netcoreapp3.1)
+      run: ./make.ps1 -frameworks netcoreapp3.1 test-all
+      shell: pwsh
+    - name: Test (net6.0)
+      run: ./make.ps1 -frameworks net6.0 test-all
+      shell: pwsh
+    - name: Test (net8.0)
+      run: ./make.ps1 -frameworks net8.0 test-all
+      shell: pwsh

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -3095,6 +3095,7 @@ namespace IronPython.Compiler {
                 l.Add(s);
             }
 
+            l.Insert(0, new EmptyStatement());
             Statement[] stmts = l.ToArray();
 
             if (returnValue && stmts.Length > 0) {


### PR DESCRIPTION
In the DebugInfoRewriter class within Microsoft.Dynamic.dll, the VisitParameter method adds debugging information starting from the second Expression. This causes the first line of code to lack debugging information, making it undebuggable.