### PR TITLE
Disable tests in Mono depending on gc.collect()

### DIFF
--- a/Tests/test_descr_stdlib.py
+++ b/Tests/test_descr_stdlib.py
@@ -6,7 +6,7 @@
 ## Run selected tests from test_descr from StdLib
 ##
 
-from iptest import is_ironpython, generate_suite, run_test
+from iptest import is_ironpython, is_mono, generate_suite, run_test
 
 import test.test_descr
 
@@ -55,6 +55,14 @@ def load_tests(loader, standard_tests, pattern):
         ]
 
         skip_tests = []
+
+        if is_mono:
+            skip_tests += [
+                # On Mono, gc.collect() may return before collection is finished making some tests unreliable
+                test.test_descr.ClassPropertiesAndMethods('test_delete_hook'),
+                test.test_descr.ClassPropertiesAndMethods('test_subtype_resurrection'),
+                test.test_descr.ClassPropertiesAndMethods('test_weakrefs'),
+            ]
 
         return generate_suite(tests, failing_tests, skip_tests)
 

--- a/Tests/test_io_stdlib.py
+++ b/Tests/test_io_stdlib.py
@@ -144,6 +144,30 @@ def load_tests(loader, standard_tests, pattern):
             test.test_io.PyMiscIOTest('test_attributes'), # AssertionError: 'wb+' != 'rb+'
         ]
 
+        if is_mono:
+            skip_tests += [
+                # On Mono, gc.collect() may return before collection is finished making some tests unreliable
+                test.test_io.CBufferedWriterTest('test_destructor'),
+                test.test_io.PyBufferedWriterTest('test_destructor'),
+                test.test_io.PyBufferedRandomTest('test_destructor'),
+                test.test_io.PyBufferedReaderTest('test_override_destructor'),
+                test.test_io.PyBufferedWriterTest('test_override_destructor'),
+                test.test_io.PyBufferedRandomTest('test_override_destructor'),
+
+                test.test_io.CTextIOWrapperTest('test_destructor'),
+                test.test_io.CIOTest('test_IOBase_finalize'),
+
+                test.test_io.PyTextIOWrapperTest('test_destructor'),
+                test.test_io.PyTextIOWrapperTest('test_override_destructor'),
+                test.test_io.PyIOTest('test_RawIOBase_destructor'),
+                test.test_io.PyIOTest('test_BufferedIOBase_destructor'),
+                test.test_io.PyIOTest('test_IOBase_destructor'),
+                test.test_io.PyIOTest('test_TextIOBase_destructor'),
+
+                test.test_io.CMiscIOTest('test_blockingioerror'),
+                test.test_io.PyMiscIOTest('test_blockingioerror'),
+            ]
+
         return generate_suite(tests, failing_tests, skip_tests)
 
     else:

--- a/Tests/test_io_stdlib.py
+++ b/Tests/test_io_stdlib.py
@@ -101,11 +101,6 @@ def load_tests(loader, standard_tests, pattern):
             test.test_io.PyMiscIOTest('test_warn_on_dealloc_fd'), # AssertionError: ResourceWarning not triggered
         ]
 
-        if is_mono:
-            failing_tests += [
-                test.test_io.CBufferedRandomTest('test_destructor'), # IndexError: index out of range: 0
-            ]
-
         skip_tests = [
             test.test_io.CBufferedWriterTest('test_override_destructor'), # StackOverflowException
             test.test_io.CBufferedRandomTest('test_override_destructor'), # StackOverflowException
@@ -147,6 +142,7 @@ def load_tests(loader, standard_tests, pattern):
         if is_mono:
             skip_tests += [
                 # On Mono, gc.collect() may return before collection is finished making some tests unreliable
+                test.test_io.CBufferedRandomTest('test_destructor'),
                 test.test_io.CBufferedWriterTest('test_destructor'),
                 test.test_io.PyBufferedWriterTest('test_destructor'),
                 test.test_io.PyBufferedRandomTest('test_destructor'),

--- a/Tests/test_memoryio_stdlib.py
+++ b/Tests/test_memoryio_stdlib.py
@@ -6,7 +6,7 @@
 ## Run selected tests from test_memoryio from StdLib
 ##
 
-from iptest import is_ironpython, generate_suite, run_test
+from iptest import is_ironpython, is_mono, generate_suite, run_test
 
 import test.test_memoryio
 
@@ -24,6 +24,12 @@ def load_tests(loader, standard_tests, pattern):
             test.test_memoryio.CBytesIOTest('test_instance_dict_leak'), # https://github.com/IronLanguages/ironpython3/issues/1004
             test.test_memoryio.CStringIOTest('test_instance_dict_leak'), # https://github.com/IronLanguages/ironpython3/issues/1004
         ]
+
+        if is_mono:
+            skip_tests += [
+                # On Mono, gc.collect() may return before collection is finished making some tests unreliable
+                test.test_memoryio.PyBytesIOTest('test_getbuffer')
+            ]
 
         return generate_suite(tests, failing_tests, skip_tests)
 

--- a/Tests/test_namebinding.py
+++ b/Tests/test_namebinding.py
@@ -3,8 +3,9 @@
 # See the LICENSE file in the project root for more information.
 
 import sys
+import unittest
 
-from iptest import IronPythonTestCase, is_cli, path_modifier, run_test
+from iptest import IronPythonTestCase, is_cli, is_mono, path_modifier, run_test
 
 glb = 0
 res = ''
@@ -312,6 +313,7 @@ class NameBindingTest(IronPythonTestCase):
         self.assertRaises(NameError, DoDelBuiltin)
         self.assertRaises(NameError, DoDelBuiltin)
 
+    @unittest.skipIf(is_mono, "TODO: figure out; the finalizer is called way after WaitForPendingFinalizers")
     def test_SimpleTest(self):
         """simple case"""
         global res


### PR DESCRIPTION
Since I changed to a faster macOS machine, these tests are failing on Mono.

There are still two more tests failing (`test__ssl` and, yup, `test__socket`…), but I haven't investigated them yet. They seem to have a different type of issues than `gc.collect()`.