### PR TITLE
Enable test query for exact test name

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -220,9 +220,9 @@ function Test([String] $target, [String] $configuration, [String[]] $frameworks,
             "cpython"    { $tasks += createTask "cpython" "TestCategory=CPython" }
             default      {
                 if ($filter.ToLower().StartsWith('ironpython')) {
-                    $tasks += createTask "query" "TestCategory=IronPython&$filter"
+                    $tasks += createTask "query" "TestCategory=IronPython&Name=$framework.$filter"
                 } elseif ($filter.ToLower().StartsWith('cpython')) {
-                    $tasks += createTask "query" "TestCategory=CPython&$filter"
+                    $tasks += createTask "query" "TestCategory=CPython&Name=$framework.$filter"
                 } else {
                     $tasks += createTask "query" $filter
                 }


### PR DESCRIPTION
The standard way of running a specific test is by using a query. E.g. to test `test_codecs`

```
./make.ps1 test-test_codecs
```

However, this matches tests by substring, so for more popular test names the query may catch several tests. The example above selects the following tests for running:
* CPython.test_codecs (currently ignored)
* IronPython.modules.io_related.test_codecs
* IronPython.test_codecs
* Ironpython.test_codecs_stdlib

Even running more specific

```
./make.ps1 test-IronPython.test_codecs
```

will still match two tests.

To be able to run just one selected test, one must resolve to construct an elaborate query, which is also framework specific:

```
./make.ps1 "test-TestCategory=IronPython&Name=net8.0.IronPython.test_codecs" -framework net8.0
```

This PR adds the possbilility to query for the exact test name and reduce the verbosity of the query filter. The above test can be now filtered out and run on all supported frameworks concurrently by:

```
./make.ps1 test-IronPython.test_codecs
```

This is btw an excellent way to check is a given test is parallel-safe.

The old behaviour for queries that start with `CPython` or `IronPython` (matching by substring) can still be achieved by adding explicit `Name~` to the query, e.g.

```
./make.ps1 test-Name~IronPython.test_codecs
```