### PR TITLE
Do not lock while calling signal handles

### DIFF
--- a/src/core/IronPython.Modules/signal.SimpleSignalState.cs
+++ b/src/core/IronPython.Modules/signal.SimpleSignalState.cs
@@ -15,8 +15,7 @@ namespace IronPython.Modules {
     public static partial class PythonSignal {
         private class SimpleSignalState : PythonSignalState {
 
-            public SimpleSignalState(PythonContext pc)
-                : base(pc) {
+            public SimpleSignalState(PythonContext pc) : base(pc) {
                 Console.CancelKeyPress += new ConsoleCancelEventHandler(Console_CancelKeyPress);
             }
 
@@ -29,52 +28,27 @@ namespace IronPython.Modules {
                         _ => throw new InvalidOperationException("unreachable"),
                     };
 
-                lock (PySignalToPyHandler) {
-                    if (PySignalToPyHandler[pySignal].GetType() == typeof(int)) {
-                        int tempId = (int)PySignalToPyHandler[pySignal];
+                object? handler = PySignalToPyHandler[pySignal];
 
-                        if (tempId == SIG_DFL) {
-                            // SIG_DFL - do whatever it normally would
-                            return;
-                        } else if (tempId == SIG_IGN) {
-                            // SIG_IGN - we do nothing, but tell the OS we handled the signal
-                            e.Cancel = false;
-                            return;
-                        } else {
-                            throw new Exception("unreachable");
-                        }
-                    } else if (PySignalToPyHandler[pySignal] == default_int_handler) {
-                        if (pySignal != SIGINT) {
-                            // We're dealing with the default_int_handlerImpl which we
-                            // know doesn't care about the frame parameter
-                            e.Cancel = true;
-                            default_int_handlerImpl(pySignal, null);
-                            return;
-                        } else {
-                            // Let the real interrupt handler throw a KeyboardInterrupt for SIGINT.
-                            // It handles this far more gracefully than we can
-                            return;
-                        }
-                    } else {
-                        // We're dealing with a callable matching PySignalHandler's signature
-                        PySignalHandler temp = (PySignalHandler)Converter.ConvertToDelegate(PySignalToPyHandler[pySignal],
-                                                                                            typeof(PySignalHandler));
-
-                        try {
-                            if (SignalPythonContext.PythonOptions.Frames) {
-                                temp.Invoke(pySignal, SysModule._getframeImpl(null,
-                                                                              0,
-                                                                              SignalPythonContext._mainThreadFunctionStack));
-                            } else {
-                                temp.Invoke(pySignal, null);
-                            }
-                        } catch (Exception ex) {
-                            System.Console.WriteLine(SignalPythonContext.FormatException(ex));
-                        }
-
+                if (handler is int tempId) {
+                    if (tempId == SIG_DFL) {
+                        // SIG_DFL - do whatever it normally would
+                        return;
+                    } else if (tempId == SIG_IGN) {
+                        // SIG_IGN - we do nothing, but tell the OS we handled the signal
                         e.Cancel = true;
                         return;
+                    } else {
+                        throw new InvalidOperationException("unreachable");
                     }
+                } else if (ReferenceEquals(handler, default_int_handler) && pySignal == SIGINT) {
+                    // Let the real interrupt handler throw a KeyboardInterrupt for SIGINT.
+                    // It handles this far more gracefully than we can
+                    return;
+                } else {
+                    CallPythonHandler(pySignal, handler);
+                    e.Cancel = true;
+                    return;
                 }
             }
         }

--- a/tests/suite/modules/system_related/test_signal.py
+++ b/tests/suite/modules/system_related/test_signal.py
@@ -86,7 +86,7 @@ class SignalTest(IronPythonTestCase):
         # test that unsupported signals raise OSError on trying to set a handler
         for x in range(1, signal.NSIG):
             if x in SUPPORTED_SIGNALS: continue
-            if is_linux and 35 <= x <= 64: continue # Real-time signals
+            if is_linux and signal.SIGRTMIN <= x <= signal.SIGRTMAX: continue # Real-time signals
             self.assertRaisesMessage(ValueError if is_windows else OSError, "invalid signal value" if is_windows else "[Errno 22] Invalid argument",
                                 signal.signal, x, a)
 


### PR DESCRIPTION
This PR removes a lock hold that used to be held during the execution of a custom signal handler. For two main reasons:
 1. CPython does not synchronize the execution of custom handlers (although it always runs them on the main thread) — if a signal comes during the execution of a custom signal handler function, the function will be interrupted and re-entered.
 2. In theory holding a lock during the callback could create a deadlock — in IronPython any thread can set a signal handler (in CPython — only the main thread), so if the callback waits on a thread that tries to change signal registrations, it will cause a deadlock.

Point 1 would technically be a breaking change since the callback has to be now thread-safe (re-entrant, like in CPython), except that the only signal currently supported is SIGINT and it will always result in `ThreadAbortException`, even when handled by the custom handler. This is deadly on POSIX since thread abort is unsupported, so likely nobody tries to handle it in this way.

There are some other smaller changes in this PR as well, mostly editorial.