### PR TITLE
Improve performance on struct.unpack

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -121,7 +121,7 @@
 
   <!-- Release -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugSymbols>false</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>

--- a/Src/IronPython.Modules/_ctypes/_ctypes.cs
+++ b/Src/IronPython.Modules/_ctypes/_ctypes.cs
@@ -688,10 +688,6 @@ namespace IronPython.Modules {
             return intPtrHandle;
         }
 
-        private static void ValidateArraySizes(ArrayModule.array array, int offset, int size) {
-            ValidateArraySizes(array.__len__() * array.itemsize, offset, size);
-        }
-
         private static void ValidateArraySizes(int arraySize, int offset, int size) {
             if (offset < 0) {
                 throw PythonOps.ValueError("offset cannot be negative");

--- a/Src/IronPython.Modules/_struct.cs
+++ b/Src/IronPython.Modules/_struct.cs
@@ -60,7 +60,7 @@ namespace IronPython.Modules {
             }
 
             [Documentation("creates a new uninitialized struct object - all arguments are ignored")]
-            public Struct([ParamDictionary]IDictionary<object, object> kwArgs, params object[] args) {
+            public Struct([ParamDictionary] IDictionary<object, object> kwArgs, params object[] args) {
             }
 
             [Documentation("initializes or re-initializes the compiled struct object with a new format")]
@@ -372,7 +372,6 @@ namespace IronPython.Modules {
                 System.Diagnostics.Debug.Assert(res_idx == res.Length);
 
                 return PythonTuple.MakeTuple(res);
-
             }
 
             public PythonTuple/*!*/ unpack(CodeContext/*!*/ context, [NotNone] ArrayModule.array/*!*/ buffer)
@@ -1207,16 +1206,16 @@ namespace IronPython.Modules {
         #region Data creater helpers
 
         internal static bool CreateBoolValue(CodeContext/*!*/ context, ref int index, IList<byte> data) {
-            return (int)ReadData(context, ref index, data) != 0;
+            return data[index++] != 0;
         }
 
         internal static byte CreateCharValue(CodeContext/*!*/ context, ref int index, IList<byte> data) {
-            return ReadData(context, ref index, data);
+            return data[index++];
         }
 
         internal static short CreateShortValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
-            byte b1 = (byte)ReadData(context, ref index, data);
-            byte b2 = (byte)ReadData(context, ref index, data);
+            byte b1 = data[index++];
+            byte b2 = data[index++];
 
             if (fLittleEndian) {
                 return (short)((b2 << 8) | b1);
@@ -1226,8 +1225,8 @@ namespace IronPython.Modules {
         }
 
         internal static ushort CreateUShortValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
-            byte b1 = (byte)ReadData(context, ref index, data);
-            byte b2 = (byte)ReadData(context, ref index, data);
+            byte b1 = data[index++];
+            byte b2 = data[index++];
 
             if (fLittleEndian) {
                 return (ushort)((b2 << 8) | b1);
@@ -1238,16 +1237,16 @@ namespace IronPython.Modules {
 
         internal static float CreateFloatValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
             byte[] bytes = new byte[4];
-            if (fLittleEndian) {
-                bytes[0] = (byte)ReadData(context, ref index, data);
-                bytes[1] = (byte)ReadData(context, ref index, data);
-                bytes[2] = (byte)ReadData(context, ref index, data);
-                bytes[3] = (byte)ReadData(context, ref index, data);
+            if (fLittleEndian == BitConverter.IsLittleEndian) {
+                bytes[0] = data[index++];
+                bytes[1] = data[index++];
+                bytes[2] = data[index++];
+                bytes[3] = data[index++];
             } else {
-                bytes[3] = (byte)ReadData(context, ref index, data);
-                bytes[2] = (byte)ReadData(context, ref index, data);
-                bytes[1] = (byte)ReadData(context, ref index, data);
-                bytes[0] = (byte)ReadData(context, ref index, data);
+                bytes[3] = data[index++];
+                bytes[2] = data[index++];
+                bytes[1] = data[index++];
+                bytes[0] = data[index++];
             }
             float res = BitConverter.ToSingle(bytes, 0);
 
@@ -1261,10 +1260,10 @@ namespace IronPython.Modules {
         }
 
         internal static int CreateIntValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
-            byte b1 = (byte)ReadData(context, ref index, data);
-            byte b2 = (byte)ReadData(context, ref index, data);
-            byte b3 = (byte)ReadData(context, ref index, data);
-            byte b4 = (byte)ReadData(context, ref index, data);
+            byte b1 = data[index++];
+            byte b2 = data[index++];
+            byte b3 = data[index++];
+            byte b4 = data[index++];
 
             if (fLittleEndian)
                 return (int)((b4 << 24) | (b3 << 16) | (b2 << 8) | b1);
@@ -1273,10 +1272,10 @@ namespace IronPython.Modules {
         }
 
         internal static uint CreateUIntValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
-            byte b1 = (byte)ReadData(context, ref index, data);
-            byte b2 = (byte)ReadData(context, ref index, data);
-            byte b3 = (byte)ReadData(context, ref index, data);
-            byte b4 = (byte)ReadData(context, ref index, data);
+            byte b1 = data[index++];
+            byte b2 = data[index++];
+            byte b3 = data[index++];
+            byte b4 = data[index++];
 
             if (fLittleEndian)
                 return (uint)((b4 << 24) | (b3 << 16) | (b2 << 8) | b1);
@@ -1285,14 +1284,14 @@ namespace IronPython.Modules {
         }
 
         internal static long CreateLongValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
-            long b1 = (byte)ReadData(context, ref index, data);
-            long b2 = (byte)ReadData(context, ref index, data);
-            long b3 = (byte)ReadData(context, ref index, data);
-            long b4 = (byte)ReadData(context, ref index, data);
-            long b5 = (byte)ReadData(context, ref index, data);
-            long b6 = (byte)ReadData(context, ref index, data);
-            long b7 = (byte)ReadData(context, ref index, data);
-            long b8 = (byte)ReadData(context, ref index, data);
+            long b1 = data[index++];
+            long b2 = data[index++];
+            long b3 = data[index++];
+            long b4 = data[index++];
+            long b5 = data[index++];
+            long b6 = data[index++];
+            long b7 = data[index++];
+            long b8 = data[index++];
 
             if (fLittleEndian)
                 return (long)((b8 << 56) | (b7 << 48) | (b6 << 40) | (b5 << 32) |
@@ -1303,14 +1302,14 @@ namespace IronPython.Modules {
         }
 
         internal static ulong CreateULongValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
-            ulong b1 = (byte)ReadData(context, ref index, data);
-            ulong b2 = (byte)ReadData(context, ref index, data);
-            ulong b3 = (byte)ReadData(context, ref index, data);
-            ulong b4 = (byte)ReadData(context, ref index, data);
-            ulong b5 = (byte)ReadData(context, ref index, data);
-            ulong b6 = (byte)ReadData(context, ref index, data);
-            ulong b7 = (byte)ReadData(context, ref index, data);
-            ulong b8 = (byte)ReadData(context, ref index, data);
+            ulong b1 = data[index++];
+            ulong b2 = data[index++];
+            ulong b3 = data[index++];
+            ulong b4 = data[index++];
+            ulong b5 = data[index++];
+            ulong b6 = data[index++];
+            ulong b7 = data[index++];
+            ulong b8 = data[index++];
             if (fLittleEndian)
                 return (ulong)((b8 << 56) | (b7 << 48) | (b6 << 40) | (b5 << 32) |
                                 (b4 << 24) | (b3 << 16) | (b2 << 8) | b1);
@@ -1321,24 +1320,24 @@ namespace IronPython.Modules {
 
         internal static double CreateDoubleValue(CodeContext/*!*/ context, ref int index, bool fLittleEndian, IList<byte> data) {
             byte[] bytes = new byte[8];
-            if (fLittleEndian) {
-                bytes[0] = (byte)ReadData(context, ref index, data);
-                bytes[1] = (byte)ReadData(context, ref index, data);
-                bytes[2] = (byte)ReadData(context, ref index, data);
-                bytes[3] = (byte)ReadData(context, ref index, data);
-                bytes[4] = (byte)ReadData(context, ref index, data);
-                bytes[5] = (byte)ReadData(context, ref index, data);
-                bytes[6] = (byte)ReadData(context, ref index, data);
-                bytes[7] = (byte)ReadData(context, ref index, data);
+            if (fLittleEndian == BitConverter.IsLittleEndian) {
+                bytes[0] = data[index++];
+                bytes[1] = data[index++];
+                bytes[2] = data[index++];
+                bytes[3] = data[index++];
+                bytes[4] = data[index++];
+                bytes[5] = data[index++];
+                bytes[6] = data[index++];
+                bytes[7] = data[index++];
             } else {
-                bytes[7] = (byte)ReadData(context, ref index, data);
-                bytes[6] = (byte)ReadData(context, ref index, data);
-                bytes[5] = (byte)ReadData(context, ref index, data);
-                bytes[4] = (byte)ReadData(context, ref index, data);
-                bytes[3] = (byte)ReadData(context, ref index, data);
-                bytes[2] = (byte)ReadData(context, ref index, data);
-                bytes[1] = (byte)ReadData(context, ref index, data);
-                bytes[0] = (byte)ReadData(context, ref index, data);
+                bytes[7] = data[index++];
+                bytes[6] = data[index++];
+                bytes[5] = data[index++];
+                bytes[4] = data[index++];
+                bytes[3] = data[index++];
+                bytes[2] = data[index++];
+                bytes[1] = data[index++];
+                bytes[0] = data[index++];
             }
 
             double res = BitConverter.ToDouble(bytes, 0);
@@ -1354,30 +1353,25 @@ namespace IronPython.Modules {
         internal static Bytes CreateString(CodeContext/*!*/ context, ref int index, int count, IList<byte> data) {
             using var res = new MemoryStream();
             for (int i = 0; i < count; i++) {
-                res.WriteByte(ReadData(context, ref index, data));
+                res.WriteByte(data[index++]);
             }
             return Bytes.Make(res.ToArray());
         }
 
 
         internal static Bytes CreatePascalString(CodeContext/*!*/ context, ref int index, int count, IList<byte> data) {
-            int realLen = (int)ReadData(context, ref index, data);
+            int realLen = (int)data[index++];
             using var res = new MemoryStream();
             for (int i = 0; i < realLen; i++) {
-                res.WriteByte(ReadData(context, ref index, data));
+                res.WriteByte(data[index++]);
             }
             for (int i = realLen; i < count; i++) {
                 // throw away null bytes
-                ReadData(context, ref index, data);
+                index++;
             }
             return Bytes.Make(res.ToArray());
         }
 
-        private static byte ReadData(CodeContext/*!*/ context, ref int index, IList<byte> data) {
-            if (index >= data.Count) throw Error(context, "not enough data while reading");
-
-            return data[index++];
-        }
         #endregion
 
         #region Misc. Private APIs

--- a/Src/IronPython.Modules/re.cs
+++ b/Src/IronPython.Modules/re.cs
@@ -734,12 +734,15 @@ namespace IronPython.Modules {
                             return bytes.MakeString();
                         case ByteArray byteArray:
                             return byteArray.MakeString();
-                        case ArrayModule.array array:
-                            return Bytes.Make(array.ToByteArray()).MakeString();
 #if FEATURE_MMAP
                         case MmapModule.MmapDefault mmapFile:
                             return mmapFile.GetSearchString().MakeString();
 #endif
+                        case IBufferProtocol bufferProtocol: {
+                                using var buffer = bufferProtocol.GetBuffer();
+                                return buffer.AsReadOnlySpan().MakeString();
+                            }
+
                         default:
                             throw PythonOps.TypeError($"expected string or bytes-like object");
                     }

--- a/Src/StdLib/Lib/test/test_struct.py
+++ b/Src/StdLib/Lib/test/test_struct.py
@@ -542,13 +542,13 @@ class StructTest(unittest.TestCase):
 
         # format lists containing only count spec should result in an error
         self.assertRaises(struct.error, struct.pack, '12345')
-        self.assertRaises(struct.error, struct.unpack, '12345', '')
+        self.assertRaises(struct.error, struct.unpack, '12345', b'')
         self.assertRaises(struct.error, struct.pack_into, '12345', store, 0)
         self.assertRaises(struct.error, struct.unpack_from, '12345', store, 0)
 
         # Format lists with trailing count spec should result in an error
         self.assertRaises(struct.error, struct.pack, 'c12345', 'x')
-        self.assertRaises(struct.error, struct.unpack, 'c12345', 'x')
+        self.assertRaises(struct.error, struct.unpack, 'c12345', b'x')
         self.assertRaises(struct.error, struct.pack_into, 'c12345', store, 0,
                            'x')
         self.assertRaises(struct.error, struct.unpack_from, 'c12345', store,
@@ -557,7 +557,7 @@ class StructTest(unittest.TestCase):
         # Mixed format tests
         self.assertRaises(struct.error, struct.pack, '14s42', 'spam and eggs')
         self.assertRaises(struct.error, struct.unpack, '14s42',
-                          'spam and eggs')
+                          b'spam and eggs')
         self.assertRaises(struct.error, struct.pack_into, '14s42', store, 0,
                           'spam and eggs')
         self.assertRaises(struct.error, struct.unpack_from, '14s42', store, 0)

--- a/Tests/test_struct_stdlib.py
+++ b/Tests/test_struct_stdlib.py
@@ -15,12 +15,10 @@ def load_tests(loader, standard_tests, pattern):
 
     if is_ironpython:
         failing_tests = [
-            test.test_struct.StructTest('test_705836'), # TODO: figure out
-            test.test_struct.StructTest('test_bool'), # TODO: figure out
-            test.test_struct.StructTest('test_calcsize'), # TODO: figure out
-            test.test_struct.StructTest('test_count_overflow'), # TODO: figure out
-            test.test_struct.StructTest('test_trailing_counter'), # TODO: figure out
-            test.test_struct.UnpackIteratorTest('test_construct'), # TODO: figure out
+            test.test_struct.StructTest('test_705836'), # AssertionError: OverflowError not raised by pack
+            test.test_struct.StructTest('test_bool'), # struct.error: expected bool value got IronPython.NewTypes.System.Object_1$1
+            test.test_struct.StructTest('test_calcsize'), # AssertionError: 4 not greater than or equal to 8
+            test.test_struct.StructTest('test_count_overflow'), # AssertionError: error not raised by calcsize
         ]
 
         return generate_suite(tests, failing_tests)


### PR DESCRIPTION
Improves performance on struct.unpack and fixes some failing tests.

Also removes array overloads which are covered by the buffer protocol.