### PR TITLE
Avoid throw/catch exceptions when requesting optional buffer through `IBufferProtocol`

### DIFF
--- a/src/core/IronPython.Modules/_ctypes/CData.cs
+++ b/src/core/IronPython.Modules/_ctypes/CData.cs
@@ -125,7 +125,7 @@ namespace IronPython.Modules {
 
             private int _numExports;
 
-            IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags) {
+            IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags, bool throwOnError) {
                 if (_disposed) throw new ObjectDisposedException(GetType().Name);
                 _ = MemHolder; // check if fully initialized
                 Interlocked.Increment(ref _numExports);

--- a/src/core/IronPython.Modules/array.cs
+++ b/src/core/IronPython.Modules/array.cs
@@ -1037,7 +1037,7 @@ namespace IronPython.Modules {
 
             #region IBufferProtocol Members
 
-            IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags) {
+            IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags, bool throwOnError) {
                 return _data.GetBuffer(this, _typeCode.ToString(), flags);
             }
 

--- a/src/core/IronPython.Modules/mmap.cs
+++ b/src/core/IronPython.Modules/mmap.cs
@@ -1314,10 +1314,13 @@ namespace IronPython.Modules {
 
             #endregion
 
-            public IPythonBuffer GetBuffer(BufferFlags flags = BufferFlags.Simple) {
-                if (flags.HasFlag(BufferFlags.Writable) && IsReadOnly)
-                    throw PythonOps.BufferError("Object is not writable.");
-
+            public IPythonBuffer? GetBuffer(BufferFlags flags, bool throwOnError) {
+                if (flags.HasFlag(BufferFlags.Writable) && IsReadOnly) {
+                    if (throwOnError) {
+                        throw PythonOps.BufferError("Object is not writable.");
+                    }
+                    return null;
+                }
                 return new MmapBuffer(this, flags);
             }
 

--- a/src/core/IronPython/Runtime/BufferProtocol.cs
+++ b/src/core/IronPython/Runtime/BufferProtocol.cs
@@ -17,7 +17,7 @@ namespace IronPython.Runtime {
     /// Equivalent functionality of CPython's <a href="https://docs.python.org/3/c-api/buffer.html">Buffer Protocol</a>.
     /// </summary>
     public interface IBufferProtocol {
-        IPythonBuffer GetBuffer(BufferFlags flags = BufferFlags.Simple);
+        IPythonBuffer? GetBuffer(BufferFlags flags, bool throwOnError);
     }
 
     /// <summary>
@@ -120,9 +120,12 @@ namespace IronPython.Runtime {
     }
 
     internal static class BufferProtocolExtensions {
+        internal static IPythonBuffer GetBuffer(this IBufferProtocol bufferProtocol, BufferFlags flags = BufferFlags.Simple)
+            => bufferProtocol.GetBuffer(flags, throwOnError: true) ?? throw new BufferException("Buffer type not supported");
+
         internal static IPythonBuffer? GetBufferNoThrow(this IBufferProtocol bufferProtocol, BufferFlags flags = BufferFlags.Simple) {
             try {
-                return bufferProtocol.GetBuffer(flags);
+                return bufferProtocol.GetBuffer(flags, throwOnError: false);
             } catch (BufferException) {
                 return null;
             }

--- a/src/core/IronPython/Runtime/ByteArray.cs
+++ b/src/core/IronPython/Runtime/ByteArray.cs
@@ -1584,7 +1584,7 @@ namespace IronPython.Runtime {
 
         #region IBufferProtocol Members
 
-        IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags) {
+        IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags, bool throwOnError) {
             return _bytes.GetBuffer(this, "B", flags);
         }
 

--- a/src/core/IronPython/Runtime/Bytes.cs
+++ b/src/core/IronPython/Runtime/Bytes.cs
@@ -1241,10 +1241,13 @@ namespace IronPython.Runtime {
 
         #region IBufferProtocol Support
 
-        IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags) {
-            if (flags.HasFlag(BufferFlags.Writable))
-                throw PythonOps.BufferError("Object is not writable.");
-
+        IPythonBuffer? IBufferProtocol.GetBuffer(BufferFlags flags, bool throwOnError) {
+            if (flags.HasFlag(BufferFlags.Writable)) {
+                if (throwOnError) {
+                    throw PythonOps.TypeError("bytes object is not writable");
+                }
+                return null;
+            }
             return new BytesView(this, flags);
         }
 

--- a/src/core/IronPython/Runtime/Bytes.cs
+++ b/src/core/IronPython/Runtime/Bytes.cs
@@ -1244,7 +1244,7 @@ namespace IronPython.Runtime {
         IPythonBuffer? IBufferProtocol.GetBuffer(BufferFlags flags, bool throwOnError) {
             if (flags.HasFlag(BufferFlags.Writable)) {
                 if (throwOnError) {
-                    throw PythonOps.TypeError("bytes object is not writable");
+                    throw PythonOps.BufferError("bytes object is not writable");
                 }
                 return null;
             }

--- a/src/core/IronPython/Runtime/ConversionWrappers.cs
+++ b/src/core/IronPython/Runtime/ConversionWrappers.cs
@@ -436,13 +436,16 @@ namespace IronPython.Runtime {
             _memory = memory;
         }
 
-        public IPythonBuffer GetBuffer(BufferFlags flags) {
+        public IPythonBuffer? GetBuffer(BufferFlags flags, bool throwOnError) {
             if (_memory.HasValue) {
                 return new MemoryBufferWrapper(_memory.Value, flags);
             }
 
             if (flags.HasFlag(BufferFlags.Writable)) {
-                throw Operations.PythonOps.BufferError("ReadOnlyMemory is not writable.");
+                if (throwOnError) {
+                    throw Operations.PythonOps.BufferError("ReadOnlyMemory is not writable.");
+                }
+                return null;
             }
 
             return new MemoryBufferWrapper(_rom, flags);

--- a/src/core/IronPython/Runtime/MemoryView.cs
+++ b/src/core/IronPython/Runtime/MemoryView.cs
@@ -963,32 +963,39 @@ namespace IronPython.Runtime {
 
         #region IBufferProtocol Members
 
-        IPythonBuffer IBufferProtocol.GetBuffer(BufferFlags flags) {
+        IPythonBuffer? IBufferProtocol.GetBuffer(BufferFlags flags, bool throwOnError) {
             CheckBuffer();
 
             if (flags.HasFlag(BufferFlags.Writable) && _isReadOnly)
-                throw PythonOps.BufferError("memoryview: underlying buffer is not writable");
+                return ReportError("memoryview: underlying buffer is not writable");
 
             if (flags.HasFlag(BufferFlags.CContiguous) && !_isCContig)
-                throw PythonOps.BufferError("memoryview: underlying buffer is not C-contiguous");
+                return ReportError("memoryview: underlying buffer is not C-contiguous");
 
             if (flags.HasFlag(BufferFlags.FContiguous) && !_isFContig)
-                throw PythonOps.BufferError("memoryview: underlying buffer is not Fortran contiguous");
+                return ReportError("memoryview: underlying buffer is not Fortran contiguous");
 
             if (flags.HasFlag(BufferFlags.AnyContiguous) && !_isCContig && !_isFContig)
-                throw PythonOps.BufferError("memoryview: underlying buffer is not contiguous");
+                return ReportError("memoryview: underlying buffer is not contiguous");
 
             // TODO: Support for suboffsets
             //if (!flags.HasFlag(!BufferFlags.Indirect) && _suboffsets != null)
-            //    throw PythonOps.BufferError("memoryview: underlying buffer requires suboffsets");
+            //    return ReportError("memoryview: underlying buffer requires suboffsets");
 
             if (!flags.HasFlag(BufferFlags.Strides) && !_isCContig)
-                throw PythonOps.BufferError("memoryview: underlying buffer is not C-contiguous");
+                return ReportError("memoryview: underlying buffer is not C-contiguous");
 
             if (!flags.HasFlag(BufferFlags.ND) && flags.HasFlag(BufferFlags.Format))
-                throw PythonOps.BufferError("memoryview: cannot cast to unsigned bytes if the format flag is present");
+                return ReportError("memoryview: cannot cast to unsigned bytes if the format flag is present");
 
             return new MemoryView(this, flags);
+
+            IPythonBuffer? ReportError(string msg) {
+                if (throwOnError) {
+                    throw PythonOps.BufferError(msg);
+                }
+                return null;
+            }
         }
 
         #endregion


### PR DESCRIPTION
It turns out that `GetBufferNoThrow` is quite popular. However, it entailed a `try`/`catch` of `BufferException`, which incurs a performance penalty. In CPython, it turns out it is fairly common to try to get a buffer that is not supported , and then fall back on some more supported versions, since the error is inexpensive to return. However, it requires checking every return value, which is not convenient to the users of the interface. Besides, it is the provider, not the user, that can describe the error best.

This PR keeps the current of the usage interface the same, while keeping the complexity of implementing `IBufferProtocol` at a similar level, and avoiding the try/catch of the exception for unsupported calls.