### PR TITLE
Get rid of ArrayUtils.EmptyObjects

### DIFF
--- a/Src/IronPython.Modules/_thread.cs
+++ b/Src/IronPython.Modules/_thread.cs
@@ -228,9 +228,9 @@ namespace IronPython.Modules {
                 try {
 #pragma warning disable 618 // TODO: obsolete
                     if (_kwargs != null) {
-                        PythonOps.CallWithArgsTupleAndKeywordDictAndContext(_context, _func, ArrayUtils.EmptyObjects, ArrayUtils.EmptyStrings, _args, _kwargs);
+                        PythonOps.CallWithArgsTupleAndKeywordDictAndContext(_context, _func, [], [], _args, _kwargs);
                     } else {
-                        PythonOps.CallWithArgsTuple(_func, ArrayUtils.EmptyObjects, _args);
+                        PythonOps.CallWithArgsTuple(_func, [], _args);
                     }
 #pragma warning restore 618
                 } catch (SystemExitException) {

--- a/Src/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -15,7 +15,6 @@ using System.Threading;
 using IronPython.Runtime;
 
 using Microsoft.Scripting;
-using Microsoft.Scripting.Actions;
 using Microsoft.Scripting.Utils;
 
 using AstUtils = Microsoft.Scripting.Ast.Utils;
@@ -403,7 +402,7 @@ namespace IronPython.Compiler.Ast {
 
                 if (parameters.Count == 0) {
                     // no point analyzing function with no parameters
-                    return ArrayUtils.EmptyStrings;
+                    return [];
                 }
 
                 var finder = new SelfNameFinder(function, parameters[0]);

--- a/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/Src/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -5,21 +5,20 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
-using System.Runtime.CompilerServices;
+
+using IronPython.Runtime;
+using IronPython.Runtime.Operations;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Interpreter;
 using Microsoft.Scripting.Utils;
 
-using IronPython.Runtime;
-using IronPython.Runtime.Operations;
-
-using MSAst = System.Linq.Expressions;
-
-using LightLambdaExpression = Microsoft.Scripting.Ast.LightLambdaExpression;
 using AstUtils = Microsoft.Scripting.Ast.Utils;
+using LightLambdaExpression = Microsoft.Scripting.Ast.LightLambdaExpression;
+using MSAst = System.Linq.Expressions;
 
 namespace IronPython.Compiler.Ast {
     using Ast = MSAst.Expression;
@@ -85,8 +84,7 @@ namespace IronPython.Compiler.Ast {
         internal override int ArgCount {
             get {
                 int argCount = 0;
-                for (argCount = 0; argCount < _parameters.Length; argCount++)
-                {
+                for (argCount = 0; argCount < _parameters.Length; argCount++) {
                     Parameter p = _parameters[argCount];
                     if (p.IsDictionary || p.IsList || p.IsKeywordOnly) break;
                 }
@@ -256,7 +254,7 @@ namespace IronPython.Compiler.Ast {
                 NeedsLocalsDictionary = true;
             }
         }
-        
+
         internal override void FinishBind(PythonNameBinder binder) {
             foreach (var param in _parameters) {
                 _variableMapping[param.PythonVariable] = param.FinishBind(forceClosureCell: ExposesLocalVariable(param.PythonVariable));
@@ -286,7 +284,7 @@ namespace IronPython.Compiler.Ast {
                 new SourceSpan(GlobalParent.IndexToLocation(StartIndex), GlobalParent.IndexToLocation(HeaderIndex))
             );
         }
-        
+
         /// <summary>
         /// Returns an expression which creates the function object.
         /// </summary>
@@ -542,7 +540,7 @@ namespace IronPython.Compiler.Ast {
                         defaults[i] = frame.Pop();
                     }
                 } else {
-                    defaults = ArrayUtils.EmptyObjects;
+                    defaults = [];
                 }
 
                 object modName;
@@ -779,7 +777,7 @@ namespace IronPython.Compiler.Ast {
 
             return res;
         }
-        
+
         private void InitializeParameters(List<MSAst.Expression> init, bool needsWrapperMethod, MSAst.Expression[] parameters) {
             for (int i = 0; i < _parameters.Length; i++) {
                 Parameter p = _parameters[i];
@@ -829,10 +827,10 @@ namespace IronPython.Compiler.Ast {
 
         internal override void RewriteBody(MSAst.ExpressionVisitor visitor) {
             _dlrBody = null;    // clear the cached body if we've been reduced
-            
+
             MSAst.Expression funcCode = GlobalParent.Constant(GetOrMakeFunctionCode());
             FuncCodeExpr = funcCode;
-            
+
             Body = new RewrittenBodyStatement(Body, visitor.Visit(Body));
         }
 

--- a/Src/IronPython/Compiler/Ast/ScopeStatement.cs
+++ b/Src/IronPython/Compiler/Ast/ScopeStatement.cs
@@ -92,7 +92,7 @@ namespace IronPython.Compiler.Ast {
         ///
         /// It is used to ensure that the first argument is accessible through a closure cell.
         /// </summary>
-        internal bool ContainsSuperCall{ get; set; }
+        internal bool ContainsSuperCall { get; set; }
 
         public virtual string Name => "<unknown scope>";
 
@@ -116,7 +116,7 @@ namespace IronPython.Compiler.Ast {
         internal bool NeedsLocalContext
             => NeedsLocalsDictionary || ContainsNestedFreeVariables || ContainsSuperCall;
 
-        internal virtual string[] ParameterNames => ArrayUtils.EmptyStrings;
+        internal virtual string[] ParameterNames => [];
 
         internal virtual int ArgCount => 0;
 
@@ -439,7 +439,7 @@ namespace IronPython.Compiler.Ast {
         }
 
         internal void EnsureNonlocalVariable(string name, NonlocalStatement node) {
-           _nonlocalVars ??= new();
+            _nonlocalVars ??= new();
             if (!_nonlocalVars.ContainsKey(name)) {
                 CreateNonlocalVariable(name);
                 _nonlocalVars[name] = node;
@@ -611,7 +611,7 @@ namespace IronPython.Compiler.Ast {
 
         internal MSAst.MethodCallExpression CreateLocalContext(MSAst.Expression parentContext, bool newNamespace = true) {
             var closureVariables = _closureVariables ?? Array.Empty<ClosureInfo>();
-            
+
             int numFreeVars = FreeVariables?.Count ?? 0;
             int firstArgIdx = -1;
             if ((NeedsLocalsDictionary || ContainsSuperCall) && ArgCount > 0) {

--- a/Src/IronPython/Compiler/Parser.cs
+++ b/Src/IronPython/Compiler/Parser.cs
@@ -804,7 +804,7 @@ namespace IronPython.Compiler {
                 dotCount++;
             }
 
-            string[] names = ArrayUtils.EmptyStrings;
+            string[] names = [];
             if (PeekToken() is NameToken) {
                 names = ReadNames();
             }

--- a/Src/IronPython/Runtime/Binding/WarningInfo.cs
+++ b/Src/IronPython/Runtime/Binding/WarningInfo.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Dynamic;
 using System.Linq.Expressions;
 
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
-using Microsoft.Scripting.Utils;
 
 using AstUtils = Microsoft.Scripting.Ast.Utils;
 
@@ -29,7 +29,7 @@ namespace IronPython.Runtime.Binding {
                 codeContext,
                 AstUtils.Constant(_type),
                 AstUtils.Constant(_message),
-                AstUtils.Constant(ArrayUtils.EmptyObjects)
+                AstUtils.Constant(Array.Empty<object>())
             );
 
             if (_condition != null) {

--- a/Src/IronPython/Runtime/BuiltinPythonModule.cs
+++ b/Src/IronPython/Runtime/BuiltinPythonModule.cs
@@ -2,9 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+
 using IronPython.Compiler;
+
 using Microsoft.Scripting.Utils;
 
 namespace IronPython.Runtime {
@@ -50,7 +51,7 @@ namespace IronPython.Runtime {
         /// direct access to global members.
         /// </summary>
         protected internal virtual IEnumerable<string/*!*/>/*!*/ GetGlobalVariableNames() {
-            return ArrayUtils.EmptyStrings;
+            return [];
         }
 
         /// <summary>

--- a/Src/IronPython/Runtime/Converter.cs
+++ b/Src/IronPython/Runtime/Converter.cs
@@ -532,7 +532,7 @@ namespace IronPython.Runtime {
         private static TypeConverter GetTypeConverter(TypeConverterAttribute tca) {
             try {
                 ConstructorInfo ci = Type.GetType(tca.ConverterTypeName).GetConstructor(ReflectionUtils.EmptyTypes);
-                if (ci != null) return ci.Invoke(ArrayUtils.EmptyObjects) as TypeConverter;
+                if (ci != null) return ci.Invoke([]) as TypeConverter;
             } catch (TargetInvocationException) {
             }
             return null;

--- a/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
+++ b/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
@@ -6,11 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Dynamic;
 using System.IO;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -122,7 +119,7 @@ namespace IronPython.Runtime.Exceptions {
         }
 
         public partial class _OSError {
-            public static new object __new__(PythonType cls, [ParamDictionary]IDictionary<string, object> kwArgs, params object[] args) {
+            public static new object __new__(PythonType cls, [ParamDictionary] IDictionary<string, object> kwArgs, params object[] args) {
                 if (cls == OSError && args.Length >= 1 && args[0] is int errno) {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                         if (args.Length >= 4 && args[3] is int winerror) {
@@ -223,8 +220,7 @@ namespace IronPython.Runtime.Exceptions {
             }
 
             private static PythonType ErrnoToPythonType(Error errno) {
-                var res = errno switch
-                {
+                var res = errno switch {
                     Error.EPERM => PermissionError,
                     Error.ENOENT => FileNotFoundError,
                     Error.ESRCH => ProcessLookupError,
@@ -239,8 +235,7 @@ namespace IronPython.Runtime.Exceptions {
                     _ => null
                 };
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                    res ??= errno switch
-                    {
+                    res ??= errno switch {
                         // Windows or remapped OSX
                         Error.WSAEWOULDBLOCK => BlockingIOError,
                         Error.WSAEINPROGRESS => BlockingIOError,
@@ -253,8 +248,7 @@ namespace IronPython.Runtime.Exceptions {
                         _ => null
                     };
                 } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                    res ??= errno switch
-                    {
+                    res ??= errno switch {
                         // Linux
                         Error.ECONNABORTED => ConnectionAbortedError,
                         Error.ECONNRESET => ConnectionResetError,
@@ -529,7 +523,7 @@ for k, v in toError.items():
         }
 
         public partial class _ImportError {
-            public void __init__([ParamDictionary]IDictionary<string, object> kwargs, params object[] args) {
+            public void __init__([ParamDictionary] IDictionary<string, object> kwargs, params object[] args) {
                 base.__init__(args);
 
                 foreach (var pair in kwargs) {
@@ -702,7 +696,7 @@ for k, v in toError.items():
             if (PythonOps.IsInstance(value, type)) {
                 pyEx = value;
             } else if (value is PythonTuple) {
-                pyEx = PythonOps.CallWithArgsTuple(type, ArrayUtils.EmptyObjects, value);
+                pyEx = PythonOps.CallWithArgsTuple(type, [], value);
             } else if (value != null) {
                 pyEx = PythonCalls.Call(context, type, value);
             } else {

--- a/Src/IronPython/Runtime/FunctionCode.cs
+++ b/Src/IronPython/Runtime/FunctionCode.cs
@@ -2,26 +2,25 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq.Expressions;
-using Microsoft.Scripting.Ast;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+using IronPython.Compiler;
+using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
+
 using Microsoft.Scripting;
+using Microsoft.Scripting.Ast;
 using Microsoft.Scripting.Debugging.CompilerServices;
 using Microsoft.Scripting.Generation;
 using Microsoft.Scripting.Interpreter;
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
-
-using IronPython.Compiler;
-using IronPython.Runtime.Operations;
-using IronPython.Runtime.Types;
 
 namespace IronPython.Runtime {
     /// <summary>
@@ -601,7 +600,7 @@ namespace IronPython.Runtime {
                 return optimizedModuleCode(this);
             }
 
-            var func = new PythonFunction(context, this, null, ArrayUtils.EmptyObjects, null, null, new MutableTuple<object>());
+            var func = new PythonFunction(context, this, null, [], null, null, new MutableTuple<object>());
             CallSite<Func<CallSite, CodeContext, PythonFunction, object>> site = context.LanguageContext.FunctionCallSite;
             return site.Target(site, context, func);
         }
@@ -772,7 +771,7 @@ namespace IronPython.Runtime {
             );
         }
 
-        
+
         /// <summary>
         /// Gets the correct final LambdaExpression for this piece of code.
         /// 
@@ -784,8 +783,8 @@ namespace IronPython.Runtime {
                 finalCode = Code;
             } else {
                 finalCode = Code.ToGenerator(
-                    _lambda.ShouldInterpret, 
-                    _lambda.EmitDebugSymbols, 
+                    _lambda.ShouldInterpret,
+                    _lambda.EmitDebugSymbols,
                     _lambda.GlobalParent.PyContext.Options.CompilationThreshold
                 );
             }
@@ -838,7 +837,7 @@ namespace IronPython.Runtime {
 
         internal Delegate AddRecursionCheck(PythonContext context, Delegate finalTarget) {
             if (context.RecursionLimit != Int32.MaxValue) {
-                if (finalTarget is Func<CodeContext, CodeContext> || 
+                if (finalTarget is Func<CodeContext, CodeContext> ||
                     finalTarget is Func<FunctionCode, object> ||
                     finalTarget is LookupCompilationDelegate) {
                     // no recursion enforcement on classes or modules
@@ -1185,7 +1184,6 @@ namespace IronPython.Runtime {
                     return _loopIds;
                 }
             }
-
         }
     }
 }

--- a/Src/IronPython/Runtime/ModuleDictionaryStorage.cs
+++ b/Src/IronPython/Runtime/ModuleDictionaryStorage.cs
@@ -6,11 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
+
 using IronPython.Compiler;
 using IronPython.Runtime.Types;
+
 using Microsoft.Scripting.Actions;
 using Microsoft.Scripting.Runtime;
-using Microsoft.Scripting.Utils;
 
 namespace IronPython.Runtime {
     /// <summary>
@@ -162,7 +163,7 @@ namespace IronPython.Runtime {
 
                             var propInfo = (PropertyInfo)members[0];
                             if ((propInfo.GetGetMethod() ?? propInfo.GetSetMethod()).IsStatic) {
-                                value = ((PropertyInfo)members[0]).GetValue(null, ArrayUtils.EmptyObjects);
+                                value = ((PropertyInfo)members[0]).GetValue(null, []);
                             } else {
                                 throw new InvalidOperationException("instance property declared on module.  Propreties should be declared as static, marked as PythonHidden, or you should use a PythonGlobal.");
                             }
@@ -217,7 +218,7 @@ namespace IronPython.Runtime {
                 return value != Uninitialized.Instance;
             }
 
-            if(key is string strKey) {
+            if (key is string strKey) {
                 return TryGetLazyValue(strKey, out value);
             }
 

--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -10,10 +10,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
+using IronPython.Runtime.Types;
+
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
-
-using IronPython.Runtime.Types;
 
 using SpecialNameAttribute = System.Runtime.CompilerServices.SpecialNameAttribute;
 
@@ -291,7 +291,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static object?[] GetSlice(object?[] data, int start, int stop) {
-            if (stop <= start) return ArrayUtils.EmptyObjects;
+            if (stop <= start) return [];
 
             var ret = new object?[stop - start];
             int index = 0;
@@ -309,7 +309,7 @@ namespace IronPython.Runtime.Operations {
             }
 
             int size = PythonOps.GetSliceCount(start, stop, step);
-            if (size <= 0) return ArrayUtils.EmptyObjects;
+            if (size <= 0) return [];
 
             var res = new object?[size];
             for (int i = 0, index = start; i < res.Length; i++, index += step) {
@@ -330,7 +330,7 @@ namespace IronPython.Runtime.Operations {
 
             if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
                 if (data.GetType().GetElementType() == typeof(object))
-                    return ArrayUtils.EmptyObjects;
+                    return Array.Empty<object>();
 
                 return Array.CreateInstance(data.GetType().GetElementType()!, 0);
             }
@@ -352,7 +352,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static object?[] CopyArray(object?[] data, int newSize) {
-            if (newSize == 0) return ArrayUtils.EmptyObjects;
+            if (newSize == 0) return [];
 
             var newData = new object?[newSize];
             if (data.Length < 20) {

--- a/Src/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/Src/IronPython/Runtime/Operations/InstanceOps.cs
@@ -2,22 +2,19 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq.Expressions;
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
+using IronPython.Runtime.Types;
+
 using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
-using Microsoft.Scripting.Utils;
-
-using IronPython.Runtime.Exceptions;
-using IronPython.Runtime.Types;
 
 namespace IronPython.Runtime.Operations {
     /// <summary>
@@ -107,7 +104,7 @@ namespace IronPython.Runtime.Operations {
             return type\u00F8.CreateInstance(context);
         }
 
-        public static object DefaultNewClsKW(CodeContext context, PythonType type\u00F8, [ParamDictionary]IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
+        public static object DefaultNewClsKW(CodeContext context, PythonType type\u00F8, [ParamDictionary] IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
             object res = DefaultNew(context, type\u00F8, args\u00F8);
 
             if (kwargs\u00F8.Count > 0) {
@@ -127,13 +124,13 @@ namespace IronPython.Runtime.Operations {
             return overloads\u00F8.Call(context, storage, null, args\u00F8);
         }
 
-        public static object OverloadedNewKW(CodeContext context, BuiltinFunction overloads\u00F8, PythonType type\u00F8, [ParamDictionary]IDictionary<object, object> kwargs\u00F8) {
+        public static object OverloadedNewKW(CodeContext context, BuiltinFunction overloads\u00F8, PythonType type\u00F8, [ParamDictionary] IDictionary<object, object> kwargs\u00F8) {
             if (type\u00F8 == null) throw PythonOps.TypeError("__new__ expected type object, got {0}", PythonOps.Repr(context, DynamicHelpers.GetPythonType(type\u00F8)));
 
-            return overloads\u00F8.Call(context, null, null, ArrayUtils.EmptyObjects, kwargs\u00F8);
+            return overloads\u00F8.Call(context, null, null, [], kwargs\u00F8);
         }
 
-        public static object OverloadedNewClsKW(CodeContext context, BuiltinFunction overloads\u00F8, PythonType type\u00F8, [ParamDictionary]IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
+        public static object OverloadedNewClsKW(CodeContext context, BuiltinFunction overloads\u00F8, PythonType type\u00F8, [ParamDictionary] IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
             if (type\u00F8 == null) throw PythonOps.TypeError("__new__ expected type object, got {0}", PythonOps.Repr(context, DynamicHelpers.GetPythonType(type\u00F8)));
             if (args\u00F8 == null) args\u00F8 = new object[1];
 
@@ -145,7 +142,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "self"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "kwargs\u00F8"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "args\u00F8")]
-        public static void DefaultInitKW(CodeContext context, object self, [ParamDictionary]IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
+        public static void DefaultInitKW(CodeContext context, object self, [ParamDictionary] IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context")]
@@ -158,23 +155,23 @@ namespace IronPython.Runtime.Operations {
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context")]
         [StaticExtensionMethod]
-        public static object NonDefaultNewKW(CodeContext context, PythonType type\u00F8, [ParamDictionary]IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
+        public static object NonDefaultNewKW(CodeContext context, PythonType type\u00F8, [ParamDictionary] IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
             if (type\u00F8 == null) throw PythonOps.TypeError("__new__ expected type object, got {0}", PythonOps.Repr(context, DynamicHelpers.GetPythonType(type\u00F8)));
             if (args\u00F8 == null) args\u00F8 = new object[1];
 
-            string []names;
+            string[] names;
             GetKeywordArgs(kwargs\u00F8, args\u00F8, out args\u00F8, out names);
             return type\u00F8.CreateInstance(context, args\u00F8, names);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "context")]
         [StaticExtensionMethod]
-        public static object NonDefaultNewKWNoParams(CodeContext context, PythonType type\u00F8, [ParamDictionary]IDictionary<object, object> kwargs\u00F8) {
+        public static object NonDefaultNewKWNoParams(CodeContext context, PythonType type\u00F8, [ParamDictionary] IDictionary<object, object> kwargs\u00F8) {
             if (type\u00F8 == null) throw PythonOps.TypeError("__new__ expected type object, got {0}", PythonOps.Repr(context, DynamicHelpers.GetPythonType(type\u00F8)));
 
             string[] names;
             object[] args;
-            GetKeywordArgs(kwargs\u00F8, ArrayUtils.EmptyObjects, out args, out names);
+            GetKeywordArgs(kwargs\u00F8, [], out args, out names);
             return type\u00F8.CreateInstance(context, args, names);
         }
 

--- a/Src/IronPython/Runtime/Operations/TypeGroupOps.cs
+++ b/Src/IronPython/Runtime/Operations/TypeGroupOps.cs
@@ -13,15 +13,14 @@ using IronPython.Runtime.Types;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Actions;
-using Microsoft.Scripting.Utils;
 
 namespace IronPython.Runtime.Operations {
     public static class TypeGroupOps {
         public static string __repr__(TypeGroup self) {
             StringBuilder sb = new StringBuilder("<types ");
             bool pastFirstType = false;
-            foreach(Type type in self.Types) {
-                if (pastFirstType) { 
+            foreach (Type type in self.Types) {
+                if (pastFirstType) {
                     sb.Append(", ");
                 }
                 PythonType dt = DynamicHelpers.GetPythonTypeFromType(type);
@@ -51,16 +50,16 @@ namespace IronPython.Runtime.Operations {
             return PythonCalls.Call(
                 context,
                 DynamicHelpers.GetPythonTypeFromType(self.GetNonGenericType()),
-                args ?? ArrayUtils.EmptyObjects
+                args ?? []
             );
         }
 
         [SpecialName]
-        public static object? Call(CodeContext/*!*/ context, TypeGroup/*!*/ self, [ParamDictionary]PythonDictionary kwArgs, params object?[] args) {
+        public static object? Call(CodeContext/*!*/ context, TypeGroup/*!*/ self, [ParamDictionary] PythonDictionary kwArgs, params object?[] args) {
             return PythonCalls.CallWithKeywordArgs(
-                context, 
+                context,
                 DynamicHelpers.GetPythonTypeFromType(self.GetNonGenericType()),
-                args ?? ArrayUtils.EmptyObjects,
+                args ?? [],
                 kwArgs ?? new PythonDictionary()
             );
         }
@@ -68,7 +67,7 @@ namespace IronPython.Runtime.Operations {
         [SpecialName]
         public static PythonType GetItem(TypeGroup self, params object?[] types) {
             PythonType[] pythonTypes = new PythonType[types.Length];
-            for(int i = 0; i < types.Length; i++) {
+            for (int i = 0; i < types.Length; i++) {
                 object? t = types[i];
                 if (t is PythonType) {
                     pythonTypes[i] = (PythonType)t;
@@ -108,6 +107,5 @@ namespace IronPython.Runtime.Operations {
 
             return DynamicHelpers.GetPythonTypeFromType(res);
         }
-
     }
 }

--- a/Src/IronPython/Runtime/PythonFunction.cs
+++ b/Src/IronPython/Runtime/PythonFunction.cs
@@ -68,7 +68,7 @@ namespace IronPython.Runtime {
                 _context = new CodeContext(new PythonDictionary(), new ModuleContext(globals, DefaultContext.DefaultPythonContext));
             }
 
-            _defaults = defaults == null ? ArrayUtils.EmptyObjects : defaults.ToArray();
+            _defaults = defaults == null ? [] : defaults.ToArray();
             _code = code;
             _doc = code._initialDoc;
             _name = name ?? code.PythonCode.Name;
@@ -90,7 +90,7 @@ namespace IronPython.Runtime {
             Assert.NotNull(context, funcInfo);
 
             _context = context;
-            _defaults = defaults ?? ArrayUtils.EmptyObjects;
+            _defaults = defaults ?? [];
             _kwdefaults = kwdefaults;
             _code = funcInfo;
             _doc = funcInfo._initialDoc;
@@ -99,7 +99,7 @@ namespace IronPython.Runtime {
             _annotations = annotations ?? new PythonDictionary();
 
             Debug.Assert(_defaults.Length <= _code.co_argcount);
-            Debug.Assert((__kwdefaults__ ?.Count ?? 0) <= _code.co_kwonlyargcount);
+            Debug.Assert((__kwdefaults__?.Count ?? 0) <= _code.co_kwonlyargcount);
             if (modName != Uninitialized.Instance) {
                 _module = modName;
             }
@@ -142,7 +142,7 @@ namespace IronPython.Runtime {
                 return new PythonTuple(_defaults);
             }
             set {
-                _defaults = value == null ? ArrayUtils.EmptyObjects : value.ToArray();
+                _defaults = value == null ? [] : value.ToArray();
                 FunctionCompatibility = CalculatedCachedCompat();
             }
         }
@@ -211,7 +211,7 @@ namespace IronPython.Runtime {
 
         public FunctionCode __code__ {
             get {
-                return _code; 
+                return _code;
             }
             set {
                 if (value == null) {
@@ -226,7 +226,7 @@ namespace IronPython.Runtime {
             return PythonCalls.Call(context, this, args);
         }
 
-        public object __call__(CodeContext/*!*/ context, [ParamDictionary]IDictionary<object, object> dict, params object[] args) {
+        public object __call__(CodeContext/*!*/ context, [ParamDictionary] IDictionary<object, object> dict, params object[] args) {
             return PythonCalls.CallWithKeywordArgs(context, this, args, dict);
         }
 
@@ -417,7 +417,7 @@ namespace IronPython.Runtime {
         }
 
         #endregion
-       
+
         #region Custom member lookup operators
 
         IList<string> IMembersList.GetMemberNames() {
@@ -471,7 +471,7 @@ namespace IronPython.Runtime {
             }
             return _dict;
         }
-        
+
         internal static int AddRecursionDepth(int change) {
             // ManagedThreadId starts at 1 and increases as we get more threads.
             // Therefore we keep track of a limited number of threads in an array
@@ -523,8 +523,7 @@ namespace IronPython.Runtime {
     }
 
     [PythonType("cell")]
-    public sealed class ClosureCell : ICodeFormattable
-    {
+    public sealed class ClosureCell : ICodeFormattable {
         [PythonHidden]
         public object Value;
 

--- a/Src/IronPython/Runtime/PythonList.cs
+++ b/Src/IronPython/Runtime/PythonList.cs
@@ -12,14 +12,13 @@ using System.Numerics;
 using System.Text;
 using System.Threading;
 
+using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
+
 using Microsoft.Scripting;
 using Microsoft.Scripting.Generation;
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
-
-using IronPython.Runtime.Exceptions;
-using IronPython.Runtime.Operations;
-using IronPython.Runtime.Types;
 
 using SpecialNameAttribute = System.Runtime.CompilerServices.SpecialNameAttribute;
 
@@ -156,7 +155,7 @@ namespace IronPython.Runtime {
 
         internal PythonList(int capacity) {
             if (capacity == 0) {
-                _data = ArrayUtils.EmptyObjects;
+                _data = [];
             } else {
                 _data = new object[capacity];
             }
@@ -953,7 +952,7 @@ namespace IronPython.Runtime {
 
                 try {
                     // make the list appear empty for the duration of the sort...
-                    _data = ArrayUtils.EmptyObjects;
+                    _data = [];
                     _size = 0;
 
                     if (key != null) {

--- a/Src/IronPython/Runtime/Types/NewTypeMaker.cs
+++ b/Src/IronPython/Runtime/Types/NewTypeMaker.cs
@@ -6,19 +6,19 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Dynamic;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-using System.Dynamic;
 using System.Text;
+
+using IronPython.Runtime.Binding;
+using IronPython.Runtime.Operations;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Actions;
 using Microsoft.Scripting.Generation;
 using Microsoft.Scripting.Utils;
-
-using IronPython.Runtime.Binding;
-using IronPython.Runtime.Operations;
 
 namespace IronPython.Runtime.Types {
     /// <summary>
@@ -44,7 +44,7 @@ namespace IronPython.Runtime.Types {
         private FieldInfo _dictField;
         private FieldInfo _slotsField;
         private FieldInfo _explicitMO;
-        
+
         private ILGen _cctor;
         private int _site;
 
@@ -70,7 +70,7 @@ namespace IronPython.Runtime.Types {
         private static readonly Dictionary<Type, Dictionary<string, List<MethodInfo>>> _overriddenMethods = new Dictionary<Type, Dictionary<string, List<MethodInfo>>>();
         [MultiRuntimeAware]
         private static readonly Dictionary<Type, Dictionary<string, List<ExtensionPropertyTracker>>> _overriddenProperties = new Dictionary<Type, Dictionary<string, List<ExtensionPropertyTracker>>>();
-        
+
 
         private NewTypeMaker(NewTypeInfo typeInfo) {
             _baseType = typeInfo.BaseType;
@@ -105,7 +105,7 @@ namespace IronPython.Runtime.Types {
                     // creation code                    
                     return new NewTypeMaker(typeInfo).CreateNewType();
                 });
-            
+
             return ret;
         }
 
@@ -118,7 +118,7 @@ namespace IronPython.Runtime.Types {
 
             MethodBuilder mb = tb.DefineMethod(_constructorMethodName, MethodAttributes.Public | MethodAttributes.Static, typeof(CachedNewTypeInfo[]), ReflectionUtils.EmptyTypes);
             ILGenerator ilg = mb.GetILGenerator();
-            
+
             // new CachedTypeInfo[types.Count]
             // we leave this on the stack (duping it) and storing into it.
             EmitInt(ilg, types.Count);
@@ -127,7 +127,7 @@ namespace IronPython.Runtime.Types {
 
             foreach (var v in types) {
                 NewTypeInfo nti = NewTypeInfo.GetTypeInfo(String.Empty, v);
-                
+
                 var typeInfos = new NewTypeMaker(nti).SaveType(ag, "Python" + _typeCount++ + "$" + nti.BaseType.Name);
 
                 // prepare for storing the element into our final array
@@ -138,14 +138,14 @@ namespace IronPython.Runtime.Types {
 
                 // load the type
                 ilg.Emit(OpCodes.Ldtoken, typeInfos.Key);
-                ilg.Emit(OpCodes.Call, typeof(Type).GetMethod("GetTypeFromHandle"));                
+                ilg.Emit(OpCodes.Call, typeof(Type).GetMethod("GetTypeFromHandle"));
 
                 // create the dictionary<str, str[]> of special names
                 ilg.Emit(OpCodes.Newobj, typeof(Dictionary<string, string[]>).GetConstructor(Array.Empty<Type>()));
                 foreach (var specialName in typeInfos.Value) {
                     // dup dict
                     ilg.Emit(OpCodes.Dup);
-                    
+
                     // emit key
                     ilg.Emit(OpCodes.Ldstr, specialName.Key);
 
@@ -161,7 +161,7 @@ namespace IronPython.Runtime.Types {
                     }
 
                     // assign to dict
-                    ilg.Emit(OpCodes.Call, typeof(Dictionary<string, string[]>).GetMethod("set_Item"));                    
+                    ilg.Emit(OpCodes.Call, typeof(Dictionary<string, string[]>).GetMethod("set_Item"));
                 }
 
                 // emit the interface types (if any)
@@ -412,13 +412,13 @@ namespace IronPython.Runtime.Types {
                     // parameter based attribute logic
                     if (pi.IsDefined(typeof(ParamArrayAttribute), false)) {
                         pb.SetCustomAttribute(new CustomAttributeBuilder(
-                            typeof(ParamArrayAttribute).GetConstructor(ReflectionUtils.EmptyTypes), ArrayUtils.EmptyObjects));
+                            typeof(ParamArrayAttribute).GetConstructor(ReflectionUtils.EmptyTypes), []));
                     } else if (pi.IsDefined(typeof(ParamDictionaryAttribute), false)) {
                         pb.SetCustomAttribute(new CustomAttributeBuilder(
-                            typeof(ParamDictionaryAttribute).GetConstructor(ReflectionUtils.EmptyTypes), ArrayUtils.EmptyObjects));
+                            typeof(ParamDictionaryAttribute).GetConstructor(ReflectionUtils.EmptyTypes), []));
                     } else if (pi.IsDefined(typeof(BytesLikeAttribute), false)) {
                         pb.SetCustomAttribute(new CustomAttributeBuilder(
-                            typeof(BytesLikeAttribute).GetConstructor(ReflectionUtils.EmptyTypes), ArrayUtils.EmptyObjects));
+                            typeof(BytesLikeAttribute).GetConstructor(ReflectionUtils.EmptyTypes), []));
                     }
 
                     if ((pi.Attributes & ParameterAttributes.HasDefault) != 0) {
@@ -465,7 +465,7 @@ namespace IronPython.Runtime.Types {
             MethodInfo init = typeof(PythonOps).GetMethod(nameof(PythonOps.InitializeUserTypeSlots));
 
             il.EmitLoadArg(0);
-            
+
             il.EmitLoadArg(typeArg);
             il.EmitCall(init);
 
@@ -564,7 +564,7 @@ namespace IronPython.Runtime.Types {
 
         private void ImplementDynamicObject() {
             // true if the user has explicitly included IDynamicMetaObjectProvider in the list of interfaces
-            bool explicitDynamicObject = false; 
+            bool explicitDynamicObject = false;
             foreach (Type t in _interfaceTypes) {
                 if (t == typeof(IDynamicMetaObjectProvider)) {
                     explicitDynamicObject = true;
@@ -634,7 +634,7 @@ namespace IronPython.Runtime.Types {
                 il.Emit(OpCodes.Dup);
                 il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Beq, retNull);
-                
+
                 // store the local value
                 il.Emit(OpCodes.Stloc_S, retVal.LocalIndex);
 
@@ -644,7 +644,7 @@ namespace IronPython.Runtime.Types {
                 // user returned null, fallback to base impl
                 il.MarkLabel(retNull);
                 il.Emit(OpCodes.Pop);
-                
+
                 // no override exists
                 il.MarkLabel(noOverride);
 
@@ -665,7 +665,7 @@ namespace IronPython.Runtime.Types {
 
             il.EmitLoadArg(0);  // this
             il.EmitLoadArg(1);  // parameter
-                
+
             // baseMetaObject
             if (baseIdo) {
                 InterfaceMapping imap = _baseType.GetInterfaceMap(typeof(IDynamicMetaObjectProvider));
@@ -736,7 +736,7 @@ namespace IronPython.Runtime.Types {
                 il.Emit(OpCodes.Ret);
                 _tg.DefineMethodOverride(impl, decl);
             }
-            
+
             // Types w/ DynamicBaseType attribute still need new slots implementation
 
             _slotsField = _tg.DefineField(SlotsAndWeakRefFieldName, typeof(object[]), FieldAttributes.Public);
@@ -805,7 +805,7 @@ namespace IronPython.Runtime.Types {
             // we need to create public helper methods that expose them. These methods are
             // used by the IDynamicMetaObjectProvider implementation (in MetaUserObject)
 
-            foreach (FieldInfo fi in  _baseType.GetInheritedFields(flattenHierarchy: true)) {
+            foreach (FieldInfo fi in _baseType.GetInheritedFields(flattenHierarchy: true)) {
                 if (!fi.IsProtected()) {
                     continue;
                 }
@@ -901,13 +901,13 @@ namespace IronPython.Runtime.Types {
                     added[key] = mi;
                 }
             }
-            
+
             if (type.IsAbstract && !type.IsInterface) {
                 // abstract types can define interfaces w/o implementations
                 foreach (Type iface in type.GetInterfaces()) {
                     InterfaceMapping mapping = type.GetInterfaceMap(iface);
                     for (int i = 0; i < mapping.TargetMethods.Length; i++) {
-                        
+
                         if (mapping.TargetMethods[i] == null) {
                             MethodInfo mi = mapping.InterfaceMethods[i];
 
@@ -1150,7 +1150,7 @@ namespace IronPython.Runtime.Types {
             // we're accessing a property
             return callTarget;
         }
-        
+
         private MethodBuilder CreateVTableGetterOverride(MethodInfo mi, string name) {
             MethodBuilder impl;
             ILGen il;
@@ -1274,7 +1274,7 @@ namespace IronPython.Runtime.Types {
             DefineVTableMethodOverride(mi, out impl, out il);
             //CompilerHelpers.GetArgumentNames(parameters));  TODO: Set names
 
-            LocalBuilder callTarget = EmitNonInheritedMethodLookup(name, il);            
+            LocalBuilder callTarget = EmitNonInheritedMethodLookup(name, il);
             Label instanceCall = il.DefineLabel();
             il.Emit(OpCodes.Brtrue, instanceCall);
 
@@ -1603,7 +1603,7 @@ namespace IronPython.Runtime.Types {
                 }
             }
         }
-        
+
         private static void StoreOverriddenField(MethodInfo mi, string newName) {
             Type baseType = mi.DeclaringType.BaseType;
             string fieldName = newName.Substring(FieldGetterPrefix.Length); // get_ or set_
@@ -1705,7 +1705,7 @@ namespace IronPython.Runtime.Types {
             lock (PythonTypeOps._propertyCache) {
                 string propName = newName.Substring(4); // get_ or set_
                 ExtensionPropertyTracker newProp = null;
-                foreach (PropertyInfo pi in baseType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy)) {                    
+                foreach (PropertyInfo pi in baseType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy)) {
                     if (pi.Name == propName) {
                         Type declType = pi.DeclaringType;
                         if (newName.StartsWith("get_", StringComparison.Ordinal)) {
@@ -1801,6 +1801,5 @@ namespace IronPython.Runtime.Types {
         }
 
         #endregion
-
     }
 }

--- a/Src/IronPython/Runtime/Types/ParameterInfoWrapper.cs
+++ b/Src/IronPython/Runtime/Types/ParameterInfoWrapper.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Reflection;
-using Microsoft.Scripting.Utils;
-using System.Collections.Generic;
 
 namespace Microsoft.Scripting.Generation {
     /// <summary>
@@ -41,11 +39,11 @@ namespace Microsoft.Scripting.Generation {
         }
 
         public override object[] GetCustomAttributes(bool inherit) {
-            return ArrayUtils.EmptyObjects;
+            return [];
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit) {
-            return ArrayUtils.EmptyObjects;
+            return [];
         }
     }
 }

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -504,7 +504,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             return PythonTypeOps.CallParams(context, this, args);
         }
 
-        public object __call__(CodeContext context, [ParamDictionary]IDictionary<string, object> kwArgs, params object[] args) {
+        public object __call__(CodeContext context, [ParamDictionary] IDictionary<string, object> kwArgs, params object[] args) {
             return PythonTypeOps.CallWorker(context, this, kwArgs, args);
         }
 
@@ -575,8 +575,8 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         public static object Get__module__(CodeContext/*!*/ context, PythonType self) {
             PythonTypeSlot pts;
             object res;
-            if (self._dict != null && 
-                self._dict.TryGetValue("__module__", out pts) && 
+            if (self._dict != null &&
+                self._dict.TryGetValue("__module__", out pts) &&
                 pts.TryGetValue(context, self, DynamicHelpers.GetPythonType(self), out res)) {
                 return res;
             }
@@ -638,7 +638,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             type.QualName = name;
         }
 
-        public static PythonDictionary __prepare__([ParamDictionary]IDictionary<object, object> kwargs, params object[] args)
+        public static PythonDictionary __prepare__([ParamDictionary] IDictionary<object, object> kwargs, params object[] args)
             => new PythonDictionary();
 
         public string/*!*/ __repr__(CodeContext/*!*/ context) {
@@ -789,13 +789,13 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// <returns></returns>
         internal static PythonType/*!*/ GetPythonType(Type type) {
             object res;
-            
+
             if (!_pythonTypes.TryGetValue(type, out res)) {
                 lock (_pythonTypes) {
                     if (!_pythonTypes.TryGetValue(type, out res)) {
                         res = new PythonType(type);
 
-                       _pythonTypes.Add(type, res);
+                        _pythonTypes.Add(type, res);
                     }
                 }
             }
@@ -873,7 +873,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 case 1: return _instanceCtor.CreateInstance(context, args[0]);
                 case 2: return _instanceCtor.CreateInstance(context, args[0], args[1]);
                 case 3: return _instanceCtor.CreateInstance(context, args[0], args[1], args[2]);
-                default: 
+                default:
                     return _instanceCtor.CreateInstance(context, args);
             }
         }
@@ -908,7 +908,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             PythonTypeSlot lenSlot = _lenSlot;
             if (lenSlot == null && !PythonOps.TryResolveTypeSlot(context, this, "__len__", out lenSlot)) {
                 length = 0;
-                return false;                
+                return false;
             }
 
             object func;
@@ -973,7 +973,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         }
 
         private void EnsureHashSite() {
-            if(_hashSite == null) {
+            if (_hashSite == null) {
                 Interlocked.CompareExchange(
                     ref _hashSite,
                     CallSite<Func<CallSite, object, int>>.Create(
@@ -1169,7 +1169,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             return !TryResolveSlot(DefaultContext.Default, name, out _) &&
                     TryResolveSlot(DefaultContext.DefaultCLS, name, out _);
         }
-        
+
         internal LateBoundInitBinder GetLateBoundInitBinder(CallSignature signature) {
             Debug.Assert(!IsSystemType); // going to hold onto a PythonContext, shouldn't ever be a system type
             Debug.Assert(_pythonContext != null);
@@ -1178,7 +1178,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 Interlocked.CompareExchange(ref _lateBoundInitBinders, new Dictionary<CallSignature, LateBoundInitBinder>(), null);
             }
 
-            lock(_lateBoundInitBinders) {
+            lock (_lateBoundInitBinders) {
                 LateBoundInitBinder res;
                 if (!_lateBoundInitBinders.TryGetValue(signature, out res)) {
                     _lateBoundInitBinders[signature] = res = new LateBoundInitBinder(this, signature);
@@ -1242,7 +1242,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (UnderlyingSystemType.IsInterface) {
                 return TypeCache.Object.TryResolveSlot(context, name, out slot);
             }
-            
+
 
             slot = null;
             return false;
@@ -1339,7 +1339,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             }
 
             // We could do more checks for things which aren't descriptors
-            if (value != null) { 
+            if (value != null) {
                 return new PythonTypeUserDescriptorSlot(value);
             }
 
@@ -1484,7 +1484,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 PythonDictionary dict = sdo.Dict;
 
                 hasValue = dict != null && dict.TryGetValue(name, out value);
-            } 
+            }
 
             // then check through all the descriptors.  If we have a data
             // descriptor it takes priority over the value we found in the
@@ -1497,7 +1497,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                     if (!hasValue || slot.IsSetDescriptor(context, this)) {
                         if (slot.TryGetValue(context, instance, this, out object newValue))
                             value = newValue;
-                            return true;
+                        return true;
                     }
                 }
             }
@@ -1611,7 +1611,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 }
 
                 setAttrSite.Target(setAttrSite, context, setattr, instance, name, value);
-                return true;                              
+                return true;
             }
 
             return TrySetNonCustomMember(context, instance, name, value);
@@ -1641,8 +1641,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                         if ((iac = sdo.SetDict(iac)) == null) {
                             return false;
                         }
-                    }
-                    else {
+                    } else {
                         return false;
                     }
                 }
@@ -1852,14 +1851,14 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 // if we directly inherit from 2 types with slots then the indexes would
                 // conflict so inheritance isn't allowed.
                 int slotCount = pt.GetUsedSlotCount();
-                
+
                 if (slotCount != 0) {
                     if (hasSlots) {
                         throw PythonOps.TypeError("multiple bases have instance lay-out conflict");
                     }
                     hasSlots = true;
                 }
-                
+
                 pt.AddSubType(this);
             }
 
@@ -1918,7 +1917,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                     bool isPythonType = false;
                     foreach (ConstructorInfo ci in ctors) {
                         ParameterInfo[] pis = ci.GetParameters();
-                        if((pis.Length > 1 && pis[0].ParameterType == typeof(CodeContext) && pis[1].ParameterType == typeof(PythonType)) ||
+                        if ((pis.Length > 1 && pis[0].ParameterType == typeof(CodeContext) && pis[1].ParameterType == typeof(PythonType)) ||
                             (pis.Length > 0 && pis[0].ParameterType == typeof(PythonType))) {
                             isPythonType = true;
                             break;
@@ -1965,7 +1964,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (_dict != null && _dict.TryGetValue("__slots__", out pts) && pts is PythonTypeUserDescriptorSlot) {
                 return SlotsToList(((PythonTypeUserDescriptorSlot)pts).Value);
             }
-            return ArrayUtils.EmptyStrings;
+            return [];
         }
 
         internal static List<string> GetSlots(PythonDictionary dict) {
@@ -2034,7 +2033,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 Debug.Assert(pt._objectInit != null && pt._objectNew != null);
 
                 if (!pt._objectNew.Value) {
-                    _objectNew = false;                    
+                    _objectNew = false;
                 }
 
                 if (!pt._objectInit.Value) {
@@ -2092,7 +2091,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (slots != null) {
                 slots.Remove("__classcell__");
                 _slots = slots.ToArray();
-                
+
                 int index = _originalSlotCount;
 
                 string typeName = IronPython.Compiler.Parser.GetPrivatePrefix(name);
@@ -2118,7 +2117,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (CheckForSlotWithDefault(context, _resolutionOrder, slots, "__dict__")) {
                 _attrs |= PythonTypeAttributes.HasDictionary;
                 bool inheritsDict = false;
-                for (int i = 1; i<_resolutionOrder.Count; i++) {
+                for (int i = 1; i < _resolutionOrder.Count; i++) {
                     PythonType pt = _resolutionOrder[i];
                     if (pt.TryResolveSlot(context, "__dict__", out _)) {
                         inheritsDict = true;
@@ -2228,7 +2227,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 }
             }
         }
-        
+
         #endregion
 
         #region System type initialization
@@ -2280,7 +2279,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                     Type newType;
                     if (TryReplaceExtensibleWithBase(curType, out newType)) {
                         mro.Add(DynamicHelpers.GetPythonTypeFromType(newType));
-                    } else if(!curType.IsDefined(typeof(PythonHiddenBaseClassAttribute), false)) {
+                    } else if (!curType.IsDefined(typeof(PythonHiddenBaseClassAttribute), false)) {
                         mro.Add(DynamicHelpers.GetPythonTypeFromType(curType));
                     }
                     curType = curType.BaseType;
@@ -2317,7 +2316,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 mro.Add(DynamicHelpers.GetPythonTypeFromType(typeof(ICollection)));
                 mro.Add(DynamicHelpers.GetPythonTypeFromType(typeof(IEnumerable)));
                 return;
-            } 
+            }
 
             Type[] interfaces = _underlyingSystemType.GetInterfaces();
             Dictionary<string, Type> methodMap = new Dictionary<string, Type>();
@@ -2326,7 +2325,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 
             PythonType[] bases = new PythonType[_bases.Length + interfaces.Length];
             Array.Copy(_bases, bases, _bases.Length);
-            for(int i = 0; i < interfaces.Length; i++) {
+            for (int i = 0; i < interfaces.Length; i++) {
                 bases[i + _bases.Length] = PythonType.GetPythonType(interfaces[i]);
             }
 
@@ -2354,11 +2353,11 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 #endif
 
                 InterfaceMapping mapping = _underlyingSystemType.GetInterfaceMap(iface);
-                
+
                 // grab all the interface methods which would hide other members
                 for (int i = 0; i < mapping.TargetMethods.Length; i++) {
                     MethodInfo target = mapping.TargetMethods[i];
-                    
+
                     if (target == null) {
                         continue;
                     }
@@ -2394,7 +2393,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                                 // no collisions so far...
                                 methodMap[iTarget.Name] = iface;
                             }
-                        } 
+                        }
                     }
                 }
             }
@@ -2492,7 +2491,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                     null);
             }
         }
-      
+
         /// <summary>
         /// Internal helper function to add a subtype
         /// </summary>
@@ -2548,7 +2547,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             /// The type has a ctor which does not accept PythonTypes.  This is used
             /// for user defined types which implement __clrtype__
             /// </summary>
-            SystemCtor    = 0x20
+            SystemCtor = 0x20
         }
 
         #endregion
@@ -2607,7 +2606,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             }
 
             public WeakRefTracker GetWeakRef() {
-                if(type.IsSystemType) {
+                if (type.IsSystemType) {
                     return context.GetSystemPythonTypeWeakRef(type);
                 }
 
@@ -2616,7 +2615,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             }
 
             public void SetFinalizer(WeakRefTracker value) {
-                if(type.IsSystemType) {
+                if (type.IsSystemType) {
                     context.SetSystemPythonTypeFinalizer(type, value);
                 } else {
                     IWeakReferenceable weakref = (IWeakReferenceable)type;
@@ -2625,10 +2624,10 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             }
 
             public bool SetWeakRef(WeakRefTracker value) {
-                if(type.IsSystemType) {
+                if (type.IsSystemType) {
                     return context.SetSystemPythonTypeWeakRef(type, value);
                 }
-                
+
                 IWeakReferenceable weakref = (IWeakReferenceable)type;
                 return weakref.SetWeakRef(value);
             }
@@ -2651,7 +2650,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         /// </summary>
         internal WeakReference/*!*/ GetSharedWeakReference() {
             if (_weakRef == null) {
-                _weakRef = new WeakReference(this);                
+                _weakRef = new WeakReference(this);
             }
 
             return _weakRef;
@@ -2667,7 +2666,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (!IsSystemType && !TryGetCustomSetAttr(Context.SharedContext, out _)) {
                 CodeContext context = PythonContext.GetPythonContext(binder).SharedContext;
                 string name = binder.Name;
-                
+
                 // optimized versions for possible literals that can show up in code.
                 Type setType = typeof(T);
                 if (setType == typeof(Func<CallSite, object, object, object>)) {
@@ -2726,7 +2725,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             public DebugProxy(PythonType type) {
                 _type = type;
             }
-            
+
             public PythonType[] __bases__ {
                 get {
                     return ArrayUtils.ToArray(_type.BaseTypes);
@@ -2835,8 +2834,8 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             _fallback = fallback;
             _isNoThrow = binder.IsNoThrow;
             _extMethods = extMethods;
-            var optNames = type.GetOptimizedInstanceNames(); 
-            
+            var optNames = type.GetOptimizedInstanceNames();
+
             switch (getKind) {
                 case OptimizedGetKind.SlotDict:
                     if (optNames != null) {
@@ -2845,7 +2844,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 
                     if (optNames != null && _dictIndex != -1) {
                         _func = SlotDictOptimized;
-                        _dictVersion = type.GetOptimizedInstanceVersion();                        
+                        _dictVersion = type.GetOptimizedInstanceVersion();
                     } else {
                         _func = SlotDict;
                     }
@@ -2868,13 +2867,13 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                         _func = UserSlotDictGetAttr;
                     } else {
                         _func = UserSlotDict;
-                    } 
+                    }
                     break;
                 case OptimizedGetKind.UserSlotOnly:
                     if (_getattrSlot != null) {
                         _func = UserSlotOnlyGetAttr;
                     } else {
-                        _func = UserSlotOnly; 
+                        _func = UserSlotOnly;
                     }
                     break;
                 default: throw new InvalidOperationException();
@@ -3098,7 +3097,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         private readonly CodeContext _context;
         private readonly int _index, _keysVersion;
 
-        public SetMemberDelegates(CodeContext context, PythonType type, OptimizedSetKind kind, string name, int version, PythonTypeSlot slot, SlotSetValue slotFunc) 
+        public SetMemberDelegates(CodeContext context, PythonType type, OptimizedSetKind kind, string name, int version, PythonTypeSlot slot, SlotSetValue slotFunc)
             : base(version) {
             _slot = slot;
             _name = name;
@@ -3147,7 +3146,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             return Update(site, self, value);
         }
 
-        
+
         public object SetDict(CallSite site, object self, TValue value) {
             if (self is IPythonObject ipo && ipo.PythonType.Version == _version && ShouldUseNonOptimizedSite) {
                 _hitCount++;
@@ -3438,7 +3437,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (!(other is CachedGetIdWeakRefExtensionMethod obj)) {
                 return false;
             }
-            return obj._extMethodSet.Target == _extMethodSet.Target && 
+            return obj._extMethodSet.Target == _extMethodSet.Target &&
                 obj.Name == Name;
         }
 

--- a/Src/IronPython/Runtime/Types/ReflectedExtensionProperty.cs
+++ b/Src/IronPython/Runtime/Types/ReflectedExtensionProperty.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Reflection;
-using Microsoft.Scripting.Utils;
+
 using IronPython.Runtime.Operations;
 
 namespace IronPython.Runtime.Types {
@@ -29,14 +29,14 @@ namespace IronPython.Runtime.Types {
                 return false;
             }
 
-            value = CallGetter(context, null, instance, ArrayUtils.EmptyObjects);
+            value = CallGetter(context, null, instance, []);
             return true;
         }
 
         internal override bool TrySetValue(CodeContext context, object instance, PythonType owner, object value) {
             if (Setter.Length == 0 || instance == null) return false;
 
-            return CallSetter(context, null, instance, ArrayUtils.EmptyObjects, value);
+            return CallSetter(context, null, instance, [], value);
         }
 
         internal override bool TryDeleteValue(CodeContext context, object instance, PythonType owner) {

--- a/Src/IronPython/Runtime/Types/ReflectedProperty.cs
+++ b/Src/IronPython/Runtime/Types/ReflectedProperty.cs
@@ -2,21 +2,19 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq.Expressions;
-
 using System;
 using System.Diagnostics;
 using System.Dynamic;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+
+using IronPython.Runtime.Binding;
+using IronPython.Runtime.Operations;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Actions;
 using Microsoft.Scripting.Generation;
-using Microsoft.Scripting.Utils;
-
-using IronPython.Runtime.Binding;
-using IronPython.Runtime.Operations;
 
 using AstUtils = Microsoft.Scripting.Ast.Utils;
 
@@ -55,7 +53,7 @@ namespace IronPython.Runtime.Types {
 
             if (instance == null) {
                 foreach (MethodInfo mi in Setter) {
-                    if(mi.IsStatic && DeclaringType != owner.UnderlyingSystemType) {
+                    if (mi.IsStatic && DeclaringType != owner.UnderlyingSystemType) {
                         return false;
                     } else if (mi.IsProtected()) {
                         throw PythonOps.TypeErrorForProtectedMember(owner.UnderlyingSystemType, _info.Name);
@@ -69,7 +67,7 @@ namespace IronPython.Runtime.Types {
                 }
             }
 
-            return CallSetter(context, context.LanguageContext.GetGenericCallSiteStorage(), instance, ArrayUtils.EmptyObjects, value);
+            return CallSetter(context, context.LanguageContext.GetGenericCallSiteStorage(), instance, [], value);
         }
 
         internal override Type DeclaringType {
@@ -198,7 +196,7 @@ namespace IronPython.Runtime.Types {
                         ).Expression,
                         typeof(object)
                     )
-                );                
+                );
             }
         }
 


### PR DESCRIPTION
Gets rid of uses of `ArrayUtils.EmptyObjects` and `ArrayUtils.EmptyStrings`. Uses the C# 12 empty collection expression `[]` as a replacement. Ultimate goal is to try and remove dependencies on DLR utils (like `ArrayUtils`) so they can be obsoleted (less code to worry about).