### PR TITLE
Code Quality: Update source to show .NET Foundation copyright

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,8 @@
     <AssemblyFileRevision Condition="'$(ReleaseLevel)' == 'final'">1000</AssemblyFileRevision>
 
     <Product>IronPython</Product>
-    <Company>IronPython Team</Company>
-    <Copyright>© IronPython Contributors</Copyright>
+    <Company>.NET Foundation</Company>
+    <Copyright>© .NET Foundation and Contributors</Copyright>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).$(MicroVersion).$(AssemblyRevision)</AssemblyVersion>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(MicroVersion).$(AssemblyFileRevision)</FileVersion>
     <InformationalVersion>$(MSBuildProjectName) $(MajorVersion).$(MinorVersion).$(MicroVersion) $(ReleaseLevel) $(ReleaseSerial)</InformationalVersion>

--- a/Package/msi/Version.wxi
+++ b/Package/msi/Version.wxi
@@ -1,4 +1,4 @@
 ﻿<Include Id="VersionNumberInclude" xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <?define ProductShortName = "IronPython" ?>
-  <?define Manufacturer = "IronPython Team" ?>
+  <?define Manufacturer = ".NET Foundation" ?>
 </Include>

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -29,7 +29,7 @@ namespace IronPython.Modules {
         // argv is set by PythonContext and only on the initial load
         public static readonly string byteorder = BitConverter.IsLittleEndian ? "little" : "big";
         // builtin_module_names is set by PythonContext and updated on reload
-        public const string copyright = "Copyright (c) IronPython Team";
+        public const string copyright = "Copyright (c) .NET Foundation and Contributors";
 
         private static string GetPrefix() {
             string prefix;


### PR DESCRIPTION
Hi there (again)!
I noticed that the .NET Foundation copyright was missing from some source files and instead showed "IronPython Team", which isn't the official licenseholder specified in the LICENSE file in the root directory.
This is a small fix to change that to the .NET Foundation. <!--(aside from .NET Foundation being the official owner, attributing the project with the official .NET foundation would probably help to make the project seem more like a major project from .NET 😄)-->