### PR TITLE
Eliminate contextless PythonTuple constructor

### DIFF
--- a/src/core/IronPython.Modules/IterTools.cs
+++ b/src/core/IronPython.Modules/IterTools.cs
@@ -763,7 +763,7 @@ namespace IronPython.Modules {
             private PythonTuple[] tuples;
 
             public product(CodeContext context, [NotNone] params object[] iterables) {
-                tuples = ArrayUtils.ConvertAll(iterables, x => new PythonTuple(PythonOps.GetEnumerator(x)));
+                tuples = ArrayUtils.ConvertAll(iterables, x => new PythonTuple(context, PythonOps.GetEnumerator(x)));
                 InnerEnumerator = Yielder(tuples);
             }
 
@@ -788,7 +788,7 @@ namespace IronPython.Modules {
                 tuples = new PythonTuple[iterables.Length * iRepeat];
                 for (int i = 0; i < iRepeat; i++) {
                     for (int j = 0; j < iterables.Length; j++) {
-                        tuples[i * iterables.Length + j] = new PythonTuple(iterables[j]);
+                        tuples[i * iterables.Length + j] = new PythonTuple(context, iterables[j]);
                     }
                 }
                 InnerEnumerator = Yielder(tuples);

--- a/src/core/IronPython.Modules/nt.cs
+++ b/src/core/IronPython.Modules/nt.cs
@@ -1389,7 +1389,7 @@ namespace IronPython.Modules {
 
                 return MakeTuple(
                     DynamicHelpers.GetPythonTypeFromType(typeof(stat_result)),
-                    MakeTuple(new PythonTuple(this), timeDict)
+                    MakeTuple(new PythonTuple(DefaultContext.Default, this), timeDict)
                 );
             }
         }

--- a/src/core/IronPython.Modules/resource.cs
+++ b/src/core/IronPython.Modules/resource.cs
@@ -245,7 +245,7 @@ public static class PythonResourceModule {
                 throw PythonOps.TypeError("resource.struct_rusage() takes a {0}-sequence ({1}-sequence given)", n_sequence_fields, __len__());
         }
 
-        private struct_rusage(object o) : base(o) {
+        private struct_rusage(object o) : base(DefaultContext.Default, o) {
             if (__len__() != n_sequence_fields)
                 throw PythonOps.TypeError("resource.struct_rusage() takes a {0}-sequence ({1}-sequence given)", n_sequence_fields, __len__());
         }

--- a/src/core/IronPython.Modules/time.cs
+++ b/src/core/IronPython.Modules/time.cs
@@ -512,7 +512,7 @@ namespace IronPython.Modules {
             }
 
             internal struct_time(PythonTuple sequence)
-                : base(sequence) {
+                : base(DefaultContext.Default, sequence) {
             }
 
             public static struct_time __new__(CodeContext context, [NotNone] PythonType cls, int year, int month, int day, int hour, int minute, int second, int dayOfWeek, int dayOfYear, int isDst) {

--- a/src/core/IronPython/Runtime/ClrModule.cs
+++ b/src/core/IronPython/Runtime/ClrModule.cs
@@ -1130,7 +1130,7 @@ import Namespace.")]
         /// All times are expressed in the same unit of measure as DateTime.Ticks
         /// </summary>
         public static PythonTuple GetProfilerData(CodeContext/*!*/ context, bool includeUnused = false) {
-            return new PythonTuple(Profiler.GetProfiler(context.LanguageContext).GetProfile(includeUnused));
+            return new PythonTuple(DefaultContext.Default, Profiler.GetProfiler(context.LanguageContext).GetProfile(includeUnused));
         }
 
         /// <summary>

--- a/src/core/IronPython/Runtime/Exceptions/PythonExceptions.BaseException.cs
+++ b/src/core/IronPython/Runtime/Exceptions/PythonExceptions.BaseException.cs
@@ -90,7 +90,7 @@ namespace IronPython.Runtime.Exceptions {
                 } else {
                     res = (BaseException)Activator.CreateInstance(cls.UnderlyingSystemType, cls)!;
                 }
-                res._args = new PythonTuple(args);
+                res._args = new PythonTuple(DefaultContext.Default, args);
                 return res;
             }
 

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -1000,7 +1000,7 @@ namespace IronPython.Runtime.Operations {
                 List<object?> largs;
 
                 if (argsTuple != null && args.Length == names.Length) {
-                    if (!(argsTuple is PythonTuple tuple)) tuple = new PythonTuple(argsTuple);
+                    if (!(argsTuple is PythonTuple tuple)) tuple = new PythonTuple(DefaultContext.Default, argsTuple);
 
                     largs = new List<object?>(tuple);
                     largs.AddRange(args);
@@ -1813,7 +1813,7 @@ namespace IronPython.Runtime.Operations {
         /// LIST_TO_TUPLE
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static PythonTuple ListToTuple(PythonList list) => new PythonTuple(list);
+        public static PythonTuple ListToTuple(PythonList list) => new PythonTuple(DefaultContext.Default, list);
 
         /// <summary>
         /// SET_ADD

--- a/src/core/IronPython/Runtime/PythonFunction.cs
+++ b/src/core/IronPython/Runtime/PythonFunction.cs
@@ -139,7 +139,7 @@ namespace IronPython.Runtime {
             get {
                 if (_defaults.Length == 0) return null;
 
-                return new PythonTuple(_defaults);
+                return new PythonTuple(DefaultContext.Default, _defaults);
             }
             set {
                 _defaults = value == null ? [] : value.ToArray();

--- a/src/core/IronPython/Runtime/PythonList.cs
+++ b/src/core/IronPython/Runtime/PythonList.cs
@@ -1302,7 +1302,7 @@ namespace IronPython.Runtime {
             int res;
             CompareUtil.Push(this);
             try {
-                res = ((IStructuralEquatable)new PythonTuple(this)).GetHashCode(comparer);
+                res = ((IStructuralEquatable)PythonTuple.Make(GetObjectArray())).GetHashCode(comparer);
             } finally {
                 CompareUtil.Pop(this);
             }

--- a/src/extensions/IronPython.SQLite/Cursor.cs
+++ b/src/extensions/IronPython.SQLite/Cursor.cs
@@ -239,10 +239,10 @@ namespace IronPython.SQLite
                                     (bool?)null
                                 };
 
-                                new_description[i] = new PythonTuple(descriptor);
+                                new_description[i] = new PythonTuple(DefaultContext.Default, descriptor);
                             }
 
-                            this.description = new PythonTuple(new_description);
+                            this.description = new PythonTuple(DefaultContext.Default, new_description);
                         }
                     }
 
@@ -362,7 +362,7 @@ namespace IronPython.SQLite
                     row[i] = converted;
                 }
 
-                return new PythonTuple(row);
+                return new PythonTuple(DefaultContext.Default, row);
             }
 
             public Cursor executescript(string operation)

--- a/src/extensions/IronPython.SQLite/Statement.cs
+++ b/src/extensions/IronPython.SQLite/Statement.cs
@@ -213,7 +213,7 @@ namespace IronPython.SQLite
                 object proto = DynamicHelpers.GetPythonTypeFromType(typeof(PythonSQLite.PrepareProtocol));
                 object type = DynamicHelpers.GetPythonType(value);
 
-                object key = new PythonTuple(new[] { type, proto });
+                object key = new PythonTuple(DefaultContext.Default, new[] { type, proto });
 
                 return PythonSQLite.adapters.ContainsKey(key);
             }
@@ -228,7 +228,7 @@ namespace IronPython.SQLite
             object proto = DynamicHelpers.GetPythonTypeFromType(typeof(PythonSQLite.PrepareProtocol));
             object type = DynamicHelpers.GetPythonType(value);
 
-            object key = new PythonTuple(new[] { type, proto });
+            object key = new PythonTuple(DefaultContext.Default, new[] { type, proto });
 
             object adapter;
             if(PythonSQLite.adapters.TryGetValue(key, out adapter))

--- a/src/extensions/IronPython.SQLite/_sqlite.cs
+++ b/src/extensions/IronPython.SQLite/_sqlite.cs
@@ -59,7 +59,7 @@ Registers an adapter with pysqlite's adapter registry. Non-standard.")]
         public static void register_adapter(CodeContext context, PythonType type, object adapter)
         {
             object proto = DynamicHelpers.GetPythonTypeFromType(typeof(PrepareProtocol));
-            object key = new PythonTuple(new object[] { type, proto });
+            object key = new PythonTuple(DefaultContext.Default, new object[] { type, proto });
             adapters[key] = adapter;
         }
 

--- a/tests/IronPython.Tests/EngineTest.cs
+++ b/tests/IronPython.Tests/EngineTest.cs
@@ -1682,7 +1682,7 @@ range = range
         [Test]
         public void ScenarioObjectOperations() {
             var ops = _pe.Operations;
-            Assert.That(ops.Format(new PythonTuple(new object[] { 1, 2, 3 })), Is.EqualTo("(1, 2, 3)"));
+            Assert.That(ops.Format(PythonTuple.Make(new object[] { 1, 2, 3 })), Is.EqualTo("(1, 2, 3)"));
 
             var scope = _pe.CreateScope();
             scope.SetVariable("ops", ops);


### PR DESCRIPTION
This further addresses Issue #1718, this time when enumerating `tuple`. It builds on #1721, which handled the case of `list`.

As with `list`, the solution is to specify the context in the constructor that uses enumeration to create the object. However, not always the current context is the best choice. For instance, when the object to enumerate is of one of the .NET types, the default context is a better solution. So alongside the constructor change, I have reviewed all instances of its use and decided whether the current or default context will be a better choice (in most practical cases). It is a heuristic, not a rule, so it is possible that in some scenarios my choices are not optimal (but still functionally correct).