### PR TITLE
Add IBufferProtocol to mmap

### DIFF
--- a/src/core/IronPython.Modules/mmap.cs
+++ b/src/core/IronPython.Modules/mmap.cs
@@ -601,6 +601,11 @@ namespace IronPython.Modules {
                         reason = StateBits.Exporting;
                         return false;
                     }
+                    if (exclusive && ((oldState & StateBits.RefCount) > StateBits.RefCountOne)) {
+                        // mmap in non-exclusive use, temporarily no exclusive use allowed
+                        reason = StateBits.Exclusive;
+                        return false;
+                    }
                     Debug.Assert((oldState & StateBits.RefCount) > 0, "resurrecting disposed mmap object (disposed without being closed)");
 
                     newState = oldState + StateBits.RefCountOne;

--- a/src/core/IronPython.Modules/re.cs
+++ b/src/core/IronPython.Modules/re.cs
@@ -516,11 +516,6 @@ namespace IronPython.Modules {
                         case IList<byte> b:
                             str = b.MakeString();
                             break;
-#if FEATURE_MMAP
-                        case MmapModule.MmapDefault mmapFile:
-                            str = mmapFile.GetSearchString().MakeString();
-                            break;
-#endif
                         case string _:
                         case ExtensibleString _:
                             throw PythonOps.TypeError("cannot use a bytes pattern on a string-like object");
@@ -537,9 +532,6 @@ namespace IronPython.Modules {
                             break;
                         case IBufferProtocol _:
                         case IList<byte> _:
-#if FEATURE_MMAP
-                        case MmapModule.MmapDefault _:
-#endif
                             throw PythonOps.TypeError("cannot use a string pattern on a bytes-like object");
                         default:
                             throw PythonOps.TypeError("expected string or bytes-like object");


### PR DESCRIPTION
Add `IBufferProtocol` to `mmap`. Throws a `NotImplementedException` if the length does not fit in a `int`.

For the case of bigger files I think we'll have to rework `IPythonBuffer`. My initial thoughts on changes would be:
- Use `nint` in place of `int` where applicable (probably where CPython uses `Py_ssize_t`).
- Change `AsSpan`/`AsReadOnlySpan` methods to have an `nint start` argument.
- Fix up everything to use `nint` arithmetic instead of `int`.

Marking as draft since I need to do more testing (and maybe write some tests). @BCSharp I'm not sure if you looked at/thought about this before so if you have any feedback would appreciate it.

Related to https://github.com/IronLanguages/ironpython3/issues/1408