### PR TITLE
Implement `fcntl` syscalls

### DIFF
--- a/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
@@ -400,6 +400,10 @@ Ignore=true
 [CPython.test_faulthandler]
 Ignore=true
 
+[CPython.test_fcntl]
+RunCondition=$(IS_POSIX)
+Reason=POSIX specific module
+
 [CPython.test_file]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 

--- a/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
@@ -400,11 +400,6 @@ Ignore=true
 [CPython.test_faulthandler]
 Ignore=true
 
-[CPython.test_fcntl]
-RunCondition=$(IS_POSIX)
-Ignore=true
-Reason=ImportError: No module named fcntl
-
 [CPython.test_file]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 
@@ -514,7 +509,7 @@ Ignore=true
 [CPython.test_ioctl]
 RunCondition=$(IS_POSIX)
 Ignore=true
-Reason=unittest.case.SkipTest: No module named 'fcntl'
+Reason=unittest.case.SkipTest: module 'termios' has no attribute 'TIOCGPGRP', 'fcntl.ioctl' is a mock
 
 [CPython.test_ipaddress]
 Ignore=true
@@ -724,7 +719,7 @@ Ignore=true
 [CPython.test_pty]
 RunCondition=$(IS_POSIX)
 Ignore=true
-Reason=unittest.case.SkipTest: No module named 'fcntl'
+Reason=Missing constants in 'termios', 'signal', 'termios' implementation is a stub
 
 [CPython.test_pulldom]
 Ignore=true

--- a/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
@@ -400,10 +400,6 @@ Ignore=true
 [CPython.test_faulthandler]
 Ignore=true
 
-[CPython.test_fcntl]
-RunCondition=$(IS_POSIX)
-Reason=POSIX specific module
-
 [CPython.test_file]
 IsolationLevel=PROCESS # https://github.com/IronLanguages/ironpython3/issues/489
 


### PR DESCRIPTION
This PR implements the main `fcntl`, plus `flock` and `lockf` and enables `test_fcntl` from the StdLib. `ioctl` remains still a mock.

The signature of syscal `fcntl` is variadic, but luckily this call is supported by _Mono.Unix_. It means that there is the extra translation step from the given _fcntl_ command code to Mono's enum, and then back to the actual OS code. This step will also filter out (as unsupported) all commands that were not defined yet by the OS at the time _Mono.Unix_ was built. For one thing, I miss `F_GETPATH`, which was added in Python 3.9. It is only on macOS, but on Linux one can get the path name from a descriptor by `readlink /dev/fd/«fileno»`. Well, maybe I will write a workaround for this one at some point.

The calls `flock` and `lockf` are not supported by _Mono.Unix_, but their signature is simple enough that the P/Invoke prototypes are not a big deal. With them in place it is finally be possible to fix SQLite on macOS (and improve on Linux).