### PR TITLE
Support additional memory protection flag combinations

### DIFF
--- a/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/CPythonCasesManifest.ini
@@ -587,7 +587,7 @@ IsolationLevel=PROCESS # Also weakref failures; https://github.com/IronLanguages
 Ignore=true
 
 [CPython.test_mmap]
-RunCondition=NOT $(IS_POSIX) OR (NOT $(IS_MONO) AND '$(FRAMEWORK)' <> '.NETCoreApp,Version=v6.0')
+RunCondition=NOT $(IS_MONO) AND (NOT $(IS_OSX) OR '$(FRAMEWORK)' <> '.NETCoreApp,Version=v6.0')
 IsolationLevel=PROCESS
 
 [CPython.test_module]

--- a/Src/StdLib/Lib/test/test_mmap.py
+++ b/Src/StdLib/Lib/test/test_mmap.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import re
 import itertools
+import struct   # IronPython: for platform architecture detection
 import socket
 import sys
 import weakref
@@ -715,7 +716,6 @@ class MmapTests(unittest.TestCase):
         gc_collect()
         self.assertIs(wr(), None)
 
-@unittest.skipIf(sys.implementation.name == "ironpython", "TODO")
 class LargeMmapTests(unittest.TestCase):
 
     def setUp(self):
@@ -748,7 +748,8 @@ class LargeMmapTests(unittest.TestCase):
 
     def test_large_filesize(self):
         with self._make_test_file(0x17FFFFFFF, b" ") as f:
-            if sys.maxsize < 0x180000000:
+            #if sys.maxsize < 0x180000000: # original CPython test
+            if struct.calcsize('P') * 8 == 32: # IronPython: better detection of 32-bit platform
                 # On 32 bit platforms the file is larger than sys.maxsize so
                 # mapping the whole file should fail -- Issue #16743
                 with self.assertRaises(OverflowError):
@@ -768,11 +769,13 @@ class LargeMmapTests(unittest.TestCase):
             with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as m:
                 self.assertEqual(m[start:end], tail)
 
-    @unittest.skipUnless(sys.maxsize > _4G, "test cannot run on 32-bit systems")
+    #@unittest.skipUnless(sys.maxsize > _4G, "test cannot run on 32-bit systems") # original CPython decorator
+    @unittest.skipUnless(struct.calcsize('P') * 8 > 32, "test cannot run on 32-bit systems") # IronPython: better detection of 32-bit platform
     def test_around_2GB(self):
         self._test_around_boundary(_2G)
 
-    @unittest.skipUnless(sys.maxsize > _4G, "test cannot run on 32-bit systems")
+    #@unittest.skipUnless(sys.maxsize > _4G, "test cannot run on 32-bit systems") # original CPython decorator
+    @unittest.skipUnless(struct.calcsize('P') * 8 > 32, "test cannot run on 32-bit systems") # IronPython: better detection of 32-bit platform
     def test_around_4GB(self):
         self._test_around_boundary(_4G)
 


### PR DESCRIPTION
One test is failing on my macOS (using Sequoia on ARM64). I have traced it to python/cpython#107888. I wonder what will happen on CI.

It turns out that `test_mmap` passes on .NET 6.0 on Linux, but not on macOS. Go figure. Anyway, I've relaxed the test run condition accordingly.

I have enabled some more tests that were marked TODO. It required some small and self-evident modifications to the test in StdLib. I've left comments at those places, in case there are some merge conflicts with later Python branches.