### PR TITLE
Display array base when nonzero

### DIFF
--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -214,24 +214,29 @@ namespace IronPython.Runtime.Operations {
                     ret.Append("Array[");
                     Type elemType = self.GetType().GetElementType()!;
                     ret.Append(DynamicHelpers.GetPythonTypeFromType(elemType).Name);
-                    ret.Append("]");
+                    ret.Append(']');
                     ret.Append("((");
                     for (int i = 0; i < self.Length; i++) {
                         if (i > 0) ret.Append(", ");
                         ret.Append(PythonOps.Repr(context, self.GetValue(i + self.GetLowerBound(0))));
                     }
-                    ret.Append("))");
+                    ret.Append(')');
+                    if (self.GetLowerBound(0) != 0) {
+                        ret.Append(", base: ");
+                        ret.Append(self.GetLowerBound(0));
+                    }
+                    ret.Append(')');
                 } else {
                     // multi dimensional arrays require multiple statements to construct so we just
                     // give enough info to identify the object and its type.
-                    ret.Append("<");
+                    ret.Append('<');
                     ret.Append(self.Rank);
                     ret.Append(" dimensional Array[");
                     Type elemType = self.GetType().GetElementType()!;
                     ret.Append(DynamicHelpers.GetPythonTypeFromType(elemType).Name);
                     ret.Append("] at ");
                     ret.Append(PythonOps.HexId(self));
-                    ret.Append(">");
+                    ret.Append('>');
                 }
                 return ret.ToString();
             } finally {

--- a/Tests/test_array.py
+++ b/Tests/test_array.py
@@ -180,7 +180,7 @@ class ArrayTest(IronPythonTestCase):
         self.assertEqual(a[2:4], System.Array[int]((2,3)))
         self.assertEqual(a[-1], 4)
 
-        self.assertEqual(repr(a), 'Array[int]((0, 1, 2, 3, 4))')
+        self.assertEqual(repr(a), 'Array[int]((0, 1, 2, 3, 4), base: 5)')
 
         a = System.Array.CreateInstance(int, (5,), (15,))
         b = System.Array.CreateInstance(int, (5,), (20,))


### PR DESCRIPTION
This is one of several changes I have stashed since several years ago that never got to the top of the priority list because the functionality looked so fringe or insignificant. I am submitting them now, before the code restructuring tsunami hits.

One of the oddities of .NET is support of arbitrary-based arrays. They are clumsy to create and use, esp. in strongly typed languages, but there they are. Support of them in IronPython is somewhat unfinished, probably for good reason, since it is such a fringe concept, and perhaps never used in anything serious.

Since two arrays with identical content but different bases (lower bounds) are **not** the same, their `repr` string should be different. This PR adds the display of the base in case it is non-zero.