### PR TITLE
Downgrade Ubuntu to Jammy (on Azure)

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ jobs:
   displayName: Linux (Ubuntu)
   timeoutInMinutes: 180
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-22.04
   steps:
   - template: eng/steps.yml
     parameters:


### PR DESCRIPTION
Looks like Noble caught up on Azure too. Related: #1867.