### PR TITLE
Implement file locking in SQLite on Posix

### DIFF
--- a/src/extensions/IronPython.SQLite/IronPython.SQLite.csproj
+++ b/src/extensions/IronPython.SQLite/IronPython.SQLite.csproj
@@ -23,6 +23,20 @@
     <DefineConstants>NET_40;$(DefineConstants);$(SQLiteCommon);$(SQLiteCommonOmit);SQLITE_MUTEX_W32;SQLITE_THREADSAFE;NDEBUG</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(IsFullFramework)' == 'true' ">
+    <Reference Include="Mono.Posix" Version="4.0.0">
+      <Private>True</Private>
+      <HintPath>$(UtilsDir)\References\Mono.Posix.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(IsFullFramework)' != 'true' ">
+    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../core/IronPython/FakeInteropServices.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\core\IronPython\IronPython.csproj" Private="false" />
     <ProjectReference Include="..\..\dlr\Src\Microsoft.Scripting\Microsoft.Scripting.csproj" Private="false" />


### PR DESCRIPTION
The file locking strategy in SQLite was basically Windows-oriented, with some provisions for limited-trust environment like Silverlight, WinRT, and Windows Mobile. These are obsolete but somebody repurposed the limited-trust strategy to work on Unix. This worked on Linux (sort of, shared locks were seemingly emulated in a way that only SQLite respected), but wasn't working at all on macOS.

This PR implements proper locking on Linux and macOS through a fcntl syscall via _Mono.Unix_. Locking on Windows is unchanged.

I resisted the temptation to start cleaning up the code (it is even badly formatted), because there would be no end to it, and it is better to replace it by a modern SQLite implementation in a longer run anyway.