### PR TITLE
Apply `is object` test

### DIFF
--- a/src/core/IronPython.Modules/nt.cs
+++ b/src/core/IronPython.Modules/nt.cs
@@ -454,7 +454,7 @@ namespace IronPython.Modules {
                 }
                 if (streams.IsConsoleStream()) return new stat_result(0x2000);
                 if (streams.IsStandardIOStream()) return new stat_result(0x1000);
-                if (StatStream(streams.ReadStream) is not null and var res) return res;
+                if (StatStream(streams.ReadStream) is object res) return res;
             }
             return LightExceptions.Throw(PythonOps.OSError(PythonErrno.EBADF, "Bad file descriptor"));
 

--- a/src/core/IronPython.Modules/termios.cs
+++ b/src/core/IronPython.Modules/termios.cs
@@ -405,7 +405,7 @@ public static class PythonTermios {
 
         object result = PythonFcntl.ioctl(fd, TIOCGWINSZ, buf, mutate_flag: true);
 
-        if (ToTermiosError(context, result) is not null and var ex) {
+        if (ToTermiosError(context, result) is object ex) {
             return ex;
         }
         return PythonTuple.MakeTuple((int)ws[0], (int)ws[1]);
@@ -431,7 +431,7 @@ public static class PythonTermios {
         var buf = new MemoryBufferProtocolWrapper<ushort>(ws.AsMemory());
 
         object result = PythonFcntl.ioctl(fd, TIOCGWINSZ, buf, mutate_flag: true);
-        if (ToTermiosError(context, result) is not null and var ex) {
+        if (ToTermiosError(context, result) is object ex) {
             return ex;
         }
 
@@ -442,7 +442,7 @@ public static class PythonTermios {
         }
 
         result = PythonFcntl.ioctl(fd, TIOCSWINSZ, buf);
-        if (ToTermiosError(context, result) is not null and var ex2) {
+        if (ToTermiosError(context, result) is object ex2) {
             return ex2;
         }
 

--- a/tests/IronPython.Tests/Cases/CaseExecuter.cs
+++ b/tests/IronPython.Tests/Cases/CaseExecuter.cs
@@ -301,7 +301,7 @@ namespace IronPythonTest.Cases {
                         #pragma warning disable SYSLIB0006 // 'Thread.ResetAbort is not supported and throws PlatformNotSupportedException.' 
                         Thread.ResetAbort();
                         #pragma warning restore SYSLIB0006
-                    } catch (Exception ex) when (ex.GetPythonException() is not null and var pex) {
+                    } catch (Exception ex) when (ex.GetPythonException() is object pex) {
                         if (DynamicHelpers.GetPythonType(pex).Name == "SkipTest") {
                             NUnit.Framework.TestContext.Progress.WriteLine($"Test {testcase.Name} skipped: {pex}");
                             res = 0;


### PR DESCRIPTION
OK, let's settle on `is object` test instead of `is not null and var`.