### PR TITLE
Emulate `fcntl.ioctl` for command `TIOCGWINSZ`

### DIFF
--- a/src/core/IronPython.Modules/fcntl.cs
+++ b/src/core/IronPython.Modules/fcntl.cs
@@ -27,6 +27,33 @@ public static class PythonFcntl {
         """;
 
 
+    // supporting fcntl.ioctl(fileno, termios.TIOCGWINSZ, buf)
+    // where buf = array.array('h', [0, 0, 0, 0])
+    public static object ioctl(CodeContext context, int fd, int cmd, [NotNone] IBufferProtocol arg, int mutate_flag = 1) {
+        if (cmd == PythonTermios.TIOCGWINSZ) {
+            using IPythonBuffer buf = arg.GetBuffer();
+
+            Span<short> winsize = stackalloc short[4];
+            winsize[0] = (short)Console.WindowHeight;
+            winsize[1] = (short)Console.WindowWidth;
+            winsize[2] = (short)Console.BufferHeight;  // buffer height and width are not accurate on macOS
+            winsize[3] = (short)Console.BufferWidth;
+            Span<byte> payload = MemoryMarshal.Cast<short, byte>(winsize);
+
+            if (buf.IsReadOnly || mutate_flag == 0) {
+                byte[] res = buf.ToArray();
+                payload.Slice(0, Math.Min(payload.Length, res.Length)).CopyTo(res);
+                return Bytes.Make(res);
+            } else {
+                var res = buf.AsSpan();
+                payload.Slice(0, Math.Min(payload.Length, res.Length)).CopyTo(res);
+                return 0;
+            }
+        }
+        throw new NotImplementedException($"ioctl: unsupported command {cmd}");
+    }
+
+
     // FD Flags
     public static int FD_CLOEXEC = 1;
     public static int FASYNC => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 0x0040 : 0x2000;

--- a/tests/suite/test_builtin_stdlib.py
+++ b/tests/suite/test_builtin_stdlib.py
@@ -23,15 +23,16 @@ def load_tests(loader, standard_tests, pattern):
             test.test_builtin.BuiltinTest('test_open_non_inheritable'), # https://github.com/IronLanguages/ironpython3/issues/1225
         ]
 
-        skip_tests = []
+        skip_tests = [
+            # module `pty` is importable but not functional on .NET Core
+            test.test_builtin.PtyTests('test_input_no_stdout_fileno'),
+            test.test_builtin.PtyTests('test_input_tty'),
+            test.test_builtin.PtyTests('test_input_tty_non_ascii'),
+            test.test_builtin.PtyTests('test_input_tty_non_ascii_unicode_errors'),
+            test.test_builtin.ShutdownTest('test_cleanup'),
+        ]
         if is_netcoreapp:
             skip_tests += [
-                # module `pty` is importable but not functional on .NET Core
-                test.test_builtin.PtyTests('test_input_no_stdout_fileno'),
-                test.test_builtin.PtyTests('test_input_tty'),
-                test.test_builtin.PtyTests('test_input_tty_non_ascii'),
-                test.test_builtin.PtyTests('test_input_tty_non_ascii_unicode_errors'),
-                test.test_builtin.ShutdownTest('test_cleanup'),
             ]
 
         return generate_suite(tests, failing_tests, skip_tests)

--- a/tests/suite/test_builtin_stdlib.py
+++ b/tests/suite/test_builtin_stdlib.py
@@ -21,15 +21,16 @@ def load_tests(loader, standard_tests, pattern):
             test.test_builtin.BuiltinTest('test_input'),
             test.test_builtin.BuiltinTest('test_len'),
             test.test_builtin.BuiltinTest('test_open_non_inheritable'), # https://github.com/IronLanguages/ironpython3/issues/1225
-            test.test_builtin.PtyTests('test_input_no_stdout_fileno'),
-            test.test_builtin.PtyTests('test_input_tty'),
-            test.test_builtin.PtyTests('test_input_tty_non_ascii'),
-            test.test_builtin.PtyTests('test_input_tty_non_ascii_unicode_errors'),
         ]
 
         skip_tests = []
         if is_netcoreapp:
             skip_tests += [
+                # module `pty` is importable but not functional on .NET Core
+                test.test_builtin.PtyTests('test_input_no_stdout_fileno'),
+                test.test_builtin.PtyTests('test_input_tty'),
+                test.test_builtin.PtyTests('test_input_tty_non_ascii'),
+                test.test_builtin.PtyTests('test_input_tty_non_ascii_unicode_errors'),
                 test.test_builtin.ShutdownTest('test_cleanup'),
             ]
 


### PR DESCRIPTION
This is a mock implementation of `fcntl.ioctl`, supporting only one command: `termios.TIOCGWINSZ` (i.e. Terminal I/O Control Get WINdow SiZe). It doesn't do any syscalls but provides the result using equivalent .NET functions. It ignores the file descriptor, and always returns the size of the console, so is not appropiate for pseudo-terminals (pty, tty). Nevertheless, it is still useful as some packages depend on this call to get the console window size (`prompt_toolkit.terminal.vt100_input`).