### PR TITLE
Override console Ctrl+C event handler with handler in module `signal`

### DIFF
--- a/src/core/IronPython/Hosting/PythonCommandLine.cs
+++ b/src/core/IronPython/Hosting/PythonCommandLine.cs
@@ -145,6 +145,7 @@ namespace IronPython.Hosting {
 
             Console.Output = new OutputWriter(PythonContext, false);
             Console.ErrorOutput = new OutputWriter(PythonContext, true);
+            Language.Console = Console;
 
             // TODO: must precede path initialization! (??? - test test_importpkg.py)
             int pathIndex = PythonContext.PythonOptions.SearchPaths.Count;

--- a/src/core/IronPython/Runtime/PythonContext.cs
+++ b/src/core/IronPython/Runtime/PythonContext.cs
@@ -22,6 +22,7 @@ using Microsoft.Scripting;
 using Microsoft.Scripting.Actions;
 using Microsoft.Scripting.Debugging.CompilerServices;
 using Microsoft.Scripting.Generation;
+using Microsoft.Scripting.Hosting.Shell;
 using Microsoft.Scripting.Runtime;
 using Microsoft.Scripting.Utils;
 
@@ -683,6 +684,11 @@ namespace IronPython.Runtime {
         internal FloatFormat FloatFormat { get; set; }
 
         internal FloatFormat DoubleFormat { get; set; }
+
+        /// <summary>
+        /// Not null if the Python context is running in a console host.
+        /// </summary>
+        internal IConsole/*?*/ Console { get; set; }
 
         /// <summary>
         /// Initializes the sys module on startup.  Called both to load and reload sys

--- a/src/core/IronPython/Runtime/PythonContext.cs
+++ b/src/core/IronPython/Runtime/PythonContext.cs
@@ -685,10 +685,14 @@ namespace IronPython.Runtime {
 
         internal FloatFormat DoubleFormat { get; set; }
 
+#nullable enable
+
         /// <summary>
         /// Not null if the Python context is running in a console host.
         /// </summary>
-        internal IConsole/*?*/ Console { get; set; }
+        internal IConsole? Console { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// Initializes the sys module on startup.  Called both to load and reload sys


### PR DESCRIPTION
This is basically a fix for the `signal` module on POSIX. What was happening was that on POSIX, signals (to be more accurate: `SIGINT` only) are handled by `SimpleSignalState`, which installs a `ConsoleCancelEventHandler` on `Console.CancelKeyPress`. However, `BasicConsole` also installs its handler to handle Ctrl+C, and it happens very early during execution, way before module `signal` can be imported. Since the event handlers are executed in the order of registrations, `BasicConsole` is seeing the event before `signal`, calling `ThreadAbort` (which obviously does not work on .NET), and module `signal` had no chance to even react to `SIGINT`. This means that setting `SIGINT` to be ignored, or to terminate the program, or to call a custom event handler was ineffective.

This problem does not occur on Windows because `NtSignalState` installs its event handler by making a syscall to `SetConsoleCtrlHandler` in `kernel32.dll`, which does its callbacks in a "last registered — first called" fashion, so the late registration in `signal` overrules `BasicConsole`.

There is no straightforward way to prevent `BasicConsole` to register its event handler, but there is a way to override what it does by modifying a public property on `BasicConsole`, and this is what this PR does. The only quirk here was that the reference to a `BasicConsole` instance was not readily available to modules, so I added a new property on `PythonContext` to provide it. If there is a better way of doing it I would be glad to hear it.