### PR TITLE
Rename PythonErrorNumber to PythonErrno

### DIFF
--- a/Src/IronPython.Modules/errno.cs
+++ b/Src/IronPython.Modules/errno.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 
 using IronPython.Runtime;
 
-[assembly: PythonModule("errno", typeof(IronPython.Modules.PythonErrorNumber))]
+[assembly: PythonModule("errno", typeof(IronPython.Modules.PythonErrno))]
 namespace IronPython.Modules {
-    public static class PythonErrorNumber {
+    public static class PythonErrno {
         public const string __doc__ = "Provides a list of common error numbers.  These numbers are frequently reported in various exceptions.";
 
         internal const int ENOERROR = 0;

--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -234,7 +234,7 @@ namespace IronPython.Modules {
             private static MemoryMappedFileAccess ToMmapFileAccess(int flags, int prot, int access) {
                 if (access == ACCESS_DEFAULT) {
                     if ((flags & (MAP_PRIVATE | MAP_SHARED)) == 0) {
-                        throw PythonOps.OSError(PythonErrorNumber.EINVAL, "Invalid argument");
+                        throw PythonOps.OSError(PythonErrno.EINVAL, "Invalid argument");
                     }
                     if ((prot & PROT_WRITE) != 0) {
                         prot |= PROT_READ;
@@ -830,7 +830,7 @@ namespace IronPython.Modules {
                         // resize on Posix platforms
                         try {
                             if (_handle.IsInvalid) {
-                                throw PythonOps.OSError(PythonErrorNumber.EBADF, "Bad file descriptor");
+                                throw PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor");
                             }
                             _view.Flush();
                             _view.Dispose();

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -397,7 +397,7 @@ namespace IronPython.Modules {
             }
 
             if (!fileManager.ValidateFdRange(fd2)) {
-                throw PythonOps.OSError(PythonErrorNumber.EBADF, "Bad file descriptor");
+                throw PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor");
             }
 
             if (fileManager.TryGetStreams(fd2, out _)) {
@@ -496,7 +496,7 @@ namespace IronPython.Modules {
                 if (streams.IsStandardIOStream()) return new stat_result(0x1000);
                 if (StatStream(streams.ReadStream) is not null and var res) return res;
             }
-            return LightExceptions.Throw(PythonOps.OSError(PythonErrorNumber.EBADF, "Bad file descriptor"));
+            return LightExceptions.Throw(PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor"));
 
             static object? StatStream(Stream stream) {
                 if (stream is FileStream fs) return lstat(fs.Name, new Dictionary<string, object>(1));
@@ -516,7 +516,7 @@ namespace IronPython.Modules {
             try {
                 streams.Flush();
             } catch (IOException) {
-                throw PythonOps.OSError(PythonErrorNumber.EBADF, "Bad file descriptor");
+                throw PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor");
             }
         }
 
@@ -1039,13 +1039,13 @@ namespace IronPython.Modules {
 
         public static Bytes read(CodeContext/*!*/ context, int fd, int buffersize) {
             if (buffersize < 0) {
-                throw PythonOps.OSError(PythonErrorNumber.EINVAL, "Invalid argument");
+                throw PythonOps.OSError(PythonErrno.EINVAL, "Invalid argument");
             }
 
             try {
                 PythonContext pythonContext = context.LanguageContext;
                 var streams = pythonContext.FileManager.GetStreams(fd);
-                if (!streams.ReadStream.CanRead) throw PythonOps.OSError(PythonErrorNumber.EBADF, "Bad file descriptor");
+                if (!streams.ReadStream.CanRead) throw PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor");
 
                 return Bytes.Make(streams.Read(buffersize));
             } catch (Exception e) {
@@ -1942,7 +1942,7 @@ namespace IronPython.Modules {
             Process? process;
             lock (_processToIdMapping) {
                 if (!_processToIdMapping.TryGetValue(pid, out process)) {
-                    throw GetOsError(PythonErrorNumber.ECHILD);
+                    throw GetOsError(PythonErrno.ECHILD);
                 }
             }
 
@@ -1964,7 +1964,7 @@ namespace IronPython.Modules {
                 using var buffer = data.GetBuffer();
                 PythonContext pythonContext = context.LanguageContext;
                 var streams = pythonContext.FileManager.GetStreams(fd);
-                if (!streams.WriteStream.CanWrite) throw PythonOps.OSError(PythonErrorNumber.EBADF, "Bad file descriptor");
+                if (!streams.WriteStream.CanWrite) throw PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor");
 
                 return streams.Write(buffer);
             } catch (Exception e) {
@@ -2411,7 +2411,7 @@ the 'status' value."),
                 return GetWin32Error(PythonExceptions._OSError.ERROR_ALREADY_EXISTS, filename);
             }
 #endif
-            return GetOsError(PythonErrorNumber.EEXIST, filename);
+            return GetOsError(PythonErrno.EEXIST, filename);
         }
 
 #if FEATURE_NATIVE


### PR DESCRIPTION
It turned to be more popular than I first thought and more usage is coming. `PythonErrno` is shorter hence more convenient. I would prefer simply `Errno`, but that could be confused with `Mono.Unix.Native.Errno`. 