### PR TITLE
Fix mmap.resize with offset

### DIFF
--- a/src/core/IronPython.Modules/mmap.cs
+++ b/src/core/IronPython.Modules/mmap.cs
@@ -1401,17 +1401,18 @@ namespace IronPython.Modules {
             internal short wProcessorRevision;
         }
 
+        [SupportedOSPlatform("windows")]
         [DllImport("kernel32", SetLastError = true)]
         private static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
 
         private static int GetAllocationGranularity() {
-            try {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 return GetAllocationGranularityWorker();
-            } catch {
-                return System.Environment.SystemPageSize;
             }
+            return System.Environment.SystemPageSize;
         }
 
+        [SupportedOSPlatform("windows")]
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int GetAllocationGranularityWorker() {
             SYSTEM_INFO info = new SYSTEM_INFO();

--- a/src/core/IronPython.StdLib/lib/test/test_mmap.py
+++ b/src/core/IronPython.StdLib/lib/test/test_mmap.py
@@ -102,7 +102,7 @@ class MmapTests(unittest.TestCase):
             # resize() not supported
             # No messages are printed, since the output of this test suite
             # would then be different across platforms.
-            pass
+            raise # ironpython: all our runners currently support resize
         else:
             # resize() is supported
             self.assertEqual(len(m), 512)
@@ -168,7 +168,7 @@ class MmapTests(unittest.TestCase):
             try:
                 m.resize(2*mapsize)
             except SystemError:   # resize is not universally supported
-                pass
+                raise # ironpython: all our runners currently support resize
             except TypeError:
                 pass
             else:
@@ -539,7 +539,7 @@ class MmapTests(unittest.TestCase):
             try:
                 m.resize(512)
             except SystemError:
-                pass
+                raise # ironpython: all our runners currently support resize
             else:
                 # resize() is supported
                 self.assertEqual(len(m), 512)


### PR DESCRIPTION
The `_offset` was being ignored when resizing on Linux. Since resize should work on all the platforms we currently target (I think), I tweaked tests so they would not swallow the exception.

Also adds `SupportedOSPlatform` to the kernel32 call.