### PR TITLE
Support mode `ab+` equivalent through os.open

### DIFF
--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -130,7 +130,7 @@ namespace IronPython.Modules {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                         // On POSIX, register the file descriptor with the file manager right after file opening
                         _context.FileManager.GetOrAssignId(_streams);
-                        // accoding to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.safefilehandle?view=net-9.0#remarks)
+                        // according to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.safefilehandle?view=net-9.0#remarks)
                         // accessing SafeFileHandle sets the current stream position to 0
                         // in practice it doesn't seem to be the case, but better to be sure
                         if (this.mode == "ab+") {

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -127,6 +127,19 @@ namespace IronPython.Modules {
                         default:
                             throw new InvalidOperationException();
                     }
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                        // On POSIX, register the file descriptor with the file manager right after file opening
+                        _context.FileManager.GetOrAssignId(_streams);
+                        // accoding to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.safefilehandle?view=net-9.0#remarks)
+                        // accessing SafeFileHandle sets the current stream position to 0
+                        // in practice it doesn't seem to be the case, but better to be sure
+                        if (this.mode == "ab+") {
+                            _streams.WriteStream.Seek(0L, SeekOrigin.End);
+                        }
+                        if (!_streams.IsSingleStream) {
+                            _streams.ReadStream.Seek(_streams.WriteStream.Position, SeekOrigin.Begin);
+                        }
+                    }
                 }
                 else {
                     object fdobj = PythonOps.CallWithContext(context, opener, name, flags);

--- a/Src/IronPython/Runtime/PythonFileManager.cs
+++ b/Src/IronPython/Runtime/PythonFileManager.cs
@@ -287,12 +287,12 @@ namespace IronPython.Runtime {
             lock (_synchObject) {
                 int res = streams.Id;
                 if (res == -1) {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                        res = Add(streams);
-                    } else {
-                        res = GetGenuineFileDescriptor(streams.ReadStream);
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                        res = GetGenuineFileDescriptor(streams.WriteStream);
                         if (res < 0) throw new InvalidOperationException("stream not associated with a file descriptor");
                         Add(res, streams);
+                    } else {
+                        res = Add(streams);
                     }
                 }
                 return res;
@@ -327,7 +327,7 @@ namespace IronPython.Runtime {
             return fd >= 0 && fd < LIMIT_OFILE;
         }
 
-        [UnsupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux"), SupportedOSPlatform("macos")]
         private static int GetGenuineFileDescriptor(Stream stream) {
             return stream switch {
                 FileStream fs => checked((int)fs.SafeFileHandle.DangerousGetHandle()),

--- a/Tests/modules/system_related/test_os.py
+++ b/Tests/modules/system_related/test_os.py
@@ -7,6 +7,14 @@ import os
 from iptest import IronPythonTestCase, is_osx, is_linux, is_windows, run_test
 
 class OsTest(IronPythonTestCase):
+    def setUp(self):
+        super(OsTest, self).setUp()
+        self.temp_file = os.path.join(self.temporary_dir, "temp_OSTest_%d.dat" % os.getpid())
+
+    def tearDown(self):
+        self.delete_files(self.temp_file)
+        return super().tearDown()
+
     def test_strerror(self):
         if is_windows:
             self.assertEqual(os.strerror(0), "No error")
@@ -28,5 +36,21 @@ class OsTest(IronPythonTestCase):
             self.assertEqual(os.strerror(40), "Too many levels of symbolic links")
         elif is_osx:
             self.assertEqual(os.strerror(40), "Message too long")
+
+    def test_open_abplus(self):
+        # equivalent to open(self.temp_file, "ab+"), see also test_file.test_open_abplus
+        fd = os.open(self.temp_file, os.O_APPEND | os.O_CREAT | os.O_RDWR)
+        try:
+            f = open(fd, mode="ab+", closefd=False)
+            f.write(b"abc")
+            f.seek(0)
+            self.assertEqual(f.read(2), b"ab")
+            f.write(b"def")
+            self.assertEqual(f.read(2), b"")
+            f.seek(0)
+            self.assertEqual(f.read(6), b"abcdef")
+            f.close()
+        finally:
+            os.close(fd)
 
 run_test(__name__)


### PR DESCRIPTION
I think I understand now why IronPython uses sometimes two streams for accessing one file. I may be wrong, but this is what I think is the case:
1. CPython was build on libc, which supports various file opening modes according to POSIX. `O_APPEND | O_CREAT | O_RDWR` is one of them, tagged as mode `ab+`.
2. .NET Framework was build on Win32, which does **not** support file mode `Append` with read access.
3. When CPython is ported to Win32, it uses MSVCRT, which emulates `Append` with R/W by opening with a regular `Open` and then seeking to the end before every write. This is functionally the same as on POSIX but non-atomic, so it may lead to data loss in some circumstances.
4. When .NET was re-developed on POSIX, it maintained the limitation from Win32 of not supporting R/W with `Append`, perhaps for consistency of API.
5. IronPython emulates `ab+` by opening two streams, one for writing with proper file mode `Append`, and a secondary one for reading. Unlike MSVCRT, it does not suffer with problems with data overwrite. 
6. Two streams per file work OK-ish on POSIX, but cause complications when genuine file descriptors come into play (since there are now two open descriptors per one file).

Given above, I decided to keep the two-stream solution, which seems to me is optimal for Win32. In this PR, I extend the two-stream solution to `os.open` (see added test, which is now passing). The usual workarounds for POSIX are still in place, but I still hope that for POSIX, `ab+` can be implemented with one stream — something for another PR.

Other changes in this PR is an explicit set of file position after accessing `SafeFileHandle`, which, according to the [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.safefilehandle?view=net-9.0#remarks) should reset the position to 0. I have not observed this behaviour in the few tests I have run (on macOS/linux the position was unchanged), but I'd rather not argue with the documentation. Perhaps there are some situations when the position is moved. Therefore, `SafeFileHandle` is now only accessed right after opening, before the descriptor/file is passed to the caller (with one exception of `dup2`, which may not even survive the winter).

Finally, wherever I see it, I change the code to put the "platform agnostic" branch in the `else` clause.