### PR TITLE
Implement equality comparisons on System.Array

### DIFF
--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -87,6 +87,30 @@ namespace IronPython.Runtime.Operations {
             return res;
         }
 
+        [StaticExtensionMethod]
+        public static object __eq__(CodeContext context, Array self, [NotNone] Array other) {
+            if (self is null) throw PythonOps.TypeError("expected Array, got None");
+            if (other is null) throw PythonOps.TypeError("expected Array, got None");
+
+            if (self.GetType() != other.GetType()) return ScriptingRuntimeHelpers.False;
+
+            return ScriptingRuntimeHelpers.BooleanToObject(
+                ((IStructuralEquatable)self).Equals(other, context.LanguageContext.EqualityComparerNonGeneric)
+            );
+        }
+
+        [StaticExtensionMethod]
+        [return: MaybeNotImplemented]
+        public static object __eq__(CodeContext context, object self, object? other) => NotImplementedType.Value;
+
+        [StaticExtensionMethod]
+        public static object __ne__(CodeContext context, Array self, [NotNone] Array other)
+            => ScriptingRuntimeHelpers.BooleanToObject(ReferenceEquals(__eq__(context, self, other), ScriptingRuntimeHelpers.False));
+
+        [StaticExtensionMethod]
+        [return: MaybeNotImplemented]
+        public static object __ne__(CodeContext context, object self, object? other) => NotImplementedType.Value;
+
         /// <summary>
         /// Multiply two object[] arrays - slow version, we need to get the type, etc...
         /// </summary>

--- a/Tests/test_array.py
+++ b/Tests/test_array.py
@@ -318,4 +318,51 @@ class ArrayTest(IronPythonTestCase):
         self.assertTrue(a != l)
         self.assertTrue(l != a)
 
+    def test_equality_base(self):
+        a = System.Array.CreateInstance(int, (5,), (5,))
+        a2 = System.Array.CreateInstance(int, (5,), (5,))
+        b = System.Array.CreateInstance(int, (6,), (5,))
+        c = System.Array.CreateInstance(int, (5,), (6,))
+        d = System.Array.CreateInstance(int, (6,), (6,))
+
+        self.assertTrue(a == a2)
+        self.assertFalse(a == b)
+        self.assertFalse(a == c)
+        self.assertFalse(a == d)
+
+        self.assertFalse(a != a2)
+        self.assertTrue(a != b)
+        self.assertTrue(a != c)
+        self.assertTrue(a != d)
+
+    def test_equality_rank(self):
+        a = System.Array.CreateInstance(int, 5, 6)
+        a2 = System.Array.CreateInstance(int, 5, 6)
+        b = System.Array.CreateInstance(int, 5, 6)
+        b[0, 0] = 1
+        c = System.Array.CreateInstance(int, (6, 5), (0, 0))
+        c[0, 0] = 1
+        d = System.Array.CreateInstance(int, (6, 5), (1, 1))
+        d[1, 1] = 1
+        d1 = System.Array.CreateInstance(int, (6, 5), (1, 1))
+        d1[1, 1] = 1
+
+        self.assertTrue(a == a2)
+        self.assertFalse(a == b) # different element
+        self.assertFalse(a == c) # different rank
+        self.assertFalse(a == d) # different rank
+        self.assertFalse(b == c) # different shape
+        self.assertFalse(b == d) # different shape & base
+        self.assertFalse(c == d) # different base
+        self.assertTrue(d == d1)
+
+        self.assertFalse(a != a2)
+        self.assertTrue(a != b)
+        self.assertTrue(a != c)
+        self.assertTrue(a != d)
+        self.assertTrue(b != c)
+        self.assertTrue(b != d)
+        self.assertTrue(c != d)
+        self.assertFalse(d != d1)
+
 run_test(__name__)

--- a/Tests/test_array.py
+++ b/Tests/test_array.py
@@ -279,4 +279,43 @@ class ArrayTest(IronPythonTestCase):
         array1[0,0] = 5
         self.assertEqual(array1[0,0], array1[(0,0)])
 
+    def test_equality(self):
+        a = System.Array.CreateInstance(int, 5)
+        a2 = System.Array.CreateInstance(int, 5) # same as a
+        b = System.Array.CreateInstance(int, 5, 6) # different rank
+        c = System.Array.CreateInstance(int, 6) # different length
+        d = System.Array.CreateInstance(int, (5,), (1,)) # different base
+        e = System.Array.CreateInstance(System.Int32, 5) # different element type
+        l = [0] * 5 # different type
+
+        self.assertTrue(a == a2)
+        self.assertTrue(a2 == a)
+        self.assertFalse(a != a2)
+        self.assertFalse(a2 != a)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+        self.assertFalse(a == c)
+        self.assertFalse(c == a)
+        self.assertTrue(a != c)
+        self.assertTrue(c != a)
+
+        self.assertFalse(a == d)
+        self.assertFalse(d == a)
+        self.assertTrue(a != d)
+        self.assertTrue(d != a)
+
+        self.assertFalse(a == e)
+        self.assertFalse(e == a)
+        self.assertTrue(a != e)
+        self.assertTrue(e != a)
+
+        self.assertFalse(a == l)
+        self.assertFalse(l == a)
+        self.assertTrue(a != l)
+        self.assertTrue(l != a)
+
 run_test(__name__)


### PR DESCRIPTION
Fixes `IndexOutOfRangeException` when equating arrays with different index bases (lower bounds).

Example:

```pycon
>>> from System import *
>>> a = Array.CreateInstance(Int32, (5,), (1,))
>>> b = Array.CreateInstance(Int32, (5,), (1,))
>>> a == b
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: Index was outside the bounds of the array.
>>> a != b
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: Index was outside the bounds of the array.
```

This is due to a bug in .NET:

```c#
var a = Array.CreateInstance(typeof(int), new[] { 5 }, new[] { 1 });
var b = Array.CreateInstance(typeof(int), new[] { 5 }, new[] { 1 });
((IStructuralEquatable)a).Equals(b, EqualityComparer<int>.Default);  // IndexOutOfRangeException
```

I'll see if this is already reported. It just shows that nonzero bases are not very popular.

In this PR I'll also cover equating multidimensional arrays, since there is just a little bit to add to address that as well.