### PR TITLE
Typecode cleanup

### DIFF
--- a/src/core/IronPython.Modules/_ctypes/SimpleType.cs
+++ b/src/core/IronPython.Modules/_ctypes/SimpleType.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Numerics;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -13,7 +14,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using IronPython.Runtime;
-using IronPython.Runtime.Exceptions;
 using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
 
@@ -170,25 +170,25 @@ namespace IronPython.Modules {
             int INativeType.Size {
                 get {
                     switch (_type) {
+                        case SimpleTypeKind.Boolean:
                         case SimpleTypeKind.Char:
                         case SimpleTypeKind.SignedByte:
                         case SimpleTypeKind.UnsignedByte:
-                        case SimpleTypeKind.Boolean:
                             return 1;
+                        case SimpleTypeKind.VariantBool:
+                        case SimpleTypeKind.WChar:
                         case SimpleTypeKind.SignedShort:
                         case SimpleTypeKind.UnsignedShort:
-                        case SimpleTypeKind.WChar:
-                        case SimpleTypeKind.VariantBool:
                             return 2;
                         case SimpleTypeKind.SignedInt:
                         case SimpleTypeKind.UnsignedInt:
-                        case SimpleTypeKind.UnsignedLong:
                         case SimpleTypeKind.SignedLong:
+                        case SimpleTypeKind.UnsignedLong:
                         case SimpleTypeKind.Single:
                             return 4;
-                        case SimpleTypeKind.Double:
                         case SimpleTypeKind.UnsignedLongLong:
                         case SimpleTypeKind.SignedLongLong:
+                        case SimpleTypeKind.Double:
                             return 8;
                         case SimpleTypeKind.Object:
                         case SimpleTypeKind.Pointer:
@@ -211,21 +211,21 @@ namespace IronPython.Modules {
                 object res;
                 switch (_type) {
                     case SimpleTypeKind.Boolean: res = owner.ReadByte(offset) != 0 ? ScriptingRuntimeHelpers.True : ScriptingRuntimeHelpers.False; break;
+                    case SimpleTypeKind.VariantBool: res = owner.ReadInt16(offset, _swap) != 0 ? ScriptingRuntimeHelpers.True : ScriptingRuntimeHelpers.False; break;
                     case SimpleTypeKind.Char: res = Bytes.FromByte(owner.ReadByte(offset)); break;
+                    case SimpleTypeKind.WChar: res = new string((char)owner.ReadInt16(offset), 1); break;
                     case SimpleTypeKind.SignedByte: res = GetIntReturn((int)(sbyte)owner.ReadByte(offset)); break;
                     case SimpleTypeKind.UnsignedByte: res = GetIntReturn((int)owner.ReadByte(offset)); break;
                     case SimpleTypeKind.SignedShort: res = GetIntReturn(owner.ReadInt16(offset, _swap)); break;
-                    case SimpleTypeKind.WChar: res = new string((char)owner.ReadInt16(offset), 1); break;
                     case SimpleTypeKind.UnsignedShort: res = GetIntReturn((ushort)owner.ReadInt16(offset, _swap)); break;
-                    case SimpleTypeKind.VariantBool: res = owner.ReadInt16(offset, _swap) != 0 ? ScriptingRuntimeHelpers.True : ScriptingRuntimeHelpers.False; break;
                     case SimpleTypeKind.SignedInt: res = GetIntReturn(owner.ReadInt32(offset, _swap)); break;
                     case SimpleTypeKind.UnsignedInt: res = GetIntReturn((uint)owner.ReadInt32(offset, _swap)); break;
-                    case SimpleTypeKind.UnsignedLong: res = GetIntReturn((uint)owner.ReadInt32(offset, _swap)); break;
                     case SimpleTypeKind.SignedLong: res = GetIntReturn(owner.ReadInt32(offset, _swap)); break;
+                    case SimpleTypeKind.UnsignedLong: res = GetIntReturn((uint)owner.ReadInt32(offset, _swap)); break;
+                    case SimpleTypeKind.SignedLongLong: res = GetIntReturn(owner.ReadInt64(offset, _swap)); break;
+                    case SimpleTypeKind.UnsignedLongLong: res = GetIntReturn((ulong)owner.ReadInt64(offset, _swap)); break;
                     case SimpleTypeKind.Single: res = GetSingleReturn(owner.ReadInt32(offset, _swap)); break;
                     case SimpleTypeKind.Double: res = GetDoubleReturn(owner.ReadInt64(offset, _swap)); break;
-                    case SimpleTypeKind.UnsignedLongLong: res = GetIntReturn((ulong)owner.ReadInt64(offset, _swap)); break;
-                    case SimpleTypeKind.SignedLongLong: res = GetIntReturn(owner.ReadInt64(offset, _swap)); break;
                     case SimpleTypeKind.Object: res = GetObjectReturn(owner.ReadIntPtr(offset)); break;
                     case SimpleTypeKind.Pointer: res = owner.ReadIntPtr(offset).ToPython(); break;
                     case SimpleTypeKind.CharPointer: res = owner.ReadMemoryHolder(offset).ReadBytes(0); break;
@@ -250,21 +250,21 @@ namespace IronPython.Modules {
 
                 switch (_type) {
                     case SimpleTypeKind.Boolean: owner.WriteByte(offset, ModuleOps.GetBoolean(value, this)); break;
+                    case SimpleTypeKind.VariantBool: owner.WriteInt16(offset, unchecked((short)ModuleOps.GetVariantBool(value, this)), _swap); break;
                     case SimpleTypeKind.Char: owner.WriteByte(offset, ModuleOps.GetChar(value, this)); break;
+                    case SimpleTypeKind.WChar: owner.WriteInt16(offset, unchecked((short)ModuleOps.GetWChar(value, this))); break;
                     case SimpleTypeKind.SignedByte: owner.WriteByte(offset, unchecked((byte)ModuleOps.GetSignedByte(value, this))); break;
                     case SimpleTypeKind.UnsignedByte: owner.WriteByte(offset, ModuleOps.GetUnsignedByte(value, this)); break;
-                    case SimpleTypeKind.WChar: owner.WriteInt16(offset, unchecked((short)ModuleOps.GetWChar(value, this))); break;
                     case SimpleTypeKind.SignedShort: owner.WriteInt16(offset, ModuleOps.GetSignedShort(value, this), _swap); break;
                     case SimpleTypeKind.UnsignedShort: owner.WriteInt16(offset, unchecked((short)ModuleOps.GetUnsignedShort(value, this)), _swap); break;
-                    case SimpleTypeKind.VariantBool: owner.WriteInt16(offset, unchecked((short)ModuleOps.GetVariantBool(value, this)), _swap); break;
                     case SimpleTypeKind.SignedInt: owner.WriteInt32(offset, ModuleOps.GetSignedInt(value, this), _swap); break;
                     case SimpleTypeKind.UnsignedInt: owner.WriteInt32(offset, unchecked((int)ModuleOps.GetUnsignedInt(value, this)), _swap); break;
+                    case SimpleTypeKind.SignedLong: owner.WriteInt32(offset, unchecked((int)ModuleOps.GetSignedLong(value, this)), _swap); break;
                     case SimpleTypeKind.UnsignedLong: owner.WriteInt32(offset, unchecked((int)ModuleOps.GetUnsignedLong(value, this)), _swap); break;
-                    case SimpleTypeKind.SignedLong: owner.WriteInt32(offset, ModuleOps.GetSignedLong(value, this), _swap); break;
-                    case SimpleTypeKind.Single: owner.WriteInt32(offset, ModuleOps.GetSingleBits(value), _swap); break;
-                    case SimpleTypeKind.Double: owner.WriteInt64(offset, ModuleOps.GetDoubleBits(value), _swap); break;
                     case SimpleTypeKind.UnsignedLongLong: owner.WriteInt64(offset, unchecked((long)ModuleOps.GetUnsignedLongLong(value, this)), _swap); break;
                     case SimpleTypeKind.SignedLongLong: owner.WriteInt64(offset, ModuleOps.GetSignedLongLong(value, this), _swap); break;
+                    case SimpleTypeKind.Single: owner.WriteInt32(offset, ModuleOps.GetSingleBits(value), _swap); break;
+                    case SimpleTypeKind.Double: owner.WriteInt64(offset, ModuleOps.GetDoubleBits(value), _swap); break;
                     case SimpleTypeKind.Object: owner.WriteIntPtr(offset, ModuleOps.GetObject(value)); break;
                     case SimpleTypeKind.Pointer: owner.WriteIntPtr(offset, ModuleOps.GetPointer(value)); break;
                     case SimpleTypeKind.CharPointer:
@@ -286,33 +286,34 @@ namespace IronPython.Modules {
                 switch (_type) {
                     case SimpleTypeKind.Boolean:
                         return typeof(bool);
+                    case SimpleTypeKind.VariantBool:
+                        return typeof(short);
                     case SimpleTypeKind.Char:
                         return typeof(byte);
+                    case SimpleTypeKind.WChar:
+                        return typeof(char);
                     case SimpleTypeKind.SignedByte:
                         return typeof(sbyte);
                     case SimpleTypeKind.UnsignedByte:
                         return typeof(byte);
                     case SimpleTypeKind.SignedShort:
-                    case SimpleTypeKind.VariantBool:
                         return typeof(short);
                     case SimpleTypeKind.UnsignedShort:
                         return typeof(ushort);
-                    case SimpleTypeKind.WChar:
-                        return typeof(char);
                     case SimpleTypeKind.SignedInt:
                     case SimpleTypeKind.SignedLong:
                         return typeof(int);
                     case SimpleTypeKind.UnsignedInt:
                     case SimpleTypeKind.UnsignedLong:
                         return typeof(uint);
+                    case SimpleTypeKind.SignedLongLong:
+                        return typeof(long);
+                    case SimpleTypeKind.UnsignedLongLong:
+                        return typeof(ulong);
                     case SimpleTypeKind.Single:
                         return typeof(float);
                     case SimpleTypeKind.Double:
                         return typeof(double);
-                    case SimpleTypeKind.UnsignedLongLong:
-                        return typeof(ulong);
-                    case SimpleTypeKind.SignedLongLong:
-                        return typeof(long);
                     case SimpleTypeKind.Object:
                         return typeof(IntPtr);
                     case SimpleTypeKind.Pointer:
@@ -361,21 +362,21 @@ namespace IronPython.Modules {
                 }
                 switch (_type) {
                     case SimpleTypeKind.Boolean:
+                    case SimpleTypeKind.VariantBool:
                     case SimpleTypeKind.Char:
+                    case SimpleTypeKind.WChar:
                     case SimpleTypeKind.SignedByte:
                     case SimpleTypeKind.UnsignedByte:
                     case SimpleTypeKind.SignedShort:
                     case SimpleTypeKind.UnsignedShort:
-                    case SimpleTypeKind.WChar:
                     case SimpleTypeKind.SignedInt:
                     case SimpleTypeKind.UnsignedInt:
-                    case SimpleTypeKind.UnsignedLong:
                     case SimpleTypeKind.SignedLong:
+                    case SimpleTypeKind.UnsignedLong:
+                    case SimpleTypeKind.SignedLongLong:
+                    case SimpleTypeKind.UnsignedLongLong:
                     case SimpleTypeKind.Single:
                     case SimpleTypeKind.Double:
-                    case SimpleTypeKind.UnsignedLongLong:
-                    case SimpleTypeKind.SignedLongLong:
-                    case SimpleTypeKind.VariantBool:
                         constantPool.Add(this);
                         method.Emit(OpCodes.Ldarg, constantPoolArgument);
                         method.Emit(OpCodes.Ldc_I4, constantPool.Count - 1);
@@ -608,16 +609,16 @@ namespace IronPython.Modules {
             void INativeType.EmitReverseMarshalling(ILGenerator method, LocalOrArg value, List<object> constantPool, int constantPoolArgument) {
                 value.Emit(method);
                 switch (_type) {
+                    case SimpleTypeKind.VariantBool:
                     case SimpleTypeKind.SignedByte:
                     case SimpleTypeKind.UnsignedByte:
                     case SimpleTypeKind.SignedShort:
                     case SimpleTypeKind.UnsignedShort:
-                    case SimpleTypeKind.VariantBool:
                         method.Emit(OpCodes.Conv_I4);
                         break;
+                    case SimpleTypeKind.Boolean:
                     case SimpleTypeKind.SignedInt:
                     case SimpleTypeKind.SignedLong:
-                    case SimpleTypeKind.Boolean:
                         break;
                     case SimpleTypeKind.Single:
                         method.Emit(OpCodes.Conv_R8);
@@ -626,11 +627,11 @@ namespace IronPython.Modules {
                         break;
                     case SimpleTypeKind.UnsignedInt:
                     case SimpleTypeKind.UnsignedLong:
+                    case SimpleTypeKind.UnsignedLongLong:
                         EmitUIntToObject(method, value);
                         break;
-                    case SimpleTypeKind.UnsignedLongLong:
                     case SimpleTypeKind.SignedLongLong:
-                        EmitXInt64ToObject(method, value);
+                        EmitInt64ToObject(method, value);
                         break;
                     case SimpleTypeKind.Object:
                         method.Emit(OpCodes.Call, typeof(ModuleOps).GetMethod(nameof(ModuleOps.IntPtrToObject)));
@@ -685,7 +686,7 @@ namespace IronPython.Modules {
                             method.MarkLabel(notNull);
 
                             method.Emit(OpCodes.Ldloc, tmpLocal);
-                            EmitXInt64ToObject(method, new Local(tmpLocal));
+                            EmitInt64ToObject(method, new Local(tmpLocal));
                         }
 
                         method.MarkLabel(done);
@@ -710,13 +711,15 @@ namespace IronPython.Modules {
                 }
             }
 
-            private static void EmitXInt64ToObject(ILGenerator method, LocalOrArg value) {
+            /// <summary>
+            /// Converts Int64 to boxed Int32 if the value fits, otherwise converts to boxed BigInteger.
+            /// </summary>
+            private static void EmitInt64ToObject(ILGenerator method, LocalOrArg value) {
+                Debug.Assert(value.Type == typeof(long));
+
                 Label done;
                 Label bigInt = method.DefineLabel();
                 done = method.DefineLabel();
-                if (value.Type == typeof(ulong)) {
-                    method.Emit(OpCodes.Conv_I8);
-                }
                 method.Emit(OpCodes.Ldc_I4, Int32.MaxValue);
                 method.Emit(OpCodes.Conv_I8);
                 method.Emit(OpCodes.Bgt, bigInt);
@@ -739,7 +742,13 @@ namespace IronPython.Modules {
                 method.MarkLabel(done);
             }
 
+            /// <summary>
+            /// Handles UInt32 and UInt64 (assumes no negative values), converting to boxed Int32 if the value fits,
+            /// otherwise converts to boxed BigInteger.
+            /// </summary>
             private static void EmitUIntToObject(ILGenerator method, LocalOrArg value) {
+                Debug.Assert(value.Type == typeof(uint) || value.Type == typeof(ulong));
+
                 Label intVal, done;
                 intVal = method.DefineLabel();
                 done = method.DefineLabel();
@@ -761,11 +770,8 @@ namespace IronPython.Modules {
                 method.MarkLabel(done);
             }
 
-            private bool IsSubClass {
-                get {
-                    return BaseTypes.Count != 1 || BaseTypes[0] != CTypes._SimpleCData;
-                }
-            }
+            private bool IsSubClass
+                => BaseTypes.Count != 1 || BaseTypes[0] != CTypes._SimpleCData;
 
             private object GetObjectReturn(IntPtr intPtr) {
                 GCHandle handle = GCHandle.FromIntPtr(intPtr);
@@ -812,11 +818,7 @@ namespace IronPython.Modules {
                 return (BigInteger)value;
             }
 
-            string INativeType.TypeFormat {
-                get {
-                    return _format;
-                }
-            }
+            string INativeType.TypeFormat => _format;
 
             #endregion
         }

--- a/src/core/IronPython.Modules/_struct.cs
+++ b/src/core/IronPython.Modules/_struct.cs
@@ -150,6 +150,16 @@ namespace IronPython.Modules {
                                 WriteUInt(res, _isLittleEndian, GetULongValue(context, curObj++, values));
                             }
                             break;
+                        case FormatType.LongLong:
+                            for (int j = 0; j < curFormat.Count; j++) {
+                                WriteLong(res, _isLittleEndian, GetLongLongValue(context, curObj++, values));
+                            }
+                            break;
+                        case FormatType.UnsignedLongLong:
+                            for (int j = 0; j < curFormat.Count; j++) {
+                                WriteULong(res, _isLittleEndian, GetULongLongValue(context, curObj++, values));
+                            }
+                            break;
                         case FormatType.Pointer:
                             for (int j = 0; j < curFormat.Count; j++) {
                                 WritePointer(res, _isLittleEndian, GetPointer(context, curObj++, values));
@@ -173,16 +183,6 @@ namespace IronPython.Modules {
                         case FormatType.SizeT:
                             for (int j = 0; j < curFormat.Count; j++) {
                                 WriteUInt(res, _isLittleEndian, GetSizeT(context, curObj++, values));
-                            }
-                            break;
-                        case FormatType.LongLong:
-                            for (int j = 0; j < curFormat.Count; j++) {
-                                WriteLong(res, _isLittleEndian, GetLongLongValue(context, curObj++, values));
-                            }
-                            break;
-                        case FormatType.UnsignedLongLong:
-                            for (int j = 0; j < curFormat.Count; j++) {
-                                WriteULong(res, _isLittleEndian, GetULongLongValue(context, curObj++, values));
                             }
                             break;
                         case FormatType.Double:
@@ -315,6 +315,16 @@ namespace IronPython.Modules {
                                 res[res_idx++] = BigIntegerOps.__int__(CreateUIntValue(context, ref curIndex, _isLittleEndian, data));
                             }
                             break;
+                        case FormatType.LongLong:
+                            for (int j = 0; j < curFormat.Count; j++) {
+                                res[res_idx++] = BigIntegerOps.__int__(CreateLongValue(context, ref curIndex, _isLittleEndian, data));
+                            }
+                            break;
+                        case FormatType.UnsignedLongLong:
+                            for (int j = 0; j < curFormat.Count; j++) {
+                                res[res_idx++] = BigIntegerOps.__int__(CreateULongValue(context, ref curIndex, _isLittleEndian, data));
+                            }
+                            break;
                         case FormatType.Pointer:
                             for (int j = 0; j < curFormat.Count; j++) {
                                 if (IntPtr.Size == 4) {
@@ -350,16 +360,6 @@ namespace IronPython.Modules {
                         case FormatType.SizeT:
                             for (int j = 0; j < curFormat.Count; j++) {
                                 res[res_idx++] = BigIntegerOps.__int__(CreateUIntValue(context, ref curIndex, _isLittleEndian, data));
-                            }
-                            break;
-                        case FormatType.LongLong:
-                            for (int j = 0; j < curFormat.Count; j++) {
-                                res[res_idx++] = BigIntegerOps.__int__(CreateLongValue(context, ref curIndex, _isLittleEndian, data));
-                            }
-                            break;
-                        case FormatType.UnsignedLongLong:
-                            for (int j = 0; j < curFormat.Count; j++) {
-                                res[res_idx++] = BigIntegerOps.__int__(CreateULongValue(context, ref curIndex, _isLittleEndian, data));
                             }
                             break;
 #if NET6_0_OR_GREATER

--- a/src/core/IronPython.Modules/array.cs
+++ b/src/core/IronPython.Modules/array.cs
@@ -117,7 +117,7 @@ namespace IronPython.Modules {
 
             public array([NotNone] string type) {
                 if (type == null || type.Length != 1) {
-                    throw PythonOps.TypeError("expected character, got {0}", PythonOps.GetPythonTypeName(type));
+                    throw PythonOps.TypeErrorForBadInstance("expected character, got {0}", type);
                 }
 
                 _typeCode = type[0];
@@ -388,31 +388,8 @@ namespace IronPython.Modules {
                 _data.Insert(i, x);
             }
 
-            public int itemsize {
-                get {
-                    switch (_typeCode) {
-                        case 'b': // signed byte
-                        case 'B': // unsigned byte
-                            return 1;
-                        case 'u': // unicode char
-                        case 'h': // signed short
-                        case 'H': // unsigned short
-                            return 2;
-                        case 'i': // signed int
-                        case 'I': // unsigned int
-                        case 'l': // signed long
-                        case 'L': // unsigned long
-                        case 'f': // float
-                            return 4;
-                        case 'q': // signed long long
-                        case 'Q': // unsigned long long
-                        case 'd': // double
-                            return 8;
-                        default:
-                            throw new InvalidOperationException(); // should never happen
-                    }
-                }
-            }
+            public int itemsize
+                => TypecodeOps.GetTypecodeWidth(_typeCode);
 
             public object pop() {
                 return pop(-1);

--- a/src/core/IronPython/Runtime/ConversionWrappers.cs
+++ b/src/core/IronPython/Runtime/ConversionWrappers.cs
@@ -405,8 +405,10 @@ namespace IronPython.Runtime {
             return new MemoryBufferWrapper(this, flags);
         }
 
-        private static char GetFormatChar()
-            => Type.GetTypeCode(typeof(T)) switch {
+        private static char GetFormatChar() {
+            Type type_T = typeof(T);
+            return Type.GetTypeCode(type_T) switch {
+                TypeCode.Boolean => '?',
                 TypeCode.SByte   => 'b',
                 TypeCode.Byte    => 'B',
                 TypeCode.Char    => 'u',
@@ -418,9 +420,13 @@ namespace IronPython.Runtime {
                 TypeCode.UInt64  => 'Q',
                 TypeCode.Single  => 'f',
                 TypeCode.Double  => 'd',
-                _ => throw new ArgumentException("Unsupported type"),
+                _ =>
+#if NET6_0_OR_GREATER
+                    type_T == typeof(Half) ? 'e' :
+#endif
+                    throw new ArgumentException("Unsupported type"),
             };
-
+        }
 
         private sealed unsafe class MemoryBufferWrapper : IPythonBuffer {
             private readonly MemoryBufferProtocolWrapper<T> _wrapper;


### PR DESCRIPTION
This PR is mostly just reorganizing the code handling typecodes across modules into a consistent ordering. Having a consistent ordering helps comparing implementations and spot irregularities (which may indicate a bug, and indeed, there were a few minor ones related to casting).

The ordering I adopted is based on what was used by `TypecodeOps` and `array` (although even there there were some inconsistencies), grouping by typecode klass:

* Boolean
* character
* integer
* floating point
* object
* pointer

Within one klass, the ordering is by size, within the same size, signed then unsigned, or regular then exotic.

This change is meant to be innocent, primarily code reordering, which is already difficult to review looking at the diffs. The more challenging typecode issues, like handling of `l`/`L` (are currently incorrect on non-Windows platforms), `e` (is incomplete), or `n`/`N` (don't know what to do with that yet) are left for dedicated PRs.