### PR TITLE
Adjust math.degrees to match CPython

### DIFF
--- a/Src/IronPython.Modules/math.cs
+++ b/Src/IronPython.Modules/math.cs
@@ -30,10 +30,12 @@ namespace IronPython.Modules {
         public const double e = Math.E;
 
         private const double degreesToRadians = Math.PI / 180.0;
+        private const double radiansToDegrees = 180.0 / Math.PI;
+
         private const int Bias = 0x3FE;
 
         public static double degrees(double radians) {
-            return Check(radians, radians / degreesToRadians);
+            return Check(radians, radians * radiansToDegrees);
         }
 
         public static double radians(double degrees) {

--- a/Tests/modules/misc/test_math.py
+++ b/Tests/modules/misc/test_math.py
@@ -718,4 +718,10 @@ def %s(self, other):
         for flt, res in int_ratio_tests:
             self.assertEqual(flt.as_integer_ratio(), res)
 
+    def test_degrees(self):
+        # check that IronPython is doing the same conversion as CPython
+        self.assertNotEqual(0.06825994771674652 / (math.pi / 180), 0.06825994771674652 * (180 / math.pi))
+        self.assertEqual(0.06825994771674652 * (180 / math.pi), 3.911006913953236)
+        self.assertEqual(math.degrees(0.06825994771674652), 3.911006913953236)
+
 run_test(__name__)


### PR DESCRIPTION
Adjusts the `math.degrees` conversion to match CPython.