### PR TITLE
Enable test_mmap on net8.0/POSIX

### DIFF
--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -587,7 +587,7 @@ IsolationLevel=PROCESS # Also weakref failures; https://github.com/IronLanguages
 Ignore=true
 
 [CPython.test_mmap]
-RunCondition=NOT $(IS_POSIX)
+RunCondition=NOT $(IS_POSIX) OR (NOT $(IS_MONO) AND '$(FRAMEWORK)' <> '.NETCoreApp,Version=v6.0')
 IsolationLevel=PROCESS
 
 [CPython.test_module]


### PR DESCRIPTION
Establishing a mmap test from StdLib on POSIX to prevent unnoticed regressions from #1855.

The test does not pass on .NET 6.0, which has problems with mmaps not backed by an existing file. A workaround is possible, but likely quite tricky to get it right (i.e. w/o data leaking). I don't think it is worth the effort given that .NET 6.0 is now past its EOL.

The case of Mono seems hopeless; it dumps core when running this test.