### PR TITLE
Backport fixes to python/cpython#107888

### DIFF
--- a/Src/StdLib/Lib/test/test_mmap.py
+++ b/Src/StdLib/Lib/test/test_mmap.py
@@ -242,10 +242,15 @@ class MmapTests(unittest.TestCase):
             # Try writing with PROT_EXEC and without PROT_WRITE
             prot = mmap.PROT_READ | getattr(mmap, 'PROT_EXEC', 0)
             with open(TESTFN, "r+b") as f:
-                m = mmap.mmap(f.fileno(), mapsize, prot=prot)
-                self.assertRaises(TypeError, m.write, b"abcdef")
-                self.assertRaises(TypeError, m.write_byte, 0)
-                m.close()
+                try:
+                    m = mmap.mmap(f.fileno(), mapsize, prot=prot)
+                except PermissionError:
+                    # on macOS 14, PROT_READ | PROT_WRITE is not allowed
+                    pass
+                else:
+                    self.assertRaises(TypeError, m.write, b"abcdef")
+                    self.assertRaises(TypeError, m.write_byte, 0)
+                    m.close()
 
     def test_bad_file_desc(self):
         # Try opening a bad file descriptor...

--- a/Src/StdLib/Lib/test/test_mmap.py
+++ b/Src/StdLib/Lib/test/test_mmap.py
@@ -245,7 +245,7 @@ class MmapTests(unittest.TestCase):
                 try:
                     m = mmap.mmap(f.fileno(), mapsize, prot=prot)
                 except PermissionError:
-                    # on macOS 14, PROT_READ | PROT_WRITE is not allowed
+                    # on macOS 14, PROT_READ | PROT_EXEC is not allowed
                     pass
                 else:
                     self.assertRaises(TypeError, m.write, b"abcdef")

--- a/Src/StdLib/Lib/test/test_mmap.py
+++ b/Src/StdLib/Lib/test/test_mmap.py
@@ -242,6 +242,7 @@ class MmapTests(unittest.TestCase):
             # Try writing with PROT_EXEC and without PROT_WRITE
             prot = mmap.PROT_READ | getattr(mmap, 'PROT_EXEC', 0)
             with open(TESTFN, "r+b") as f:
+                # try/except backported from Python 3.12
                 try:
                     m = mmap.mmap(f.fileno(), mapsize, prot=prot)
                 except PermissionError:


### PR DESCRIPTION
I kept them as a separate PR, in case they need to be reverted when IronPython migrates to later StdLib versions where these patches are already applied. AFAICS, 3.6 does not contain them.

Fixes local test failure in #1864.