### PR TITLE
Define UnsupportedOSPlatformAttribute

### DIFF
--- a/Src/IronPython/SystemRuntimeVersioning.cs
+++ b/Src/IronPython/SystemRuntimeVersioning.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Runtime.Versioning {
 #if !FEATURE_OSPLATFORMATTRIBUTE
     internal abstract class OSPlatformAttribute : Attribute {
@@ -25,6 +27,28 @@ namespace System.Runtime.Versioning {
     internal sealed class SupportedOSPlatformAttribute : OSPlatformAttribute {
         public SupportedOSPlatformAttribute(string platformName) : base(platformName) {
         }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly |
+                AttributeTargets.Class |
+                AttributeTargets.Constructor |
+                AttributeTargets.Enum |
+                AttributeTargets.Event |
+                AttributeTargets.Field |
+                AttributeTargets.Method |
+                AttributeTargets.Module |
+                AttributeTargets.Property |
+                AttributeTargets.Struct,
+                AllowMultiple = true, Inherited = false)]
+    internal sealed class UnsupportedOSPlatformAttribute : OSPlatformAttribute {
+        public UnsupportedOSPlatformAttribute(string platformName) : base(platformName) {
+        }
+
+        public UnsupportedOSPlatformAttribute (string platformName, string? message) : base(platformName) {
+            Message = message;
+        }
+
+        public string? Message { get; }
     }
 #endif
 }


### PR DESCRIPTION
I had added `UnsupportedOSPlatformAttribute` in the past already several times, only to remove it again when the final version submitted as a pull request didn't use it. Now again, I have code that uses it, although it is not the final version so in the end it may again not be using it. Nevertheless, I'd like to add this attribute and get it over with for the future. It doesn't harm if it's unused, but it is good to have it available, if needed.