### PR TITLE
Use PosixFileStream for files on POSIX

### DIFF
--- a/Src/IronPython.Modules/_warnings.cs
+++ b/Src/IronPython.Modules/_warnings.cs
@@ -260,7 +260,7 @@ namespace IronPython.Modules {
                         ((TextWriter)file).Write(text);
                     } // unrecognized file type - warning is lost
                 }
-            } catch (IOException) {
+            } catch (Exception ex) when (ex is IOException or OSException) {
                 // invalid file - warning is lost
             }
         }

--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -116,8 +116,8 @@ the mmap handle is released, it also does `DangerousRelease` of the underlying f
 (if any), plus `Dispose` of it if it owned the file stream.
 
 `SafeFileHandle` closes the underlying file descriptor on dispose and sets it to invalid. It is OK
-to close the handle several times, or even if it add-reffed and in use somewhere else. The
-descriptor will be closed ass soon as the refcount is released, and in the meantime, it will prevent
+to close the handle several times, or even if it is add-reffed and in use somewhere else. The
+descriptor will be closed as soon as the refcount is released, and in the meantime, it will prevent
 future addrefs.
 
 MmapDefault - Rules of Engagement

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -438,7 +438,7 @@ namespace IronPython.Modules {
             if (ClrModule.IsMono) {
                 // Elaborate workaround on Mono to avoid UnixStream as out
                 stream = new Mono.Unix.UnixStream(res, ownsHandle: false);
-                FileAccess fileAccess = stream.CanRead ? stream.CanWrite ? FileAccess.ReadWrite : FileAccess.Read : FileAccess.Write;
+                FileAccess fileAccess = stream.CanWrite ? stream.CanRead ? FileAccess.ReadWrite : FileAccess.Write : FileAccess.Read;
                 stream.Dispose();
                 try {
                     // FileStream on Mono created with a file descriptor might not work: https://github.com/mono/mono/issues/12783
@@ -916,7 +916,6 @@ namespace IronPython.Modules {
                 // Use PosixFileStream to operate on fd directly
                 // On Mono, we must use FileStream due to limitations in MemoryMappedFile
                 Stream s = PosixFileStream.Open(path, flags, unchecked((uint)mode), out int fd);
-                //Stream s = PythonIOModule.FileIO.OpenFilePosix(path, flags, mode, out int fd);
                 if ((flags & O_APPEND) != 0) {
                     s.Seek(0L, SeekOrigin.End);
                 }

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -431,21 +431,40 @@ namespace IronPython.Modules {
         }
 
 
+        [SupportedOSPlatform("linux"), SupportedOSPlatform("osx")]
         private static int UnixDup(int fd, int fd2, out Stream? stream) {
             int res = fd2 < 0 ? Mono.Unix.Native.Syscall.dup(fd) : Mono.Unix.Native.Syscall.dup2(fd, fd2);
             if (res < 0) throw GetLastUnixError();
             if (ClrModule.IsMono) {
-                // This does not work on .NET, probably because .NET FileStream is not aware of Mono.Unix.UnixStream
-                stream = new Mono.Unix.UnixStream(res, ownsHandle: true);
+                // Elaborate workaround on Mono to avoid UnixStream as out
+                stream = new Mono.Unix.UnixStream(res, ownsHandle: false);
+                FileAccess fileAccess = stream.CanRead ? stream.CanWrite ? FileAccess.ReadWrite : FileAccess.Read : FileAccess.Write;
+                stream.Dispose();
+                try {
+                    // FileStream on Mono created with a file descriptor might not work: https://github.com/mono/mono/issues/12783
+                    // Test if it does, without closing the handle if it doesn't
+                    var sfh = new SafeFileHandle((IntPtr)res, ownsHandle: false);
+                    stream = new FileStream(sfh, fileAccess);
+                    // No exception? Great! We can use FileStream.
+                    stream.Dispose();
+                    sfh.Dispose();
+                    stream = null; // Create outside of try block
+                } catch (IOException) {
+                    // Fall back to UnixStream
+                    stream = new Mono.Unix.UnixStream(res, ownsHandle: true);
+                }
+                if (stream is null) {
+                    // FileStream is safe
+                    var sfh = new SafeFileHandle((IntPtr)res, ownsHandle: true);
+                    stream = new FileStream(sfh, fileAccess);
+                }
             } else {
-                // This does not work 100% correctly on .NET, probably because each FileStream has its own read/write cursor
-                // (it should be shared between dupped descriptors)
-                //stream = new FileStream(new SafeFileHandle((IntPtr)res, ownsHandle: true), FileAccess.ReadWrite);
-                // Accidentaly, this would also not work on Mono: https://github.com/mono/mono/issues/12783
-                stream = null; // Handle stream sharing in PythonFileManager
+                // normal case
+                stream = new PosixFileStream(res);
             }
             return res;
         }
+
 
 #if FEATURE_PROCESS
         /// <summary>
@@ -470,6 +489,9 @@ namespace IronPython.Modules {
             PythonFileManager fileManager = context.LanguageContext.FileManager;
 
             if (fileManager.TryGetStreams(fd, out StreamBox? streams)) {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                    return fstatUnix(fd);
+                }
                 if (streams.IsConsoleStream()) return new stat_result(0x2000);
                 if (streams.IsStandardIOStream()) return new stat_result(0x1000);
                 if (StatStream(streams.ReadStream) is not null and var res) return res;
@@ -483,14 +505,8 @@ namespace IronPython.Modules {
 #endif
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                     if (ReferenceEquals(stream, Stream.Null)) return new stat_result(0x2000);
-                } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                    if (IsUnixStream(stream)) return new stat_result(0x1000);
                 }
                 return null;
-            }
-
-            static bool IsUnixStream(Stream stream) {
-                return stream is Mono.Unix.UnixStream;
             }
         }
 
@@ -869,7 +885,16 @@ namespace IronPython.Modules {
 
         private const int DefaultBufferSize = 4096;
 
-        [Documentation("open(path, flags, mode=511, *, dir_fd=None)")]
+        [Documentation("""
+            open(path, flags, mode=511, *, dir_fd=None)
+
+            Open a file for low level IO.  Returns a file descriptor (integer).
+
+            If dir_fd is not None, it should be a file descriptor open to a directory,
+            and path should be relative; path will then be relative to that directory.
+            dir_fd may not be implemented on your platform.
+            If it is unavailable, using it will raise a NotImplementedError.
+            """)]
         public static object open(CodeContext/*!*/ context, [NotNone] string path, int flags, [ParamDictionary, NotNone] IDictionary<string, object> kwargs, [NotNone] params object[] args) {
             var numArgs = args.Length;
             CheckOptionalArgsCount(numRegParms: 2, numOptPosParms: 1, numKwParms: 1, numArgs, kwargs.Count);
@@ -889,12 +914,23 @@ namespace IronPython.Modules {
                 }
             }
 
+            if ((RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && !ClrModule.IsMono) {
+                // Use PosixFileStream to operate on fd directly
+                // On Mono, we must use FileStream due to limitations in MemoryMappedFile
+                Stream s = PosixFileStream.Open(path, flags, unchecked((uint)mode), out int fd);
+                //Stream s = PythonIOModule.FileIO.OpenFilePosix(path, flags, mode, out int fd);
+                if ((flags & O_APPEND) != 0) {
+                    s.Seek(0L, SeekOrigin.End);
+                }
+                return context.LanguageContext.FileManager.Add(fd, new(s));
+            }
+
             try {
                 FileMode fileMode = FileModeFromFlags(flags);
                 FileAccess access = FileAccessFromFlags(flags);
                 FileOptions options = FileOptionsFromFlags(flags);
                 Stream s;            // the stream opened to acces the file
-                FileStream? fs;      // downcast of s if s is FileStream (this is always the case on POSIX)
+                FileStream? fs;      // downcast of s if s is FileStream
                 Stream? rs = null;   // secondary read stream if needed, otherwise same as s
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && IsNulFile(path)) {
                     fs = null;
@@ -1436,6 +1472,13 @@ namespace IronPython.Modules {
             return LightExceptions.Throw(GetLastUnixError(path));
         }
 
+        private static object fstatUnix(int fd) {
+            if (Mono.Unix.Native.Syscall.fstat(fd, out Mono.Unix.Native.Stat buf) == 0) {
+                return new stat_result(buf);
+            }
+            return LightExceptions.Throw(GetLastUnixError());
+        }
+
         private const int OPEN_EXISTING = 3;
         private const int FILE_ATTRIBUTE_NORMAL = 0x00000080;
         private const int FILE_READ_ATTRIBUTES = 0x0080;
@@ -1669,8 +1712,27 @@ namespace IronPython.Modules {
         public static void truncate(CodeContext context, int fd, BigInteger length)
             => ftruncate(context, fd, length);
 
-        public static void ftruncate(CodeContext context, int fd, BigInteger length)
-            => context.LanguageContext.FileManager.GetStreams(fd).Truncate((long)length);
+        public static void ftruncate(CodeContext context, int fd, BigInteger length) {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                ftruncateUnix(fd, (long)length);
+            } else {
+                context.LanguageContext.FileManager.GetStreams(fd).Truncate((long)length);
+            }
+        }
+
+
+        [SupportedOSPlatform("linux"), SupportedOSPlatform("osx")]
+        internal static void ftruncateUnix(int fd, long length) {
+            int result;
+            Mono.Unix.Native.Errno errno;
+            do {
+                result = Mono.Unix.Native.Syscall.ftruncate(fd, length);
+            } while (Mono.Unix.UnixMarshal.ShouldRetrySyscall(result, out errno));
+
+            if (errno != 0)
+                throw GetOsError(Mono.Unix.Native.NativeConvert.FromErrno(errno));
+        }
+
 
 #if FEATURE_FILESYSTEM
         public static object times() {

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -2417,7 +2417,7 @@ the 'status' value."),
 
 #if FEATURE_NATIVE
 
-        private static Exception GetLastUnixError(string? filename = null, string? filename2 = null)
+        internal static Exception GetLastUnixError(string? filename = null, string? filename2 = null)
             => GetOsError(Mono.Unix.Native.NativeConvert.FromErrno(Mono.Unix.Native.Syscall.GetLastError()), filename, filename2);
 
 #endif

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -109,7 +109,6 @@ namespace IronPython.Modules {
                         // Use PosixFileStream to operate on fd directly
                         // On Mono, we must use FileStream due to limitations in MemoryMappedFile
                         var stream = PosixFileStream.Open(name, flags, 0b_110_110_110, out int fd);  // mode: rw-rw-rw-
-                        //var stream = OpenFilePosix(name, flags, 0b_110_110_110, out int fd);
                         if ((flags & O_APPEND) != 0) {
                             stream.Seek(0L, SeekOrigin.End);
                         }
@@ -152,7 +151,7 @@ namespace IronPython.Modules {
                         }
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                             // On POSIX, register the file descriptor with the file manager right after file opening
-                            // Because the .NET case is already handled above before `switch`, this branch runs only on Mono
+                            // This branch is needed for Mono, the .NET case is already handled above before `switch`
                             _context.FileManager.GetOrAssignId(_streams);
                             // according to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.safefilehandle?view=net-9.0#remarks)
                             // accessing SafeFileHandle sets the current stream position to 0

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -305,10 +305,10 @@ namespace IronPython.Modules {
 
                 try {
                     flush(context);
-                } catch (IOException) {
-                    // flushing can fail, esp. if the other half of a pipe is closed
-                    // ignore it because we're closing anyway
-                }
+                } catch (IOException) { /* ignore */ } catch (OSException) { /* ignore */ }
+                // flushing can fail, esp. if the other half of a pipe is closed
+                // ignore it because we're closing anyway
+
                 _closed = true;
 
                 if (_closefd) {

--- a/Src/IronPython/Modules/_fileio.cs
+++ b/Src/IronPython/Modules/_fileio.cs
@@ -105,55 +105,67 @@ namespace IronPython.Modules {
                 this.mode = NormalizeMode(mode, out int flags);
 
                 if (opener is null) {
-                    switch (this.mode) {
-                        case "rb":
-                            _streams = new(OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
-                            break;
-                        case "wb":
-                            _streams = new(OpenFile(context, pal, name, FileMode.Create, FileAccess.Write, FileShare.ReadWrite));
-                            break;
-                        case "xb":
-                            _streams = new(OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite));
-                            break;
-                        case "ab":
-                            _streams = new(OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite));
-                            _streams.ReadStream.Seek(0L, SeekOrigin.End);
-                            break;
-                        case "rb+":
-                            _streams = new(OpenFile(context, pal, name, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite));
-                            break;
-                        case "wb+":
-                            _streams = new(OpenFile(context, pal, name, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
-                            break;
-                        case "xb+":
-                            _streams = new(OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite));
-                            break;
-                        case "ab+":
-                            // Opening writeStream before readStream will create the file if it does not exist
-                            var writeStream = OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-                            var readStream = OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                            readStream.Seek(0L, SeekOrigin.End);
-                            writeStream.Seek(0L, SeekOrigin.End);
-                            _streams = new(readStream, writeStream);
-                            break;
-                        default:
-                            throw new InvalidOperationException();
-                    }
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                        // On POSIX, register the file descriptor with the file manager right after file opening
-                        _context.FileManager.GetOrAssignId(_streams);
-                        // according to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.safefilehandle?view=net-9.0#remarks)
-                        // accessing SafeFileHandle sets the current stream position to 0
-                        // in practice it doesn't seem to be the case, but better to be sure
-                        if (this.mode.StartsWith("ab", StringComparison.InvariantCulture)) {
-                            _streams.WriteStream.Seek(0L, SeekOrigin.End);
+                    if ((RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && !ClrModule.IsMono) {
+                        // Use PosixFileStream to operate on fd directly
+                        // On Mono, we must use FileStream due to limitations in MemoryMappedFile
+                        var stream = PosixFileStream.Open(name, flags, 0b_110_110_110, out int fd);  // mode: rw-rw-rw-
+                        //var stream = OpenFilePosix(name, flags, 0b_110_110_110, out int fd);
+                        if ((flags & O_APPEND) != 0) {
+                            stream.Seek(0L, SeekOrigin.End);
                         }
-                        if (!_streams.IsSingleStream) {
-                            _streams.ReadStream.Seek(_streams.WriteStream.Position, SeekOrigin.Begin);
+                        _streams = new(stream);
+                        _context.FileManager.Add(fd, _streams);
+                    } else {
+                        switch (this.mode) {
+                            case "rb":
+                                _streams = new(OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+                                break;
+                            case "wb":
+                                _streams = new(OpenFile(context, pal, name, FileMode.Create, FileAccess.Write, FileShare.ReadWrite));
+                                break;
+                            case "xb":
+                                _streams = new(OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite));
+                                break;
+                            case "ab":
+                                _streams = new(OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite));
+                                _streams.WriteStream.Seek(0L, SeekOrigin.End);
+                                break;
+                            case "rb+":
+                                _streams = new(OpenFile(context, pal, name, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite));
+                                break;
+                            case "wb+":
+                                _streams = new(OpenFile(context, pal, name, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
+                                break;
+                            case "xb+":
+                                _streams = new(OpenFile(context, pal, name, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite));
+                                break;
+                            case "ab+":
+                                // Opening writeStream before readStream will create the file if it does not exist
+                                var writeStream = OpenFile(context, pal, name, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+                                var readStream = OpenFile(context, pal, name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                                readStream.Seek(0L, SeekOrigin.End);
+                                writeStream.Seek(0L, SeekOrigin.End);
+                                _streams = new(readStream, writeStream);
+                                break;
+                            default:
+                                throw new InvalidOperationException();
+                        }
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                            // On POSIX, register the file descriptor with the file manager right after file opening
+                            // Because the .NET case is already handled above before `switch`, this branch runs only on Mono
+                            _context.FileManager.GetOrAssignId(_streams);
+                            // according to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.filestream.safefilehandle?view=net-9.0#remarks)
+                            // accessing SafeFileHandle sets the current stream position to 0
+                            // in practice it doesn't seem to be the case, but better to be sure
+                            if (this.mode[0] == 'a') {
+                                _streams.WriteStream.Seek(0L, SeekOrigin.End);
+                            }
+                            if (!_streams.IsSingleStream) {
+                                _streams.ReadStream.Seek(_streams.WriteStream.Position, SeekOrigin.Begin);
+                            }
                         }
                     }
-                }
-                else {
+                } else {  // opener is not null
                     object? fdobj = PythonOps.CallWithContext(context, opener, name, flags);
                     if (fdobj is int fd) {
                         if (fd < 0) {

--- a/Src/IronPython/Runtime/PosixFileStream.cs
+++ b/Src/IronPython/Runtime/PosixFileStream.cs
@@ -1,0 +1,267 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+#define SPAN_OVERRIDE  // Stream has Span<T>-based virtual methods
+#endif
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+using Mono.Unix;
+using Mono.Unix.Native;
+
+using IronPython.Runtime.Operations;
+using System.Diagnostics;
+using IronPython.Runtime.Exceptions;
+
+#nullable enable
+
+namespace IronPython.Runtime;
+
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
+internal class PosixFileStream : Stream
+{
+    private readonly int _fd;
+    private readonly bool _canSeek;
+    private readonly bool _canRead;
+    private readonly bool _canWrite;
+
+    private bool _disposed;
+
+
+    public PosixFileStream(int fileDescriptor) {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            throw new PlatformNotSupportedException("This stream only works on POSIX systems");
+
+        if (fileDescriptor < 0)
+            throw PythonOps.OSError(PythonFileManager.EBADF, "Bad file descriptor");
+
+        _fd = fileDescriptor;
+
+        _canSeek = Syscall.lseek(fileDescriptor, 0, SeekFlags.SEEK_CUR) >= 0;
+        _canRead = Syscall.read(fileDescriptor, IntPtr.Zero, 0) == 0;
+        _canWrite = Syscall.write(fileDescriptor, IntPtr.Zero, 0) == 0;
+    }
+
+
+    public static Stream Open(string name, int flags, uint mode, out int fd) {
+        OpenFlags openFlags = NativeConvert.ToOpenFlags(flags);
+        FilePermissions permissions = NativeConvert.ToFilePermissions(mode);
+        Errno errno;
+
+        do {
+            fd = Syscall.open(name, openFlags, permissions);
+        } while (UnixMarshal.ShouldRetrySyscall(fd, out errno));
+
+        if (fd < 0) {
+            Debug.Assert(errno != 0);
+            throw CreateExceptionForLastError(errno, name);
+        }
+        return new PosixFileStream(fd);
+    }
+
+
+    public int Handle => _fd;
+
+    public override bool CanSeek => _canSeek;
+    public override bool CanRead => _canRead;
+    public override bool CanWrite => _canWrite;
+
+
+    public override long Length {
+        get {
+            ThrowIfDisposed();
+            int res = Syscall.fstat(_fd, out Stat stat);
+            ThrowIfError(res);
+
+            return stat.st_size;
+        }
+    }
+
+
+    public override long Position {
+        get => Seek(0, SeekOrigin.Current);
+        set => Seek(value, SeekOrigin.Begin);
+    }
+
+
+    public override long Seek(long offset, SeekOrigin origin) {
+        ThrowIfDisposed();
+        SeekFlags whence = origin switch
+        {
+            SeekOrigin.Begin => SeekFlags.SEEK_SET,
+            SeekOrigin.Current => SeekFlags.SEEK_CUR,
+            SeekOrigin.End => SeekFlags.SEEK_END,
+            _ => throw PythonOps.OSError(PythonFileManager.EINVAL, "Invalid argument")
+        };
+
+        long result = Syscall.lseek(_fd, offset, whence);
+        ThrowIfError(result);
+
+        return result;
+    }
+
+
+    public override void SetLength(long value) {
+        ThrowIfDisposed();
+        int result;
+        Errno errno;
+        do {
+            result = Syscall.ftruncate(_fd, value);
+        } while (UnixMarshal.ShouldRetrySyscall(result, out errno));
+        ThrowIfError(errno);
+    }
+
+
+#if SPAN_OVERRIDE
+#pragma warning disable IDE0036  // Modifiers are not ordered
+    override
+#pragma warning restore IDE0036
+#endif
+    public int Read(Span<byte> buffer) {
+        ThrowIfDisposed();
+        if (!CanRead)
+            throw PythonOps.OSError(PythonFileManager.EBADF, "Bad file descriptor");
+
+
+        if (buffer.Length == 0)
+            return 0;
+
+        int bytesRead;
+        Errno errno;
+        unsafe {
+            fixed (byte* buf = buffer) {
+                do {
+                    bytesRead = (int)Syscall.read(_fd, buf, (ulong)buffer.Length);
+                } while (UnixMarshal.ShouldRetrySyscall(bytesRead, out errno));
+            }
+        }
+        ThrowIfError(errno);
+
+        return bytesRead;
+    }
+
+
+    // If offset == 0 and count == 0, buffer is allowed to be null.
+    public override int Read(byte[] buffer, int offset, int count) {
+        ThrowIfDisposed();
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+
+    public override int ReadByte() {
+        Span<byte> buffer = stackalloc byte[1];
+        int bytesRead = Read(buffer);
+        return bytesRead == 0 ? -1 : buffer[0];
+    }
+
+
+#if SPAN_OVERRIDE
+#pragma warning disable IDE0036  // Modifiers are not ordered
+    override
+#pragma warning restore IDE0036
+#endif
+    public void Write(ReadOnlySpan<byte> buffer) {
+        ThrowIfDisposed();
+        if (!CanWrite)
+            throw PythonOps.OSError(PythonFileManager.EBADF, "Bad file descriptor");
+
+        if (buffer.Length == 0)
+            return;
+
+        int bytesWritten;
+        Errno errno;
+        unsafe {
+            fixed (byte* buf = buffer) {
+                do {
+                    bytesWritten = (int)Syscall.write(_fd, buf, (ulong)buffer.Length);
+                } while (UnixMarshal.ShouldRetrySyscall(bytesWritten, out errno));
+            }
+        }
+        ThrowIfError(errno);
+    }
+
+    // If offset == 0 and count == 0, buffer is allowed to be null.
+    public override void Write(byte[] buffer, int offset, int count) {
+        ThrowIfDisposed();
+        Write(buffer.AsSpan(offset, count));
+    }
+
+
+    public override void WriteByte(byte value) {
+        Span<byte> buffer = stackalloc byte[] { value };
+        Write(buffer);
+    }
+
+
+    public override void Flush() {
+        ThrowIfDisposed();
+        int result;
+        Errno errno;
+        do {
+            result = Syscall.fsync(_fd);
+        } while (UnixMarshal.ShouldRetrySyscall(result, out errno));
+        ThrowIfError(errno);
+    }
+
+    protected override void Dispose(bool disposing) {
+        if (!_disposed) {
+            int result = Syscall.close(_fd);
+            WarnIfError(result, "Error closing file descriptor {0}: {1}: {2}");
+            _disposed = true;
+        }
+        base.Dispose(disposing);
+    }
+
+
+    #region Private Methods
+
+    private void ThrowIfDisposed() {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
+    }
+
+
+    private static void ThrowIfError(long result) {
+        if (result < 0)
+            throw CreateExceptionForLastError();
+    }
+
+
+    private static void ThrowIfError(Errno errno) {
+        if (errno != 0)
+            throw CreateExceptionForLastError(errno);
+    }
+
+
+    private static Exception CreateExceptionForLastError(string? filename = null) {
+        Errno errno = Stdlib.GetLastError();
+        return CreateExceptionForLastError(errno, filename);
+    }
+
+
+    private static Exception CreateExceptionForLastError(Errno errno, string? filename = null) {
+        if (errno == 0) return new InvalidOperationException("Unknown error");
+
+        string msg = UnixMarshal.GetErrorDescription(errno);
+        int error = NativeConvert.FromErrno(errno);
+        return PythonOps.OSError(error, msg, filename);
+    }
+
+    private void WarnIfError(int result, string msgTmpl) {
+        if (result < 0) {
+            Errno errno = Stdlib.GetLastError();
+            int error = NativeConvert.FromErrno(errno);
+            PythonOps.Warn(DefaultContext.Default,
+                PythonExceptions.RuntimeWarning,
+                msgTmpl, _fd, error, UnixMarshal.GetErrorDescription(errno));
+        }
+    }
+
+    #endregion
+}

--- a/Tests/test_file.py
+++ b/Tests/test_file.py
@@ -702,7 +702,7 @@ class FileTest(IronPythonTestCase):
 
         with self.assertRaises(OSError) as cm:
             open('path_too_long' * 100)
-        self.assertEqual(cm.exception.errno, (errno.ENAMETOOLONG if is_posix else errno.EINVAL) if is_netcoreapp and not is_posix or sys.version_info >= (3,6) else errno.ENOENT)
+        self.assertEqual(cm.exception.errno, (errno.ENAMETOOLONG if is_posix else errno.EINVAL) if is_netcoreapp or sys.version_info >= (3,6) else errno.ENOENT)
 
     def test_write_bytes(self):
         fname = self.temp_file

--- a/Tests/test_io_stdlib.py
+++ b/Tests/test_io_stdlib.py
@@ -6,7 +6,7 @@
 ## Run selected tests from test_io from StdLib
 ##
 
-from iptest import is_ironpython, is_mono, generate_suite, run_test
+from iptest import is_ironpython, is_mono, is_windows, generate_suite, run_test
 
 import test.test_io
 
@@ -100,7 +100,7 @@ def load_tests(loader, standard_tests, pattern):
             test.test_io.PyMiscIOTest('test_warn_on_dealloc_fd'), # AssertionError: ResourceWarning not triggered
         ]
 
-        if is_mono:
+        if is_mono or is_windows:
             failing_tests += [
                 test.test_io.PyTextIOWrapperTest('test_seek_append_bom'), # OSError: [Errno -2146232800] Unable seek backward to overwrite data that previously existed in a file opened in Append mode.
             ]

--- a/Tests/test_io_stdlib.py
+++ b/Tests/test_io_stdlib.py
@@ -85,7 +85,6 @@ def load_tests(loader, standard_tests, pattern):
             test.test_io.CTextIOWrapperTest('test_uninitialized'), # AssertionError: Exception not raised by repr
             test.test_io.CTextIOWrapperTest('test_unseekable'), # OSError: underlying stream is not seekable
             test.test_io.PyTextIOWrapperTest('test_nonnormalized_close_error_on_close'), # AssertionError: None is not an instance of <class 'NameError'>
-            test.test_io.PyTextIOWrapperTest('test_seek_append_bom'), # OSError: [Errno -2146232800] Unable seek backward to overwrite data that previously existed in a file opened in Append mode.
             test.test_io.CMiscIOTest('test_io_after_close'), # AttributeError: 'TextIOWrapper' object has no attribute 'read1'
             test.test_io.CMiscIOTest('test_nonblock_pipe_write_bigbuf'), # AttributeError: 'module' object has no attribute 'fcntl'
             test.test_io.CMiscIOTest('test_nonblock_pipe_write_smallbuf'), # AttributeError: 'module' object has no attribute 'fcntl'
@@ -100,6 +99,11 @@ def load_tests(loader, standard_tests, pattern):
             test.test_io.PyMiscIOTest('test_warn_on_dealloc'), # AssertionError: ResourceWarning not triggered
             test.test_io.PyMiscIOTest('test_warn_on_dealloc_fd'), # AssertionError: ResourceWarning not triggered
         ]
+
+        if is_mono:
+            failing_tests += [
+                test.test_io.PyTextIOWrapperTest('test_seek_append_bom'), # OSError: [Errno -2146232800] Unable seek backward to overwrite data that previously existed in a file opened in Append mode.
+            ]
 
         skip_tests = [
             test.test_io.CBufferedWriterTest('test_override_destructor'), # StackOverflowException


### PR DESCRIPTION
This PR replaces `FileStream` with `PosixFileStream` on .NET/POSIX (not Mono), which offers unbuffered access to the file though its actual file descriptor. This addresses the issue #1846 on .NET/POSIX.

I decided to write own implementation of the stream, rather than encapsulating `UnixStream`. Not only the implementation had similar amount of work involved and complexity as a proxy class to `UnixStream`, but also it allowed me to make different implementation choices than `UnixStream`, some of which I would call problematic. The best example is `UnixStream.Close()`, which retries syscall to `close` if interrupted. This will result in error EBADF at best, and close an unrelated file descriptor at worst. It's because, on most systems (including Linux and macOS), `close` always closes the descriptor, even it the call fails with an error, and retry is not appropriate. See [CPython source code](https://github.com/python/cpython/blob/ef63cca494571f50906baae1d176469a3dcf8838/Modules/posixmodule.c#L11167-L11173). 

Another effect of this PR is that for .NET/POSIX, there are no more "double streams", meaning that operations on file descriptors behave as expected in all cases (modulo bugs and missing pieces).

The performance of this implementation is roughly the same as CPython's. When I first tested it, I shockingly discovered that it was 2.5 times slower, but then noticed that `StreamBox` always calls `Flush` after each write and that was slowing things down significantly. I included a hack to avoid it for `PosixFileStream` and it helped.

Module `mmap` is due for some cleanup, which is outside of the scope of this PR.

Unfortunately I had to leave Mono behind, that is, on `FileStream`. Between the limitations/bugs of `MemoryMappedFile` interface and `FileStream`, using `PosixFileStream` on Mono (or even `UnixStream`) would create a regression in `mmap`.

This PR also makes sure that all file descriptors created via `open` or `io.open` on .NET/POSIX are non-inheritable, in line with #1225.