### PR TITLE
Fix file seek errors

### DIFF
--- a/Src/IronPython/Runtime/PythonFileManager.cs
+++ b/Src/IronPython/Runtime/PythonFileManager.cs
@@ -222,6 +222,7 @@ namespace IronPython.Runtime {
         internal const int ENOENT = 2;
         internal const int EBADF = 9;
         internal const int EACCES = 13;
+        internal const int EINVAL = 22;
         internal const int EMFILE = 24;
 
         // *** END GENERATED CODE ***

--- a/Src/Scripts/generate_os_codes.py
+++ b/Src/Scripts/generate_os_codes.py
@@ -102,7 +102,7 @@ def darwin_code_expr(codes, fmt):
 def linux_code_expr(codes, fmt):
     return fmt(codes[linux_idx])
 
-common_errno_codes = ['ENOENT', 'EBADF', 'EACCES', 'EMFILE']
+common_errno_codes = ['ENOENT', 'EBADF', 'EACCES', 'EINVAL', 'EMFILE']
 
 def generate_common_errno_codes(cw):
     for name in common_errno_codes:


### PR DESCRIPTION
Mainly with Mono, which does not accept negative seek positions relative to current position, throwing an overflow exception instead.