### PR TITLE
Implement simple termios functions

### DIFF
--- a/src/core/IronPython.Modules/fcntl.cs
+++ b/src/core/IronPython.Modules/fcntl.cs
@@ -222,7 +222,7 @@ public static class PythonFcntl {
 
     #region Helper Methods
 
-    private static int GetFileDescriptor(CodeContext context, object? obj) {
+    internal static int GetFileDescriptor(CodeContext context, object? obj) {
         if (!PythonOps.TryGetBoundAttr(context, obj, "fileno", out object? filenoMeth)) {
             throw PythonOps.TypeError("argument must be an int, or have a fileno() method.");
         }


### PR DESCRIPTION
Implements `tcsendbreak`, `tcdrain`, `tcflush`, `tcflow`, which makes `termios` function-complete up to and including Python 3.10. The exported constants are still not complete. `tcgetattr` and `tcsetattr` remain mocks. To implement `tcgetwinsize`, and `tcsetwinsize` added in 3.11, `fcntl.ioctl` needs to be better implemented (currently it's a stub).