### PR TITLE
Use actual container type name for repr

### DIFF
--- a/src/core/IronPython.Modules/_collections.cs
+++ b/src/core/IronPython.Modules/_collections.cs
@@ -920,7 +920,8 @@ namespace IronPython.Modules {
                 infinite.Add(this);
                 try {
                     StringBuilder sb = new StringBuilder();
-                    sb.Append("deque([");
+                    sb.Append(PythonOps.GetPythonTypeName(this));
+                    sb.Append("([");
                     string comma = "";
 
                     lock (_lockObj) {
@@ -1188,7 +1189,7 @@ namespace IronPython.Modules {
             }
 
             public override string __repr__(CodeContext context) {
-                return string.Format("defaultdict({0}, {1})", ReprFactory(context, default_factory), base.__repr__(context));
+                return string.Format("{0}({1}, {2})", PythonOps.GetPythonTypeName(this), ReprFactory(context, default_factory), base.__repr__(context));
 
                 static string ReprFactory(CodeContext context, object factory) {
                     var infinite = PythonOps.GetAndCheckInfinite(factory);

--- a/src/core/IronPython.Modules/array.cs
+++ b/src/core/IronPython.Modules/array.cs
@@ -856,7 +856,7 @@ namespace IronPython.Modules {
             #region ICodeFormattable Members
 
             public virtual string/*!*/ __repr__(CodeContext/*!*/ context) {
-                string res = "array('" + typecode.ToString() + "'";
+                string res = PythonOps.GetPythonTypeName(this) + "('" + typecode.ToString() + "'";
                 if (_data.Count == 0) {
                     return res + ")";
                 }

--- a/src/core/IronPython.StdLib/lib/test/test_defaultdict.py
+++ b/src/core/IronPython.StdLib/lib/test/test_defaultdict.py
@@ -157,8 +157,14 @@ class TestDefaultDict(unittest.TestCase):
             def _factory(self):
                 return []
         d = sub()
-        self.assertTrue(repr(d).startswith(
-            "defaultdict(<bound method sub._factory of defaultdict(..."))
+        # IronPython: repr class name change adopted from Python 3.7
+        # original Python 3.4 test:
+        # self.assertTrue(repr(d).startswith(
+        #     "defaultdict(<bound method sub._factory of defaultdict(..."))
+        # Python 3.7 test:
+        self.assertRegex(repr(d),
+            r"sub\(<bound method .*sub\._factory "
+            r"of sub\(\.\.\., \{\}\)>, \{\}\)")
 
         # NOTE: printing a subclass of a builtin type does not call its
         # tp_print slot. So this part is essentially the same test as above.

--- a/src/core/IronPython/Runtime/ByteArray.cs
+++ b/src/core/IronPython/Runtime/ByteArray.cs
@@ -1079,7 +1079,7 @@ namespace IronPython.Runtime {
 
         private string Repr() {
             lock (this) {
-                return "bytearray(" + _bytes.BytesRepr() + ")";
+                return PythonOps.GetPythonTypeName(this) +  "(" + _bytes.BytesRepr() + ")";
             }
         }
 

--- a/tests/suite/test_isinstance.py
+++ b/tests/suite/test_isinstance.py
@@ -974,4 +974,26 @@ class IsInstanceTest(IronPythonTestCase):
         self.assertRaises(TypeError, tuple.__new__, str)
         self.assertRaises(TypeError, tuple.__new__, str, 'abc')
 
+
+    def test_container_repr(self):
+        import array, collections
+        class MyArray(array.array): pass
+        class MyBytearray(bytearray): pass
+        class MyDeque(collections.deque): pass
+        class MyDefaultDict(collections.defaultdict): pass
+        class MySet(set): pass
+
+        if is_cli or sys.version_info >= (3, 7):
+            self.assertEqual(repr(MyArray('b')), "MyArray('b')")
+            self.assertEqual(repr(MyBytearray(b'x')), "MyBytearray(b'x')")
+            self.assertEqual(repr(MyDeque(['c'])), "MyDeque(['c'])")
+            self.assertTrue("MyDefaultDict" in repr(MyDefaultDict(list)))
+        else:
+            self.assertEqual(repr(MyArray('b')), "array('b')")
+            self.assertEqual(repr(MyBytearray(b'x')), "bytearray(b'x')")
+            self.assertEqual(repr(MyDeque(['c'])), "deque(['c'])")
+            self.assertTrue("defaultdict" in repr(MyDefaultDict(list)))
+        self.assertEqual(repr(MySet()), "MySet()")
+
+
 run_test(__name__)


### PR DESCRIPTION
This PR changes the `repr()` on the builtin container types for their subclasses to display the subclass name rather than always the root base type. Similarly what is already done for `set`: `repr(set()` is `set()` but if `class MySet(set): pass` is defined, `repr(MySet())` is `MySet()`. The changed container types are:
- `bytearray`
- `array.array`
- `collections.defaultdict`
- `collections.deque`

This change has been implemented in Python 3.7. but in 3.4 - 3.6 there is one test in StdLib that catches the base class name; this has been upgraded here to the test from 3.7.