### PR TITLE
Fix indexing for arrays with non-zero base

### DIFF
--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -437,8 +437,12 @@ namespace IronPython.Runtime.Operations {
 
         private static int FixIndex(Array a, int v, int axis) {
             int idx = v;
-            if (idx < 0) idx += a.GetUpperBound(axis) + 1;
-            if (idx < a.GetLowerBound(axis) || idx > a.GetUpperBound(axis)) {
+            int lb = a.GetLowerBound(axis);
+            int ub = a.GetUpperBound(axis);
+            if (idx < 0 && lb >= 0) {
+                idx += ub + 1;
+            }
+            if (idx < lb || idx > ub) {
                 throw PythonOps.IndexError("index out of range: {0}", v);
             }
             return idx;
@@ -464,7 +468,7 @@ namespace IronPython.Runtime.Operations {
             } else {
                 ostart = Converter.ConvertToIndex(slice.start);
                 if (ostart < lb) {
-                    if (ostart < 0) {
+                    if (ostart < 0 && lb >= 0) {
                         ostart += ub + 1;
                     }
                     if (ostart < lb) {
@@ -480,7 +484,7 @@ namespace IronPython.Runtime.Operations {
             } else {
                 ostop = Converter.ConvertToIndex(slice.stop);
                 if (ostop < lb) {
-                    if (ostop < 0) {
+                    if (ostop < 0 && lb >= 0) {
                         ostop += ub + 1;
                     }
                     if (ostop < 0) {

--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -390,10 +390,10 @@ namespace IronPython.Runtime.Operations {
                 return Array.CreateInstance(data.GetType().GetElementType()!, 0);
             }
 
-            if (step == 1) {
+            if (step == 1 && (!ClrModule.IsMono || data.GetLowerBound(0) == 0)) {
                 int n = stop - start;
                 Array ret = Array.CreateInstance(data.GetType().GetElementType()!, n);
-                Array.Copy(data, start, ret, 0, n);
+                Array.Copy(data, start, ret, 0, n);  // doesn't work OK on Mono with non-0-based arrays
                 return ret;
             } else {
                 int n = PythonOps.GetSliceCount(start, stop, step);

--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -171,14 +171,14 @@ namespace IronPython.Runtime.Operations {
             if (data == null) throw PythonOps.TypeError("expected Array, got None");
             if (data.Rank != 1) throw PythonOps.TypeError("bad dimensions for array, got {0} expected {1}", 1, data.Rank);
 
-            return data.GetValue(PythonOps.FixIndex(index, data.Length) + data.GetLowerBound(0));
+            return data.GetValue(FixIndex(data, index, 0));
         }
 
         [SpecialName]
         public static object GetItem(Array data, Slice slice) {
             if (data == null) throw PythonOps.TypeError("expected Array, got None");
 
-            return GetSlice(data, data.Length, slice);
+            return GetSlice(data, slice);
         }
 
         [SpecialName]
@@ -201,7 +201,6 @@ namespace IronPython.Runtime.Operations {
             int[] iindices = TupleToIndices(data, indices);
             if (data.Rank != indices.Length) throw PythonOps.TypeError("bad dimensions for array, got {0} expected {1}", indices.Length, data.Rank);
 
-            for (int i = 0; i < iindices.Length; i++) iindices[i] += data.GetLowerBound(i);
             return data.GetValue(iindices);
         }
 
@@ -210,7 +209,7 @@ namespace IronPython.Runtime.Operations {
             if (data == null) throw PythonOps.TypeError("expected Array, got None");
             if (data.Rank != 1) throw PythonOps.TypeError("bad dimensions for array, got {0} expected {1}", 1, data.Rank);
 
-            data.SetValue(Converter.Convert(value, data.GetType().GetElementType()), PythonOps.FixIndex(index, data.Length) + data.GetLowerBound(0));
+            data.SetValue(Converter.Convert(value, data.GetType().GetElementType()), FixIndex(data, index, 0));
         }
 
         [SpecialName]
@@ -231,8 +230,6 @@ namespace IronPython.Runtime.Operations {
 
             if (a.Rank != args.Length) throw PythonOps.TypeError("bad dimensions for array, got {0} expected {1}", args.Length, a.Rank);
 
-            for (int i = 0; i < indices.Length; i++) indices[i] += a.GetLowerBound(i);
-
             Type elm = t.GetElementType()!;
             a.SetValue(Converter.Convert(indexAndValue[indexAndValue.Length - 1], elm), indices);
         }
@@ -243,9 +240,15 @@ namespace IronPython.Runtime.Operations {
 
             Type elm = a.GetType().GetElementType()!;
 
+            int lb = a.GetLowerBound(0);
+            if (lb != 0) {
+                FixSlice(index, a, out int start, out int stop, out int step);
+                index = new Slice(start - lb, stop - lb, step);
+            }
+
             index.DoSliceAssign(
                 delegate (int idx, object? val) {
-                    a.SetValue(Converter.Convert(val, elm), idx + a.GetLowerBound(0));
+                    a.SetValue(Converter.Convert(val, elm), idx + lb);
                 },
                 a.Length,
                 value);
@@ -375,10 +378,10 @@ namespace IronPython.Runtime.Operations {
             return GetSlice(data, start, stop, step);
         }
 
-        internal static Array GetSlice(Array data, int size, Slice slice) {
+        private static Array GetSlice(Array data, Slice slice) {
             if (data.Rank != 1) throw PythonOps.NotImplementedError("slice on multi-dimensional array");
 
-            slice.Indices(size, out int start, out int stop, out int step);
+            FixSlice(slice, data, out int start, out int stop, out int step);
 
             if ((step > 0 && start >= stop) || (step < 0 && start <= stop)) {
                 if (data.GetType().GetElementType() == typeof(object))
@@ -390,14 +393,14 @@ namespace IronPython.Runtime.Operations {
             if (step == 1) {
                 int n = stop - start;
                 Array ret = Array.CreateInstance(data.GetType().GetElementType()!, n);
-                Array.Copy(data, start + data.GetLowerBound(0), ret, 0, n);
+                Array.Copy(data, start, ret, 0, n);
                 return ret;
             } else {
                 int n = PythonOps.GetSliceCount(start, stop, step);
                 Array ret = Array.CreateInstance(data.GetType().GetElementType()!, n);
                 int ri = 0;
                 for (int i = 0, index = start; i < n; i++, index += step) {
-                    ret.SetValue(data.GetValue(index + data.GetLowerBound(0)), ri++);
+                    ret.SetValue(data.GetValue(index), ri++);
                 }
                 return ret;
             }
@@ -427,9 +430,66 @@ namespace IronPython.Runtime.Operations {
             int[] indices = new int[tuple.Count];
             for (int i = 0; i < indices.Length; i++) {
                 int iindex = Converter.ConvertToInt32(tuple[i]);
-                indices[i] = i < a.Rank ? PythonOps.FixIndex(iindex, a.GetLength(i)) : int.MinValue;
+                indices[i] = i < a.Rank ? FixIndex(a, iindex, i) : int.MinValue;
             }
             return indices;
+        }
+
+        private static int FixIndex(Array a, int v, int axis) {
+            int idx = v;
+            if (idx < 0) idx += a.GetUpperBound(axis) + 1;
+            if (idx < a.GetLowerBound(axis) || idx > a.GetUpperBound(axis)) {
+                throw PythonOps.IndexError("index out of range: {0}", v);
+            }
+            return idx;
+        }
+
+        private static void FixSlice(Slice slice, Array a, out int ostart, out int ostop, out int ostep) {
+            Debug.Assert(a.Rank == 1);
+
+            if (slice.step == null) {
+                ostep = 1;
+            } else {
+                ostep = Converter.ConvertToIndex(slice.step);
+                if (ostep == 0) {
+                    throw PythonOps.ValueError("step cannot be zero");
+                }
+            }
+
+            int lb = a.GetLowerBound(0);
+            int ub = a.GetUpperBound(0);
+
+            if (slice.start == null) {
+                ostart = ostep > 0 ? lb : ub;
+            } else {
+                ostart = Converter.ConvertToIndex(slice.start);
+                if (ostart < lb) {
+                    if (ostart < 0) {
+                        ostart += ub + 1;
+                    }
+                    if (ostart < lb) {
+                        ostart = ostep > 0 ? lb : lb - 1;
+                    }
+                } else if (ostart > ub) {
+                    ostart = ostep > 0 ? ub + 1 : ub;
+                }
+            }
+
+            if (slice.stop == null) {
+                ostop = ostep > 0 ? ub + 1 : lb - 1;
+            } else {
+                ostop = Converter.ConvertToIndex(slice.stop);
+                if (ostop < lb) {
+                    if (ostop < 0) {
+                        ostop += ub + 1;
+                    }
+                    if (ostop < 0) {
+                        ostop = ostep > 0 ? lb : lb - 1;
+                    }
+                } else if (ostop > ub) {
+                    ostop = ostep > 0 ? ub + 1 : ub;
+                }
+            }
         }
 
         #endregion

--- a/Tests/test_array.py
+++ b/Tests/test_array.py
@@ -173,35 +173,55 @@ class ArrayTest(IronPythonTestCase):
 
     def test_nonzero_lowerbound(self):
         a = System.Array.CreateInstance(int, (5,), (5,))
-        for i in range(5): a[i] = i
+        for i in range(5, 5 + a.Length): a[i] = i
 
-        self.assertEqual(a[:2], System.Array[int]((0,1)))
-        self.assertEqual(a[2:], System.Array[int]((2,3,4)))
-        self.assertEqual(a[2:4], System.Array[int]((2,3)))
-        self.assertEqual(a[-1], 4)
+        self.assertEqual(a[:7], System.Array[int]((5,6)))
+        self.assertEqual(a[7:], System.Array[int]((7,8,9)))
+        self.assertEqual(a[7:9], System.Array[int]((7,8)))
+        self.assertEqual(a[-1:-3:-1], System.Array[int]((9,8)))
+        self.assertEqual(a[-1], 9)
 
-        self.assertEqual(repr(a), 'Array[int]((0, 1, 2, 3, 4), base: 5)')
+        self.assertEqual(repr(a), 'Array[int]((5, 6, 7, 8, 9), base: 5)')
 
         a = System.Array.CreateInstance(int, (5,), (15,))
         b = System.Array.CreateInstance(int, (5,), (20,))
         self.assertEqual(a.Length, b.Length)
         for i in range(a.Length):
-            self.assertEqual(a[i], b[i])
+            self.assertEqual(a[i + 15], b[i + 20])
 
-        ## 5-dimension
+        a0 = System.Array.CreateInstance(int, 5) # regular, 0-based
+        for i in range(5): a0[i] = i
+
+        a[17:19] = a0[2:4]
+        self.assertEqual(a[17:19], System.Array[int]((2, 3)))
+
+        self.assertEqual(a0[3:1:-1], System.Array[int]((3, 2)))
+        self.assertEqual(a[18:16:-1], System.Array[int]((3, 2)))
+
+        self.assertEqual(a0[-3:-1], System.Array[int]((2, 3)))
+        self.assertEqual(a[-3:-1], System.Array[int]((2, 3)))
+
+        a[18:16:-1] = a0[2:4]
+        self.assertEqual(a[17:19], System.Array[int]((3, 2)))
+
+        ## 5-dimension, 2-length/dim, progressive lowerbound
         a = System.Array.CreateInstance(int, (2,2,2,2,2), (1,2,3,4,5))
-        self.assertEqual(a[0,0,0,0,0], 0)
+        self.assertEqual(a[1,2,3,4,5], 0)
+
+        ## 5-dimension, 2-length/dim, progressive lowerbound
+        a = System.Array.CreateInstance(int, (2,2,2,2,2), (1,2,3,4,5))
+        self.assertEqual(a[1,2,3,4,5], 0)
 
         for i in range(5):
-            index = [0,0,0,0,0]
-            index[i] = 1
+            index = [1,2,3,4,5]
+            index[i] += 1
 
             a[index[0], index[1], index[2], index[3], index[4]] = i
             self.assertEqual(a[index[0], index[1], index[2], index[3], index[4]], i)
 
         for i in range(5):
-            index = [0,0,0,0,0]
-            index[i] = 0
+            index = [2,3,4,5,6]
+            index[i] -= 1
 
             a[index[0], index[1], index[2], index[3], index[4]] = i
             self.assertEqual(a[index[0], index[1], index[2], index[3], index[4]], i)
@@ -217,6 +237,35 @@ class ArrayTest(IronPythonTestCase):
         self.assertRaises(NotImplementedError, sliceArray, a, -200)
         self.assertRaises(NotImplementedError, sliceArrayAssign, a, -200, 1)
         self.assertRaises(NotImplementedError, sliceArrayAssign, a, 1, 1)
+
+    def test_base1(self):
+        # 1-based 2x2 matrix
+        arr = System.Array.CreateInstance(str, (2,2), (1,1))
+        
+        self.assertEqual(arr.GetLowerBound(0), 1)
+        self.assertEqual(arr.GetLowerBound(1), 1)
+        self.assertEqual(arr.GetUpperBound(0), 2)
+        self.assertEqual(arr.GetUpperBound(1), 2)
+
+        arr.SetValue("a_1,1", System.Array[System.Int32]((1,1)))
+        arr.SetValue("a_1,2", System.Array[System.Int32]((1,2)))
+        arr.SetValue("a_2,1", System.Array[System.Int32]((2,1)))
+        arr.SetValue("a_2,2", System.Array[System.Int32]((2,2)))
+
+        self.assertEqual(arr[1, 1], "a_1,1")
+        self.assertEqual(arr[1, 2], "a_1,2")
+        self.assertEqual(arr[2, 1], "a_2,1")
+        self.assertEqual(arr[2, 2], "a_2,2")
+
+        arr[1, 1] = "b_1,1"
+        arr[1, 2] = "b_1,2"
+        arr[2, 1] = "b_2,1"
+        arr[2, 2] = "b_2,2"
+
+        self.assertEqual(arr.GetValue(System.Array[System.Int32]((1,1))), "b_1,1")
+        self.assertEqual(arr.GetValue(System.Array[System.Int32]((1,2))), "b_1,2")
+        self.assertEqual(arr.GetValue(System.Array[System.Int32]((2,1))), "b_2,1")
+        self.assertEqual(arr.GetValue(System.Array[System.Int32]((2,2))), "b_2,2")
 
     def test_array_type(self):
 


### PR DESCRIPTION
Currently IronPython ignores the lowerbound of a CLI array and always treats the array as 0-based. Assume `arr` is a 1-based 2x2 matrix. Using `SetValue` or `GetValue` requires using 1-based indices, but when using subscripts all indices are must be shifted down by 1. This is not .NET-compliant.

```python
from System import *

# 1-based 2x2 matrix
arr = Array.CreateInstance(str, (2,2), (1,1))

# SetValue uses correct indices
arr.SetValue("a_1,1", Array[Int32]((1,1)))
arr.SetValue("a_1,2", Array[Int32]((1,2)))
arr.SetValue("a_2,1", Array[Int32]((2,1)))
arr.SetValue("a_2,2", Array[Int32]((2,2)))

# BUT subscripts are off by 1
arr[0, 0] = "a_1,1"
arr[0, 1] = "a_1,2"
arr[1, 0] = "a_2,1"
arr[1, 1] = "a_2,2"
```

After this PR:

```python
# As above:
arr.SetValue("a_1,1", Array[Int32]((1,1)))
arr.SetValue("a_1,2", Array[Int32]((1,2)))
arr.SetValue("a_2,1", Array[Int32]((2,1)))
arr.SetValue("a_2,2", Array[Int32]((2,2)))

# AND:
arr[1, 1] = "a_1,1"
arr[1, 2] = "a_1,2"
arr[2, 1] = "a_2,1"
arr[2, 2] = "a_2,2"
```

This puts IronPython on par with C#:

```C#
// Creates and initializes a 2-dimensional, 1-based Array of type string (a 2x2 matrix).
Array myArray = Array.CreateInstance(typeof(string), new[] { 2, 2 }, new[] { 1, 1 } );
for (int i = myArray.GetLowerBound(0); i <= myArray.GetUpperBound(0); i++)
    for (int j = myArray.GetLowerBound(1); j <= myArray.GetUpperBound(1); j++)
        myArray.SetValue($"a_{i},{j}", new int[2] { i, j } );

// Equivalently:
var arr = (string[,])myArray;
arr[1, 1] = "a_1,1";
arr[1, 2] = "a_1,2";
arr[2, 1] = "a_2,1";
arr[2, 2] = "a_2,2";
```

### Notes on indexing in C#

The only way to create non-zero-based arrays in C# is by using `Array.CreateInstance`, which returns an object of abstract type `Array`. This type does not implement the index operator; to use it, the array has to be downcast to the concrete (native) type. Hence the cast to `(string[,])` above is necessary.

Actually, the concrete type of an non-zero-based array is not `string[,]` but `string[*,*]`. But a cast `(string[*,*])` in C# is syntactically invalid. The compiler accepts cast `(string[,])` but interprets it as `(string[*,*])`. That is, `var arr` is `string[*,*] arr` as it were.

Surprisingly, this is only supported for higher dimensional arrays; for 1-dimensional arrays casting from 1-based string array to `string[]` results in a compile error of invalid cast from `string[*]` to `string[]`. In practice this means that 1-based 1-dimentional arrays cannot be indexed in C# using the index operator. I can only speculate why it is so.

IronPython, being a dynamic language, does not require casting and an array of any type can be indexed using the index operator.


### Summary of indexing of CLI arrays in IronPython:

| Base | Index >= 0                           | Index < 0         |
|------|--------------------------------------|-------------------|
|  > 0 | absolue                              | relative from end |
|    0 | absolute == relative from beginning  | relative from end |
|  < 0 | absolute                             | absolute          |

Comparison to indexing in C# and CPython:

* Index >= 0, any base is C# compliant.
* Base 0, any index is CPython compliant.
* Base 0, index < 0 is not supported by C# but can be achieved by `System.Index` with 1-dim arrays only; then IronPython indexing is C# compliant (as well as CPython compliant) in principle (support for `System.Index` is not implemented).
* Base > 0, index < 0 is not supported by C#; IronPython follows the CPython convention as more practical.
* Base < 0, index < 0 is C# compliant.
* Base != 0 is not supported by CPython for any builtin structures.
