### PR TITLE
Unregister signal handlers during engine shutdown

### DIFF
--- a/src/core/IronPython.Modules/signal.NtSignalState.cs
+++ b/src/core/IronPython.Modules/signal.NtSignalState.cs
@@ -27,6 +27,17 @@ namespace IronPython.Modules {
             }
 
 
+            protected override void Dispose(bool disposing) {
+                if (disposing) {
+                    NativeWindowsSignal.SetConsoleCtrlHandler(this.WinAllSignalsHandlerDelegate, false);
+                } else {
+                    var winAllSignalsHandlerDelegate = new NativeWindowsSignal.WinSignalsHandler(WindowsEventHandler);
+                    NativeWindowsSignal.SetConsoleCtrlHandler(winAllSignalsHandlerDelegate, false);
+                }
+                base.Dispose(disposing);
+            }
+
+
             // Our implementation of WinSignalsHandler
             private bool WindowsEventHandler(uint winSignal) {
                 bool retVal;

--- a/src/core/IronPython.Modules/signal.cs
+++ b/src/core/IronPython.Modules/signal.cs
@@ -421,7 +421,7 @@ namespace IronPython.Modules {
         /// <summary>
         /// This class is used to store the installed signal handlers.
         /// </summary>
-        private class PythonSignalState {
+        private class PythonSignalState : IDisposable {
             // this provides us with access to the Main thread's stack
             public readonly PythonContext SignalPythonContext;
 
@@ -511,6 +511,25 @@ namespace IronPython.Modules {
                     }
                 }
             }
+
+            public void Dispose() {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            ~PythonSignalState() {
+                Dispose(false);
+            }
+
+            protected virtual void Dispose(bool disposing) {
+                if (!_disposed) {
+                    if (disposing) {
+                        Array.Clear(PySignalToPyHandler, 0, PySignalToPyHandler.Length);
+                    }
+                    _disposed = true;
+                }
+            }
+            private bool _disposed = false;
         }
 
 


### PR DESCRIPTION
This PR is relevant for hosting scenarios. Importing module `signal` in one IronPython engine registers a Ctrl+C signal handler, but it was not properly unregistered on engine shutdown. This means the handler was being referenced from the static `System.Console` (on Windows I suppose from the callback marshalling code) and caused a memory leak and interference with another later instance of the engine (at best).

The solution in this PR is to make `PythonSignalState` disposable and modify `PythonContext` that it recognizes disposable module states. For good measure I implemented a finalizer too although I think it will never (i.e before process termination) be called because without a call to `Dispose()` reference will stay alive and not being GC-ed.