### PR TITLE
Skip test if exception `SkipTest` is raised

### DIFF
--- a/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
@@ -472,10 +472,6 @@ NotParallelSafe=true # Creates/deletes a directory with static name 'xx'
 [CPython.test_glob]
 RunCondition=NOT $(IS_POSIX) # TODO: figure out
 
-[CPython.test_grp]
-RunCondition=$(IS_POSIX)
-Reason=Only valid for Unix
-
 [CPython.test_httplib] # IronPython.test_httplib_stdlib
 Ignore=true
 Reason=Blocking
@@ -713,7 +709,7 @@ Reason=Blocking
 [CPython.test_posix]
 RunCondition=$(IS_POSIX)
 Ignore=true
-Reason=unittest.case.SkipTest: No module named 'posix'
+Reason=AttributeError: module 'posix' has no attribute 'chown'
 
 [CPython.test_posixpath]
 Ignore=true
@@ -728,10 +724,6 @@ Reason=unittest.case.SkipTest: No module named 'fcntl'
 
 [CPython.test_pulldom]
 Ignore=true
-
-[CPython.test_pwd]
-RunCondition=$(IS_POSIX)
-Reason=Only valid for Unix
 
 [CPython.test_py_compile]
 Ignore=true

--- a/tests/IronPython.Tests/Cases/CaseExecuter.cs
+++ b/tests/IronPython.Tests/Cases/CaseExecuter.cs
@@ -17,6 +17,7 @@ using IronPython;
 using IronPython.Hosting;
 using IronPython.Runtime;
 using IronPython.Runtime.Exceptions;
+using IronPython.Runtime.Types;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Hosting;
@@ -300,6 +301,13 @@ namespace IronPythonTest.Cases {
                         #pragma warning disable SYSLIB0006 // 'Thread.ResetAbort is not supported and throws PlatformNotSupportedException.' 
                         Thread.ResetAbort();
                         #pragma warning restore SYSLIB0006
+                    } catch (Exception ex) when (ex.GetPythonException() is not null and var pex) {
+                        if (DynamicHelpers.GetPythonType(pex).Name == "SkipTest") {
+                            NUnit.Framework.TestContext.Progress.WriteLine($"Test {testcase.Name} skipped: {pex}");
+                            res = 0;
+                        } else {
+                            throw;
+                        }
                     }
                 }, maxStackSize) {
                     IsBackground = true


### PR DESCRIPTION
I think this is a better way of handling `fcntl_test` failure on Windows (#1893). It is skipping by exception name `SkipTest` rather than `unittest.SkipTest` because I coudn't figure out how to retrieve the defining module name.