### PR TITLE
Use module context with iterables

### DIFF
--- a/src/core/IronPython.Modules/_functools.cs
+++ b/src/core/IronPython.Modules/_functools.cs
@@ -27,7 +27,7 @@ namespace IronPython.Modules {
         public const string __doc__ = "provides functionality for manipulating callable objects";
 
         public static object? reduce(CodeContext/*!*/ context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object?, object?, object?, object?>>> siteData, object? func, object? seq) {
-            IEnumerator i = PythonOps.GetEnumerator(seq);
+            IEnumerator i = PythonOps.GetEnumerator(context, seq);
             if (!i.MoveNext()) {
                 throw PythonOps.TypeError("reduce() of empty sequence with no initial value");
             }
@@ -43,7 +43,7 @@ namespace IronPython.Modules {
         }
 
         public static object? reduce(CodeContext/*!*/ context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object?, object?, object?, object?>>> siteData, object? func, object? seq, object? initializer) {
-            IEnumerator i = PythonOps.GetEnumerator(seq);
+            IEnumerator i = PythonOps.GetEnumerator(context, seq);
             EnsureReduceData(context, siteData);
 
             CallSite<Func<CallSite, CodeContext, object?, object?, object?, object?>> site = siteData.Data;

--- a/src/core/IronPython.Modules/_heapq.cs
+++ b/src/core/IronPython.Modules/_heapq.cs
@@ -87,7 +87,7 @@ namespace IronPython.Modules {
             }
 
             PythonList ret = new PythonList(Math.Min(n, 4000)); // don't allocate anything too huge
-            IEnumerator en = PythonOps.GetEnumerator(iterable);
+            IEnumerator en = PythonOps.GetEnumerator(context, iterable);
 
             // populate list with first n items
             for (int i = 0; i < n; i++) {
@@ -120,7 +120,7 @@ namespace IronPython.Modules {
             }
 
             PythonList ret = new PythonList(Math.Min(n, 4000)); // don't allocate anything too huge
-            IEnumerator en = PythonOps.GetEnumerator(iterable);
+            IEnumerator en = PythonOps.GetEnumerator(context, iterable);
 
             // populate list with first n items
             for (int i = 0; i < n; i++) {

--- a/src/core/IronPython.Modules/_operator.cs
+++ b/src/core/IronPython.Modules/_operator.cs
@@ -275,7 +275,7 @@ namespace IronPython.Modules {
         }
 
         public static int countOf(CodeContext/*!*/ context, object? a, object? b) {
-            System.Collections.IEnumerator e = PythonOps.GetEnumerator(a);
+            System.Collections.IEnumerator e = PythonOps.GetEnumerator(context, a);
             int count = 0;
             while (e.MoveNext()) {
                 if (PythonOps.IsOrEqualsRetBool(context, e.Current, b)) {
@@ -294,7 +294,7 @@ namespace IronPython.Modules {
         }
 
         public static int indexOf(CodeContext/*!*/ context, object? a, object? b) {
-            System.Collections.IEnumerator e = PythonOps.GetEnumerator(a);
+            System.Collections.IEnumerator e = PythonOps.GetEnumerator(context, a);
             int index = 0;
             while (e.MoveNext()) {
                 if (PythonOps.IsOrEqualsRetBool(context, e.Current, b)) {

--- a/src/core/IronPython.Modules/array.cs
+++ b/src/core/IronPython.Modules/array.cs
@@ -326,8 +326,8 @@ namespace IronPython.Modules {
                 }
             }
 
-            public void fromlist([NotNone] PythonList iterable) {
-                IEnumerator ie = PythonOps.GetEnumerator(iterable);
+            public void fromlist(CodeContext context, [NotNone] PythonList iterable) {
+                IEnumerator ie = PythonOps.GetEnumerator(context, iterable);
 
                 List<object> items = new List<object>();
                 while (ie.MoveNext()) {

--- a/src/core/IronPython.Modules/select.cs
+++ b/src/core/IronPython.Modules/select.cs
@@ -90,7 +90,7 @@ namespace IronPython.Modules {
             socketToOriginal = new Dictionary<Socket, object>();
             socketList = new PythonList();
 
-            IEnumerator cursor = PythonOps.GetEnumerator(sequence);
+            IEnumerator cursor = PythonOps.GetEnumerator(context, sequence);
             while (cursor.MoveNext()) {
                 object original = cursor.Current;
                 Socket socket = ObjectToSocket(context, original);

--- a/src/core/IronPython/Modules/Builtin.cs
+++ b/src/core/IronPython/Modules/Builtin.cs
@@ -768,7 +768,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         private static readonly object UndefinedKeywordArgument = new object();
 
         public static object? max(CodeContext/*!*/ context, object? x) {
-            IEnumerator i = PythonOps.GetEnumerator(x);
+            IEnumerator i = PythonOps.GetEnumerator(context, x);
             if (!i.MoveNext())
                 throw PythonOps.ValueError("max() arg is an empty sequence");
             object? ret = i.Current;
@@ -804,7 +804,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         }
 
         public static object? max(CodeContext/*!*/ context, object? x, [ParamDictionary] IDictionary<string, object?> dict) {
-            IEnumerator i = PythonOps.GetEnumerator(x);
+            IEnumerator i = PythonOps.GetEnumerator(context, x);
 
             var kwargTuple = GetMaxKwArg(dict, isDefaultAllowed: true);
             object? method = kwargTuple.Item1;
@@ -881,7 +881,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         }
 
         public static object? min(CodeContext/*!*/ context, object? x) {
-            IEnumerator i = PythonOps.GetEnumerator(x);
+            IEnumerator i = PythonOps.GetEnumerator(context, x);
             if (!i.MoveNext()) {
                 throw PythonOps.ValueError("empty sequence");
             }
@@ -915,7 +915,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         }
 
         public static object? min(CodeContext/*!*/ context, object? x, [ParamDictionary] IDictionary<string, object?> dict) {
-            IEnumerator i = PythonOps.GetEnumerator(x);
+            IEnumerator i = PythonOps.GetEnumerator(context, x);
             var kwargTuple = GetMinKwArg(dict, isDefaultAllowed: true);
             object? method = kwargTuple.Item1;
             object? def = kwargTuple.Item2;
@@ -1371,7 +1371,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
             object? iterable,
             [ParamDictionary] IDictionary<string, object> kwArgs) {
 
-            IEnumerator iter = PythonOps.GetEnumerator(iterable);
+            IEnumerator iter = PythonOps.GetEnumerator(context, iterable);
             PythonList l = new PythonList(10);
             while (iter.MoveNext()) {
                 l.AddNoLock(iter.Current);
@@ -1395,7 +1395,7 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
         }
 
         public static object? sum(CodeContext/*!*/ context, object? sequence, object? start) {
-            IEnumerator i = PythonOps.GetEnumerator(sequence);
+            IEnumerator i = PythonOps.GetEnumerator(context, sequence);
 
             ValidateSumStart(start);
 

--- a/src/core/IronPython/Runtime/Binding/PythonBinaryOperationBinder.cs
+++ b/src/core/IronPython/Runtime/Binding/PythonBinaryOperationBinder.cs
@@ -567,7 +567,7 @@ namespace IronPython.Runtime.Binding {
         private object ListAddAssign(CallSite site, object self, object other) {
             if (self != null && self.GetType() == typeof(PythonList) &&
                 other != null && other.GetType() == typeof(PythonList)) {
-                return ((PythonList)self).InPlaceAdd(other);
+                return ((PythonList)self).InPlaceAdd(DefaultContext.Default, other);
             }
 
             return ((CallSite<Func<CallSite, object, object, object>>)site).Update(site, self, other);

--- a/src/core/IronPython/Runtime/ByteArray.cs
+++ b/src/core/IronPython/Runtime/ByteArray.cs
@@ -585,8 +585,8 @@ namespace IronPython.Runtime {
         /// in the sequence seq. The separator between elements is the 
         /// string providing this method
         /// </summary>
-        public ByteArray join(object? iterable) {
-            IEnumerator seq = PythonOps.GetEnumerator(iterable);
+        public ByteArray join(CodeContext context, object? iterable) {
+            IEnumerator seq = PythonOps.GetEnumerator(context, iterable);
             if (!seq.MoveNext()) {
                 return new ByteArray();
             }

--- a/src/core/IronPython/Runtime/Bytes.cs
+++ b/src/core/IronPython/Runtime/Bytes.cs
@@ -456,8 +456,8 @@ namespace IronPython.Runtime {
         /// in the sequence seq. The separator between elements is the
         /// string providing this method
         /// </summary>
-        public Bytes join(object? iterable) {
-            IEnumerator seq = PythonOps.GetEnumerator(iterable);
+        public Bytes join(CodeContext context, object? iterable) {
+            IEnumerator seq = PythonOps.GetEnumerator(context, iterable);
             if (!seq.MoveNext()) {
                 return Empty;
             }

--- a/src/core/IronPython/Runtime/DictionaryOps.cs
+++ b/src/core/IronPython/Runtime/DictionaryOps.cs
@@ -138,17 +138,17 @@ namespace IronPython.Runtime {
                 }
             } else if (PythonOps.TryGetBoundAttr(other, "keys", out object keysFunc)) {
                 // user defined dictionary
-                IEnumerator i = PythonOps.GetEnumerator(PythonCalls.Call(context, keysFunc));
+                IEnumerator i = PythonOps.GetEnumerator(context, PythonCalls.Call(context, keysFunc));
                 while (i.MoveNext()) {
                     self._storage.Add(ref self._storage, i.Current, PythonOps.GetIndex(context, other, i.Current));
                 }
             } else {
                 // list of lists (key/value pairs), list of tuples,
                 // tuple of tuples, etc...
-                IEnumerator i = PythonOps.GetEnumerator(other);
+                IEnumerator i = PythonOps.GetEnumerator(context, other);
                 int index = 0;
                 while (i.MoveNext()) {
-                    if (!AddKeyValue(self, i.Current)) {
+                    if (!AddKeyValue(context, self, i.Current)) {
                         throw PythonOps.ValueError("dictionary update sequence element #{0} has bad length; 2 is required", index);
                     }
                     index++;
@@ -196,8 +196,8 @@ namespace IronPython.Runtime {
             return false;
         }
 
-        internal static bool AddKeyValue(PythonDictionary self, object o) {
-            IEnumerator i = PythonOps.GetEnumerator(o); //c.GetEnumerator();
+        internal static bool AddKeyValue(CodeContext context, PythonDictionary self, object o) {
+            IEnumerator i = PythonOps.GetEnumerator(context, o); //c.GetEnumerator();
             if (i.MoveNext()) {
                 object key = i.Current;
                 if (i.MoveNext()) {

--- a/src/core/IronPython/Runtime/Exceptions/PythonExceptions.cs
+++ b/src/core/IronPython/Runtime/Exceptions/PythonExceptions.cs
@@ -775,8 +775,8 @@ for k, v in toError.items():
 
             if (PythonOps.IsInstance(value, type)) {
                 pyEx = value;
-            } else if (value is PythonTuple) {
-                pyEx = PythonOps.CallWithArgsTuple(type, [], value);
+            } else if (value is PythonTuple pt) {
+                pyEx = PythonOps.CallWithArgsTuple(type, [], pt);
             } else if (value != null) {
                 pyEx = PythonCalls.Call(context, type, value);
             } else {

--- a/src/core/IronPython/Runtime/Importer.cs
+++ b/src/core/IronPython/Runtime/Importer.cs
@@ -588,7 +588,7 @@ namespace IronPython.Runtime {
             Assert.NotNull(context, scope, name);
             if (scope.__dict__.TryGetValue(name, out nested)) {
                 if (nested is PythonModule pm) {
-                    var fullPath = ".".join(SubArray(parts, current));
+                    var fullPath = string.Join(".", SubArray(parts, current));
                     // double check, some packages mess with package namespace
                     // see cp35116
                     if (pm.GetName() == fullPath) {

--- a/src/core/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/src/core/IronPython/Runtime/Operations/ArrayOps.cs
@@ -65,7 +65,7 @@ namespace IronPython.Runtime.Operations {
             Array res = @base == 0 ?
                 Array.CreateInstance(type, len) : Array.CreateInstance(type, [len], [@base]);
 
-            IEnumerator ie = PythonOps.GetEnumerator(items);
+            IEnumerator ie = PythonOps.GetEnumerator(context, items);
             int i = @base;
             while (ie.MoveNext()) {
                 res.SetValue(Converter.Convert(ie.Current, type), i++);

--- a/src/core/IronPython/Runtime/Operations/ByteOps.cs
+++ b/src/core/IronPython/Runtime/Operations/ByteOps.cs
@@ -123,7 +123,7 @@ namespace IronPython.Runtime.Operations {
                     int len = 0;
                     if (useHint) PythonOps.TryInvokeLengthHint(context ?? DefaultContext.Default, value, out len);
                     List<byte> ret = new List<byte>(len);
-                    IEnumerator ie = PythonOps.GetEnumerator(value);
+                    IEnumerator ie = PythonOps.GetEnumerator(context ?? DefaultContext.Default, value);
                     while (ie.MoveNext()) {
                         ret.Add(GetByte(ie.Current));
                     }

--- a/src/core/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/src/core/IronPython/Runtime/Operations/ObjectOps.cs
@@ -381,7 +381,7 @@ namespace IronPython.Runtime.Operations {
 
             object? listIterator = null;
             if (self is PythonList) {
-                listIterator = PythonOps.GetEnumerator(self);
+                listIterator = PythonOps.GetEnumerator(context, self);
             }
 
             object? dictIterator = null;

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -438,7 +438,7 @@ namespace IronPython.Runtime.Operations {
 
                 IEnumerator ie = PythonOps.GetEnumerator(bases);
                 while (ie.MoveNext()) {
-                    if (!(ie.Current is PythonType baseType)) continue;
+                    if (ie.Current is not PythonType baseType) continue;
                     if (c.IsSubclassOf(baseType)) return true;
                 }
                 return false;
@@ -1025,7 +1025,7 @@ namespace IronPython.Runtime.Operations {
             }
         }
 
-        public static object? CallWithArgsTuple(object func, object?[] args, object argsTuple) {
+        public static object? CallWithArgsTuple(object func, object?[] args, IEnumerable argsTuple) {
             if (argsTuple is PythonTuple tp) {
                 object?[] nargs = new object[args.Length + tp.__len__()];
                 for (int i = 0; i < args.Length; i++) nargs[i] = args[i];
@@ -1035,7 +1035,7 @@ namespace IronPython.Runtime.Operations {
 
             PythonList allArgs = new PythonList(args.Length + 10);
             allArgs.AddRange(args);
-            IEnumerator e = PythonOps.GetEnumerator(argsTuple);
+            IEnumerator e = argsTuple.GetEnumerator();
             while (e.MoveNext()) allArgs.AddNoLock(e.Current);
 
             return PythonCalls.Call(func, allArgs.GetObjectArray());

--- a/src/core/IronPython/Runtime/PythonDictionary.cs
+++ b/src/core/IronPython/Runtime/PythonDictionary.cs
@@ -385,7 +385,7 @@ namespace IronPython.Runtime {
                     pyDict = new PythonDictionary();
                 }
 
-                IEnumerator i = PythonOps.GetEnumerator(o);
+                IEnumerator i = PythonOps.GetEnumerator(context, o);
                 while (i.MoveNext()) {
                     pyDict._storage.AddNoLock(ref pyDict._storage, i.Current, value);
                 }
@@ -399,14 +399,14 @@ namespace IronPython.Runtime {
 
             if (pyDict != null) {
                 // then store all the keys with their associated value
-                IEnumerator i = PythonOps.GetEnumerator(o);
+                IEnumerator i = PythonOps.GetEnumerator(context, o);
                 while (i.MoveNext()) {
                     pyDict[i.Current] = value;
                 }
             } else {
                 // slow path, cls.__new__ returned a user defined dictionary instead of a PythonDictionary.
                 PythonContext pc = context.LanguageContext;
-                IEnumerator i = PythonOps.GetEnumerator(o);
+                IEnumerator i = PythonOps.GetEnumerator(context, o);
                 while (i.MoveNext()) {
                     pc.SetIndex(dict, i.Current, value);
                 }

--- a/src/core/IronPython/Runtime/PythonList.cs
+++ b/src/core/IronPython/Runtime/PythonList.cs
@@ -383,11 +383,11 @@ namespace IronPython.Runtime {
         }
 
         [SpecialName]
-        public virtual object InPlaceAdd(object? other) {
+        public virtual object InPlaceAdd(CodeContext context, object? other) {
             if (ReferenceEquals(this, other)) {
                 InPlaceMultiply(2);
             } else {
-                IEnumerator e = PythonOps.GetEnumerator(other);
+                IEnumerator e = PythonOps.GetEnumerator(context, other);
                 while (e.MoveNext()) {
                     append(e.Current);
                 }


### PR DESCRIPTION
This PR builds further on #1721 and #1946 by using `CodeContext` with various iterables.