### PR TITLE
Code Quality: Removed unnecessary files from GitHub statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,3 +44,6 @@ tests/suite/file_without_BOM.txt -text
 
 # Do not normalize on commit.
 *.pdf -text
+
+*.pck linguist-detectable=false
+*.html linguist-documentation=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,8 @@
 *.ps1 text
 
 # Explicitly declare files that should not have line endings modified, ever
-Tests/file_with_BOM.txt -text
-Tests/file_without_BOM.txt -text
+tests/suite/file_with_BOM.txt -text
+tests/suite/file_without_BOM.txt -text
 
 # Declare files that will always have CRLF line endings on checkout.
 *.bat text eol=crlf

--- a/src/core/IronPython.StdLib/.gitattributes
+++ b/src/core/IronPython.StdLib/.gitattributes
@@ -18,15 +18,15 @@
 *.zip binary
 
 # Specific binary files
-Lib/test/sndhdrdata/sndhdr.* binary
+lib/test/sndhdrdata/sndhdr.* binary
 
 # Text files that should not be subject to eol conversion
-Lib/test/cjkencodings/* -text
-Lib/test/decimaltestdata/*.decTest -text
-Lib/test/test_email/data/*.txt -text
-Lib/test/xmltestdata/* -text
-Lib/test/coding20731.py -text
-Lib/test/test_importlib/data01/* -text
+lib/test/cjkencodings/* -text
+lib/test/decimaltestdata/*.decTest -text
+lib/test/test_email/data/*.txt -text
+lib/test/xmltestdata/* -text
+lib/test/coding20731.py -text
+lib/test/test_importlib/data01/* -text
 
 # CRLF files
 *.bat text eol=crlf


### PR DESCRIPTION
> @BCSharp while you're fixing this, might as well make this change.
> 
> ---
> 
> This hides files from showing up in GitHub here:
> ![image](https://github.com/user-attachments/assets/cead9079-a811-4c3c-90c8-d283a4f913a2)
> 
> IronPython doesn't use PSQL significantly enough for it to be detected, and HTML is used only for the documentation, which GitHub automatically enables filters for (that seem to not be working).

> So, this is how GitHub works… I had no idea.
> 
> You have raised a valid point, but although it also affects `.gitattributes`, it has nothing to do with code restructuring, so I'd rather it be done separately. Also, it deserves a proper discussion, e.g.:
> 
> * If we were to hide PLSQL, why not Roff?
> * If we hide PSQL and Roff, then perhaps other 0.0%-used languages will show up? Where does it end?
> * AFAICS, the HTML is being used for tests (and so is PLSQL; IDK about Roff). The question is, should tests be excluded from the "Laungages" statistics? My intuition says no, since we do need to write and maintain tests as well.
> * The above point notwithstanding, should we include/exclude StdLib in the statistics? Technically, it is not IronPython-originated code, but it is tweaked for IronPython and distributed alongside with IronPython, so I presume it should be included.
> * Perhaps StdLib tests could be excluded, but they still require sometimes some maintenance from our project, so it feels like they contribute to the codebase as well.

---

#1884 was merged making https://github.com/BCSharp/ironpython3/pull/1 invalid, the changes have been forwarded here