### PR TITLE
Isolate POSIX-specific native calls in PythonNT into separate file

### DIFF
--- a/Src/IronPython.Modules/_overlapped.cs
+++ b/Src/IronPython.Modules/_overlapped.cs
@@ -5,11 +5,14 @@
 using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 using IronPython.Runtime;
 
 [assembly: PythonModule("_overlapped", typeof(IronPython.Modules.PythonOverlapped), PlatformsAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
+
+    [SupportedOSPlatform("windows")]
     public static class PythonOverlapped {
         public const int ERROR_NETNAME_DELETED = 64;
         public const int ERROR_SEM_TIMEOUT = 121;

--- a/Src/IronPython.Modules/_winapi.cs
+++ b/Src/IronPython.Modules/_winapi.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 
 using IronPython.Runtime;
@@ -16,9 +17,11 @@ using IronPython.Runtime.Operations;
 
 [assembly: PythonModule("_winapi", typeof(IronPython.Modules.PythonWinApi), PlatformsAttribute.PlatformFamily.Windows)]
 namespace IronPython.Modules {
+    [SupportedOSPlatform("windows")]
     public static class PythonWinApi {
         #region Public API
 
+        [SupportedOSPlatform("windows")]
         public static object? ConnectNamedPipe(BigInteger handle, bool overlapped = false) {
             if (overlapped) throw new NotImplementedException();
 

--- a/Src/IronPython.Modules/_winapi.cs
+++ b/Src/IronPython.Modules/_winapi.cs
@@ -21,7 +21,6 @@ namespace IronPython.Modules {
     public static class PythonWinApi {
         #region Public API
 
-        [SupportedOSPlatform("windows")]
         public static object? ConnectNamedPipe(BigInteger handle, bool overlapped = false) {
             if (overlapped) throw new NotImplementedException();
 

--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -5,7 +5,6 @@
 #if FEATURE_MMAP
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -205,12 +204,12 @@ namespace IronPython.Modules {
 
         public static readonly string __doc__ = null;
 
-        private static string FormatError(int errorCode) {
-            return new Win32Exception(errorCode).Message;
-        }
-
-        private static Exception WindowsError(int code) {
-            return PythonExceptions.CreateThrowable(PythonExceptions.OSError, code, FormatError(code));
+        private static Exception WindowsError(int winerror) {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                return PythonNT.GetWin32Error(winerror);
+            } else {
+                return PythonNT.GetOsError(PythonExceptions._OSError.WinErrorToErrno(winerror));
+            }
         }
 
         public static PythonType error => PythonExceptions.OSError;
@@ -234,7 +233,7 @@ namespace IronPython.Modules {
             private static MemoryMappedFileAccess ToMmapFileAccess(int flags, int prot, int access) {
                 if (access == ACCESS_DEFAULT) {
                     if ((flags & (MAP_PRIVATE | MAP_SHARED)) == 0) {
-                        throw PythonOps.OSError(PythonErrno.EINVAL, "Invalid argument");
+                        throw PythonNT.GetOsError(PythonErrno.EINVAL);
                     }
                     if ((prot & PROT_WRITE) != 0) {
                         prot |= PROT_READ;
@@ -356,7 +355,7 @@ namespace IronPython.Modules {
                         }
                         // otherwise leaves _file as null and _sourceStream as null
                     } else {
-                        throw PythonOps.OSError(PythonExceptions._OSError.ERROR_INVALID_BLOCK, "Bad file descriptor");
+                        throw PythonNT.GetOsError(PythonErrno.EBADF);
                     }
 
                     if (_file is null) {
@@ -414,7 +413,7 @@ namespace IronPython.Modules {
 
                     try {
                         if (!isValid) {
-                            throw PythonOps.OSError(PythonExceptions._OSError.ERROR_ACCESS_DENIED, "Invalid access mode");
+                            throw WindowsError(PythonExceptions._OSError.ERROR_ACCESS_DENIED);
                         }
 
                         if (!isWindows) {
@@ -802,12 +801,20 @@ namespace IronPython.Modules {
                         throw PythonOps.TypeError("mmap can't resize a readonly or copy-on-write memory map.");
                     }
 
+                    if (newsize < 0) {
+                        throw PythonOps.ValueError("new size out of range");
+                    }
+
                     if (_handle is not null
                         && (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))) {
                         // resize on Posix platforms
                         try {
                             if (_handle.IsInvalid) {
                                 throw PythonNT.GetOsError(PythonErrno.EBADF);
+                            }
+                            if (newsize == 0) {
+                                // resizing to an empty mapped region is not allowed
+                                throw PythonNT.GetOsError(PythonErrno.EINVAL);
                             }
                             _view.Flush();
                             _view.Dispose();

--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -807,7 +807,7 @@ namespace IronPython.Modules {
                         // resize on Posix platforms
                         try {
                             if (_handle.IsInvalid) {
-                                throw PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor");
+                                throw PythonNT.GetOsError(PythonErrno.EBADF);
                             }
                             _view.Flush();
                             _view.Dispose();
@@ -1109,20 +1109,18 @@ namespace IronPython.Modules {
                 }
             }
 
-            [SupportedOSPlatform("linux"), SupportedOSPlatform("macos")]
+            [SupportedOSPlatform("linux")]
+            [SupportedOSPlatform("macos")]
             private static long GetFileSizeUnix(SafeFileHandle handle) {
                 long size;
                 if (handle.IsInvalid) {
-                    throw PythonOps.OSError(PythonExceptions._OSError.ERROR_INVALID_HANDLE, "Invalid file handle");
+                    throw PythonNT.GetOsError(PythonErrno.EBADF);
                 }
 
                 if (Mono.Unix.Native.Syscall.fstat((int)handle.DangerousGetHandle(), out Mono.Unix.Native.Stat status) == 0) {
                     size = status.st_size;
                 } else {
-                    Mono.Unix.Native.Errno errno = Mono.Unix.Native.Stdlib.GetLastError();
-                    string msg = Mono.Unix.UnixMarshal.GetErrorDescription(errno);
-                    int error = Mono.Unix.Native.NativeConvert.FromErrno(errno);
-                    throw PythonOps.OSError(error, msg);
+                    throw PythonNT.GetLastUnixError();
                 }
 
                 return size;

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -2313,7 +2313,7 @@ the 'status' value."),
         }
 
 
-        private static Exception GetOsError(int error, string? filename = null, string? filename2 = null)
+        internal static Exception GetOsError(int error, string? filename = null, string? filename2 = null)
             => PythonOps.OSError(error, strerror(error), filename, null, filename2);
 
 #if FEATURE_NATIVE || FEATURE_CTYPES

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -2318,8 +2318,13 @@ the 'status' value."),
 
 #if FEATURE_NATIVE || FEATURE_CTYPES
 
+        [SupportedOSPlatform("windows")]
+        internal static Exception GetLastWin32Error(string? filename = null, string? filename2 = null)
+            => GetWin32Error(Marshal.GetLastWin32Error(), filename, filename2);
+
         // Gets an error message for a Win32 error code.
-        internal static string GetMessage(int errorCode) {
+        [SupportedOSPlatform("windows")]
+        private static string GetWin32ErrorMessage(int errorCode) {
             string msg = new Win32Exception(errorCode).Message;
             // error codes: https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
             if (errorCode is not (< 0 or >= 8200 or 34 or 106 or 317 or 718)) {
@@ -2332,11 +2337,9 @@ the 'status' value."),
             return msg.TrimEnd('\r', '\n', '.');
         }
 
-        internal static Exception GetLastWin32Error(string? filename = null, string? filename2 = null)
-            => GetWin32Error(Marshal.GetLastWin32Error(), filename, filename2);
-
+        [SupportedOSPlatform("windows")]
         private static Exception GetWin32Error(int error, string? filename = null, string? filename2 = null) {
-            var msg = GetMessage(error);
+            var msg = GetWin32ErrorMessage(error);
             return PythonOps.OSError(0, msg, filename, error, filename2);
         }
 

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -774,23 +774,6 @@ namespace IronPython.Modules {
             }
         }
 
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
-        public static uname_result uname() {
-            Mono.Unix.Native.Utsname info;
-            Mono.Unix.Native.Syscall.uname(out info);
-            return new uname_result(info.sysname, info.nodename, info.release, info.version, info.machine);
-        }
-
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
-        public static BigInteger getuid() {
-            return Mono.Unix.Native.Syscall.getuid();
-        }
-
-        [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
-        public static BigInteger geteuid() {
-            return Mono.Unix.Native.Syscall.geteuid();
-        }
-
 #endif
 
 #if FEATURE_FILESYSTEM
@@ -1286,12 +1269,15 @@ namespace IronPython.Modules {
 
             internal stat_result(int mode) : this(new object[10] { mode, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, null) { }
 
+            [SupportedOSPlatform("linux")]
+            [SupportedOSPlatform("macos")]
             internal stat_result(Mono.Unix.Native.Stat stat)
                 : this(new object[16] {Mono.Unix.Native.NativeConvert.FromFilePermissions(stat.st_mode), ToInt(stat.st_ino), ToInt(stat.st_dev), ToInt(stat.st_nlink), ToInt(stat.st_uid), ToInt(stat.st_gid), ToInt(stat.st_size),
                       ToInt(stat.st_atime), ToInt(stat.st_mtime), ToInt(stat.st_ctime),
                       stat.st_atime + stat.st_atime_nsec / (double)nanosecondsPerSeconds, stat.st_mtime + stat.st_mtime_nsec / (double)nanosecondsPerSeconds, stat.st_ctime + stat.st_ctime_nsec / (double)nanosecondsPerSeconds,
                       ToInt(stat.st_atime * nanosecondsPerSeconds + stat.st_atime_nsec), ToInt(stat.st_mtime * nanosecondsPerSeconds + stat.st_mtime_nsec), ToInt(stat.st_ctime * nanosecondsPerSeconds + stat.st_ctime_nsec) }, null) { }
 
+            [SupportedOSPlatform("windows")]
             internal stat_result(int mode, ulong fileidx, long size, long st_atime_ns, long st_mtime_ns, long st_ctime_ns)
                 : this(new object[16] { mode, ToInt(fileidx), 0, 0, 0, 0, ToInt(size),
                       ToInt(st_atime_ns / nanosecondsPerSeconds), ToInt(st_mtime_ns / nanosecondsPerSeconds), ToInt(st_ctime_ns / nanosecondsPerSeconds),

--- a/Src/IronPython.Modules/posix.cs
+++ b/Src/IronPython.Modules/posix.cs
@@ -27,21 +27,21 @@ namespace IronPython.Modules {
 #if FEATURE_NATIVE
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         internal static Exception GetLastUnixError(string? filename = null, string? filename2 = null)
             // On POSIX, GetLastWin32Error returns the errno value, same as GetLastPInvokeError
             => GetOsError(Marshal.GetLastWin32Error(), filename, filename2);
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static int strerror_r(int code, StringBuilder buffer)
             => Syscall.strerror_r(NativeConvert.ToErrno(code), buffer);
 
 
 #if FEATURE_PIPES
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static Tuple<int, Stream, int, Stream> CreatePipeStreamsUnix() {
             UnixPipes pipes = UnixPipes.CreatePipes();
             return Tuple.Create<int, Stream, int, Stream>(pipes.Reading.Handle, pipes.Reading, pipes.Writing.Handle, pipes.Writing);
@@ -50,7 +50,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static int DuplicateStreamDescriptorUnix(int fd, int targetfd, out Stream? stream) {
             int res = targetfd < 0 ? Syscall.dup(fd) : Syscall.dup2(fd, targetfd);
             if (res < 0) throw GetLastUnixError();
@@ -87,7 +87,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         internal static int dupUnix(int fd, bool closeOnExec) {
             int fd2 = Syscall.dup(fd);
             if (fd2 == -1) throw GetLastUnixError();
@@ -113,7 +113,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static void chmodUnix(string path, int mode) {
             if (Syscall.chmod(path, NativeConvert.ToFilePermissions((uint)mode)) == 0) return;
             throw GetLastUnixError(path);
@@ -121,7 +121,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static void linkUnix(string src, string dst) {
             if (Syscall.link(src, dst) == 0) return;
             throw GetLastUnixError(src, dst);
@@ -129,7 +129,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static void symlinkUnix(string src, string dst) {
             if (Syscall.symlink(src, dst) == 0) return;
             throw GetLastUnixError(src, dst);
@@ -137,7 +137,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static void renameUnix(string src, string dst) {
             if (Syscall.rename(src, dst) == 0) return;
             throw GetLastUnixError(src, dst);
@@ -145,7 +145,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static object statUnix(string path) {
             if (Syscall.stat(path, out Stat buf) == 0) {
                 return new stat_result(buf);
@@ -155,7 +155,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static object fstatUnix(int fd) {
             if (Syscall.fstat(fd, out Stat buf) == 0) {
                 return new stat_result(buf);
@@ -165,7 +165,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         internal static void ftruncateUnix(int fd, long length) {
             int result;
             Errno errno;
@@ -179,7 +179,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static void utimeUnix(string path, long atime_ns, long utime_ns) {
             var atime = new Timespec();
             atime.tv_sec = atime_ns / 1_000_000_000;
@@ -194,7 +194,7 @@ namespace IronPython.Modules {
 
 
         [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("osx")]
+        [SupportedOSPlatform("macos")]
         private static void killUnix(int pid, int sig) {
             if (Syscall.kill(pid, NativeConvert.ToSignum(sig)) == 0) return;
             throw GetLastUnixError();

--- a/Src/IronPython.Modules/posix.cs
+++ b/Src/IronPython.Modules/posix.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
@@ -175,6 +176,31 @@ namespace IronPython.Modules {
 
             if (errno != 0)
                 throw GetOsError(NativeConvert.FromErrno(errno));
+        }
+
+
+        [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        public static uname_result uname() {
+            if (Syscall.uname(out Utsname info) == 0) {
+                return new uname_result(info.sysname, info.nodename, info.release, info.version, info.machine);
+            }
+            throw GetLastUnixError();  // rare
+        }
+
+        [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        public static BigInteger getuid() {
+            return Syscall.getuid();
+        }
+
+        [PythonHidden(PlatformsAttribute.PlatformFamily.Windows)]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        public static BigInteger geteuid() {
+            return Syscall.geteuid();
         }
 
 

--- a/Src/IronPython.Modules/posix.cs
+++ b/Src/IronPython.Modules/posix.cs
@@ -28,7 +28,7 @@ namespace IronPython.Modules {
 
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("osx")]
-        private static Exception GetLastUnixError(string? filename = null, string? filename2 = null)
+        internal static Exception GetLastUnixError(string? filename = null, string? filename2 = null)
             // On POSIX, GetLastWin32Error returns the errno value, same as GetLastPInvokeError
             => GetOsError(Marshal.GetLastWin32Error(), filename, filename2);
 

--- a/Src/IronPython.Modules/posix.cs
+++ b/Src/IronPython.Modules/posix.cs
@@ -1,0 +1,203 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Text;
+
+using Microsoft.Scripting.Runtime;
+using Microsoft.Win32.SafeHandles;
+
+using Mono.Unix;
+using Mono.Unix.Native;
+
+using IronPython.Runtime;
+
+namespace IronPython.Modules {
+    // This file contains exclusively functions used on POSIX systems, heavily dependent on Mono.Unix.
+    // Every function in this part of PythonNT must have a platform guard preventing it from being used on Windows.
+    // This isolates Mono.Unix from the rest of the code so that we don't try to load the Mono.Unix assembly on Windows.
+    // The main implementation of module `nt` still may contain some code that is POSIX-specific, but without using Mono.Unix.
+    public static partial class PythonNT {
+#if FEATURE_NATIVE
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static Exception GetLastUnixError(string? filename = null, string? filename2 = null)
+            => GetOsError(NativeConvert.FromErrno(Syscall.GetLastError()), filename, filename2);
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static int strerror_r(int code, StringBuilder buffer)
+            => Syscall.strerror_r(NativeConvert.ToErrno(code), buffer);
+
+
+#if FEATURE_PIPES
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static Tuple<int, Stream, int, Stream> CreatePipeStreamsUnix() {
+            Mono.Unix.UnixPipes pipes = Mono.Unix.UnixPipes.CreatePipes();
+            return Tuple.Create<int, Stream, int, Stream>(pipes.Reading.Handle, pipes.Reading, pipes.Writing.Handle, pipes.Writing);
+        }
+#endif
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static int DuplicateStreamDescriptorUnix(int fd, int targetfd, out Stream? stream) {
+            int res = targetfd < 0 ? Syscall.dup(fd) : Syscall.dup2(fd, targetfd);
+            if (res < 0) throw GetLastUnixError();
+
+            if (ClrModule.IsMono) {
+                // Elaborate workaround on Mono to avoid UnixStream as out
+                stream = new UnixStream(res, ownsHandle: false);
+                FileAccess fileAccess = stream.CanWrite ? stream.CanRead ? FileAccess.ReadWrite : FileAccess.Write : FileAccess.Read;
+                stream.Dispose();
+                try {
+                    // FileStream on Mono created with a file descriptor might not work: https://github.com/mono/mono/issues/12783
+                    // Test if it does, without closing the handle if it doesn't
+                    var sfh = new SafeFileHandle((IntPtr)res, ownsHandle: false);
+                    stream = new FileStream(sfh, fileAccess);
+                    // No exception? Great! We can use FileStream.
+                    stream.Dispose();
+                    sfh.Dispose();
+                    stream = null; // Create outside of try block
+                } catch (IOException) {
+                    // Fall back to UnixStream
+                    stream = new UnixStream(res, ownsHandle: true);
+                }
+                if (stream is null) {
+                    // FileStream is safe
+                    var sfh = new SafeFileHandle((IntPtr)res, ownsHandle: true);
+                    stream = new FileStream(sfh, fileAccess);
+                }
+            } else {
+                // normal case
+                stream = new PosixFileStream(res);
+            }
+            return res;
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        internal static int dupUnix(int fd, bool closeOnExec) {
+            int fd2 = Syscall.dup(fd);
+            if (fd2 == -1) throw GetLastUnixError();
+
+            if (closeOnExec) {
+                try {
+                    // set close-on-exec flag
+                    int flags = Syscall.fcntl(fd2, FcntlCommand.F_GETFD);
+                    if (flags == -1) throw GetLastUnixError();
+    
+                    const int FD_CLOEXEC = 1;  // TODO: Move to module fcntl
+                    flags |= FD_CLOEXEC;
+                    flags = Syscall.fcntl(fd2, FcntlCommand.F_SETFD, flags);
+                    if (flags == -1) throw GetLastUnixError();
+                } catch {
+                    Syscall.close(fd2);
+                    throw;
+                }
+            }
+
+            return fd2;
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static void chmodUnix(string path, int mode) {
+            if (Syscall.chmod(path, NativeConvert.ToFilePermissions((uint)mode)) == 0) return;
+            throw GetLastUnixError(path);
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static void linkUnix(string src, string dst) {
+            if (Syscall.link(src, dst) == 0) return;
+            throw GetLastUnixError(src, dst);
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static void symlinkUnix(string src, string dst) {
+            if (Syscall.symlink(src, dst) == 0) return;
+            throw GetLastUnixError(src, dst);
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static void renameUnix(string src, string dst) {
+            if (Syscall.rename(src, dst) == 0) return;
+            throw GetLastUnixError(src, dst);
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static object statUnix(string path) {
+            if (Syscall.stat(path, out Stat buf) == 0) {
+                return new stat_result(buf);
+            }
+            return LightExceptions.Throw(GetLastUnixError(path));
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static object fstatUnix(int fd) {
+            if (Syscall.fstat(fd, out Stat buf) == 0) {
+                return new stat_result(buf);
+            }
+            return LightExceptions.Throw(GetLastUnixError());
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        internal static void ftruncateUnix(int fd, long length) {
+            int result;
+            Errno errno;
+            do {
+                result = Syscall.ftruncate(fd, length);
+            } while (Mono.Unix.UnixMarshal.ShouldRetrySyscall(result, out errno));
+
+            if (errno != 0)
+                throw GetOsError(NativeConvert.FromErrno(errno));
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static void utimeUnix(string path, long atime_ns, long utime_ns) {
+            var atime = new Timespec();
+            atime.tv_sec = atime_ns / 1_000_000_000;
+            atime.tv_nsec = atime_ns % 1_000_000_000;
+            var utime = new Timespec();
+            utime.tv_sec = utime_ns / 1_000_000_000;
+            utime.tv_nsec = utime_ns % 1_000_000_000;
+
+            if (Syscall.utimensat(Syscall.AT_FDCWD, path, new[] { atime, utime }, 0) == 0) return;
+            throw GetLastUnixError(path);
+        }
+
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("osx")]
+        private static void killUnix(int pid, int sig) {
+            if (Syscall.kill(pid, NativeConvert.ToSignum(sig)) == 0) return;
+            throw GetLastUnixError();
+        }
+
+#endif
+    }
+}

--- a/Src/IronPython.Modules/resource.cs
+++ b/Src/IronPython.Modules/resource.cs
@@ -329,8 +329,7 @@ public static class PythonResourceModule {
         => LightExceptions.Throw(PythonOps.ValueError("expected a tuple of 2 integers"));
 
     private static object GetPInvokeError() {
-        int errno = Marshal.GetLastWin32Error(); // despite its name, on Posix it retrieves errno set by the last p/Invoke call
-        return LightExceptions.Throw(PythonOps.OSError(errno, PythonNT.strerror(errno)));
+        return LightExceptions.Throw(PythonNT.GetLastUnixError());
     }
 
     private static object ToPythonInt(this ulong value)

--- a/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
+++ b/Src/IronPython/Runtime/Exceptions/PythonExceptions.cs
@@ -167,14 +167,14 @@ namespace IronPython.Runtime.Exceptions {
                     }
                     if (args.Length >= 4) {
                         winerror = args[3] ?? Undefined;
-                        if (winerror is int) {
-                            errno = WinErrorToErrno((int)winerror);
+                        if (winerror is int err) {
+                            errno = WinErrorToErrno(err);
                         }
                     }
                     if (args.Length >= 5) {
                         filename2 = args[4] ?? Undefined;
                     }
-                    args = new object[] { errno, strerror };
+                    args = [errno, strerror];
                 }
                 base.__init__(args);
             }


### PR DESCRIPTION
This adds platform guards to relevant functions in `PythonNT`. By keeping them in a separate file I hope it will be easier to prevent omissions and inadvertent loads of `Mono.Unix` on Windows. Also, it makes `nt.cs` just a little bit smaller, which is always a good thing.