### PR TITLE
Fix downward slices for positive base arrays

### DIFF
--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -491,7 +491,7 @@ namespace IronPython.Runtime.Operations {
                     if (ostop < 0 && lb >= 0) {
                         ostop += ub + 1;
                     }
-                    if (ostop < 0) {
+                    if (ostop < lb) {
                         ostop = ostep > 0 ? lb : lb - 1;
                     }
                 } else if (ostop > ub) {

--- a/Tests/test_array.py
+++ b/Tests/test_array.py
@@ -479,4 +479,20 @@ class ArrayTest(IronPythonTestCase):
         self.assertTrue(c != d)
         self.assertFalse(d != d1)
 
+    def test_slice_down(self):
+        #arr = System.Array[int]((2, 3, 4), base=2)
+        arr = System.Array.CreateInstance(int, (3,), (2,))
+        for i in range(2, 2 + 3):
+            arr[i] = i
+
+        self.assertEqual(arr[-1:-4:-1], System.Array[int]((4, 3, 2)))
+        self.assertEqual(arr[-1:-5:-1], System.Array[int]((4, 3, 2)))
+        self.assertEqual(arr[-1:-6:-1], System.Array[int]((4, 3, 2)))
+
+        self.assertEqual(arr[2:1:-1], System.Array[int]((2,)))
+        self.assertEqual(arr[2:-5:-1], System.Array[int]((2,)))
+        self.assertEqual(arr[2:-6:-1], System.Array[int]((2,)))
+        self.assertEqual(arr[1:-5:-1], System.Array[int](()))
+        self.assertEqual(arr[0:-5:-1], System.Array[int](()))
+
 run_test(__name__)


### PR DESCRIPTION
Fixes issue reported by @slozier in https://github.com/IronLanguages/ironpython3/pull/1828#pullrequestreview-2480173778:

> Unrelated to this PR, but noticed a slight asymmetry in `FixSlice` where it does `ostart < lb` vs `ostop < 0`. Don't think it hurts anything but seemed odd.

The problem was happening in some cases for arrays with base >= 2 and a negative slice step.

```pycon
>>> from System import *
>>> arr = Array.CreateInstance(Int32, (3,), (2,))       
>>> arr[-1:-5:-1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: Index was outside the bounds of the array.
```