### PR TITLE
Run test tasks in foreground

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -167,7 +167,7 @@ function RunTestTasks($tasks) {
             $testName = $tasks[$bgJobs.$finished].name
             Write-Host
             if ($finished.State -eq 'Failed') {
-                Write-Host "$testName failed"
+                Write-Host -ForegroundColor Red  "$testName failed"
                 $global:Result = $finished.ChildJobs[0].JobStateInfo.Reason.ErrorRecord.TargetObject
                 $failedTests += $testName
             } else {
@@ -184,7 +184,7 @@ function RunTestTasks($tasks) {
             Write-Host "$($bgJobs.Count) jobs running: $(($bgJobs.values | ForEach-Object {$tasks[$_].name}) -Join ", ")"
             Write-Host "$($tasks.Count - $nextJob) jobs pending: $(($nextJob..$tasks.Count | ForEach-Object {$tasks[$_].name}) -Join ", ")"
             if ($failedTests) {
-                Write-Host "$($failedTests.Count) jobs failed: $($failedTests -Join ", ")"
+                Write-Host -ForegroundColor Red  "$($failedTests.Count) jobs failed: $($failedTests -Join ", ")"
             }
             Write-Host
         }


### PR DESCRIPTION
Run test tasks sequenially in foreground if `-jobs 0`. The default did not change: it still runs all (up to the processor count) task groups in parallel jobs. `-jobs 1` also runs all tasks sequentially, but because it is run as a PowerShell job, the test output is not real-time, but displayed in 10 sec intervals.

This change has two purposes:
1. To be able to monitor the test progress in real-time, without the filter. This is useful when one or a small subset of tasks is run in a query, and especially useful if some tests that operate on stdin and std out misbehave.
2. On some devcontainer systems, PowerShell's [`Start-Job` does not work](https://github.com/PowerShell/PowerShell/discussions/24382) if not run by `root`. `-jobs 0` avoids `Start-Job` altogether.