### PR TITLE
Downgrade _macos-latest-large_ to _macos-latest_

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-22.04, macos-latest-large]
+        os: [windows-latest, ubuntu-22.04, macos-latest]
 
     steps:
     - name: Install tools

--- a/tests/IronPython.Tests/Cases/IronPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/IronPythonCasesManifest.ini
@@ -150,6 +150,7 @@ RunCondition=NOT $(IS_MONO) # Mono codepage 852 encoding incorrecly decodes 0xAA
 IsolationLevel=PROCESS # reset reporting of warnings
 
 [IronPython.test_utf8_mode_stdlib]
+Timeout=240000 # Mono is extremely slow
 IsolationLevel=PROCESS
 
 [IronPython.interop.net.derivation.test_property_override]


### PR DESCRIPTION
The IronPython3 project does not have access to _macos-latest-large_, so the CI runner on macOS always fails on start generating spurious failures (but then restarts and continues as standard and succeeds anyway. Sometimes.)