### PR TITLE
Implement handling POSIX signals

### DIFF
--- a/src/core/IronPython.Modules/signal.PosixSignalState.cs
+++ b/src/core/IronPython.Modules/signal.PosixSignalState.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+#if FEATURE_PROCESS
+#if NET
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+using Mono.Unix;
+using Mono.Unix.Native;
+
+using IronPython.Runtime;
+using IronPython.Runtime.Operations;
+using System.Threading.Tasks;
+using Microsoft.Scripting.Runtime;
+using Microsoft.Scripting.Hosting.Shell;
+
+namespace IronPython.Modules {
+    public static partial class PythonSignal {
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        private class PosixSignalState : PythonSignalState {
+            private readonly PosixSignalRegistration?[] _signalRegistrations;
+            private ConsoleCancelEventHandler? _consoleHandler;
+
+
+            public PosixSignalState(PythonContext pc) : base(pc) {
+                _signalRegistrations = new PosixSignalRegistration[NSIG];
+            }
+
+
+            protected override void Dispose(bool disposing) {
+                if (disposing) {
+                    Array.ForEach(_signalRegistrations, reg => reg?.Dispose());
+                    Array.Clear(_signalRegistrations, 0, _signalRegistrations.Length);
+                }
+                base.Dispose(disposing);
+            }
+
+
+            public override void SetPyHandler(int signalnum, object value) {
+                // normalize handler reference
+                if (value is int i) {
+                    value = (i == SIG_IGN) ? sig_ign : sig_dfl;
+                }
+
+                if (TryGetPyHandler(signalnum, out object? existingValue) && ReferenceEquals(existingValue, value)) {
+                    // no change
+                    return;
+                }
+
+                base.SetPyHandler(signalnum, value);
+
+                if (signalnum == SIGINT) {
+                    // SIGINT is special, we need to disable the handler on the console so that we can handle Ctrl+C here
+                    if (DefaultContext.DefaultPythonContext.Console is BasicConsole console) {
+                        if (!ReferenceEquals(value, default_int_handler)) {
+                            // save the console handler so it can be restored later if necessary
+                            _consoleHandler ??= console.ConsoleCancelEventHandler;
+                            // disable the console handler
+                            console.ConsoleCancelEventHandler = null;
+                        } else if (_consoleHandler != null) {
+                            // default_int_handler: restore the console handler, which is de facto default_int_handler
+                            console.ConsoleCancelEventHandler = _consoleHandler;
+                            _consoleHandler = null;
+                        }
+                    }
+                }
+
+                // remember to unregister any previous handler
+                var oldReg = _signalRegistrations[signalnum];
+
+                if (ReferenceEquals(value, sig_dfl)) {
+                    _signalRegistrations[signalnum] = null;
+                } else if (ReferenceEquals(value, sig_ign)) {
+                    _signalRegistrations[signalnum] = PosixSignalRegistration.Create((PosixSignal)signalnum,
+                        (PosixSignalContext psc) => {
+                            psc.Cancel = true;
+                        });
+                } else {
+                    _signalRegistrations[signalnum] = PosixSignalRegistration.Create((PosixSignal)signalnum, 
+                        (PosixSignalContext psc) => {
+                            // This is called on a thread from the thread pool for most signals,
+                            // and on a dedicated thread ".NET Signal Handler" for SIGINT, SIGQUIT, and SIGTERM.
+                            CallPythonHandler(signalnum, value);
+                            psc.Cancel = true;
+                        });
+                }
+                oldReg?.Dispose();
+            }
+        }
+    }
+}
+
+#endif  // NET
+#endif  // FEATURE_PROCESS

--- a/src/core/IronPython.Modules/signal.cs
+++ b/src/core/IronPython.Modules/signal.cs
@@ -495,27 +495,26 @@ namespace IronPython.Modules {
             protected void CallPythonHandler(int signum, object? handler) {
                 if (handler is null) return;
 
-                if (handler == default_int_handler) {
-                    // We're dealing with the default_int_handlerImpl which we
-                    // know doesn't care about the frame parameter
-                    default_int_handlerImpl(signum, null);
-                    return;
-                } else {
-                    // We're dealing with a callable matching PySignalHandler's signature
-                    try {
-                        PySignalHandler temp = (PySignalHandler)Converter.ConvertToDelegate(handler,
-                                                                                            typeof(PySignalHandler));
+                try {
+                    if (handler == default_int_handler) {
+                        // We're dealing with the default_int_handlerImpl which we
+                        // know doesn't care about the frame parameter
+                        default_int_handlerImpl(signum, null);
+                    } else {
+                        // We're dealing with a callable matching PySignalHandler's signature
+                            PySignalHandler temp = (PySignalHandler)Converter.ConvertToDelegate(handler,
+                                                                                                typeof(PySignalHandler));
 
-                        if (SignalPythonContext.PythonOptions.Frames) {
-                            temp.Invoke(signum, SysModule._getframeImpl(null,
-                                                                        0,
-                                                                        SignalPythonContext._mainThreadFunctionStack));
-                        } else {
-                            temp.Invoke(signum, null);
-                        }
-                    } catch (Exception ex) {
-                        System.Console.WriteLine(SignalPythonContext.FormatException(ex));
+                            if (SignalPythonContext.PythonOptions.Frames) {
+                                temp.Invoke(signum, SysModule._getframeImpl(null,
+                                                                            0,
+                                                                            SignalPythonContext._mainThreadFunctionStack));
+                            } else {
+                                temp.Invoke(signum, null);
+                            }
                     }
+                } catch (Exception ex) {
+                    SignalPythonContext.DomainManager.SharedIO.ErrorWriter.WriteLine(SignalPythonContext.FormatException(ex));
                 }
             }
 


### PR DESCRIPTION
This  implementation of handling signals on POSIX uses `PosixSignalRegistration`, which is aviavilable since .NET 6. It is not available on Mono, so on Mono, signal handling is unchanged (i.e. only handling of `SIGINT` is supported). Unfortunately, it also means no full POSIX signal handling on .NET Standard. Mono does provide its own API for handling signals (actually, three different approaches), but all of them come with some deficiencies (see below), so even if I had used them, I would still prefer `PosixSignalRegistration` on .NET, hence this is the version I submit here.

Since it works quite fine on .NET, it is quite unlikely I will be working on an alternative implementation that runs on Mono. Therefore I am writing my findings about the Mono API here just in case it might be useful in the future.

Although both IronPython and CPython require the handler be re-entrant, the thread affinity differs: CPython calls the handler always on the main thread, and IronPython never on the main thread. Probably something worth explaining in ["Differences with CPython"](https://github.com/IronLanguages/ironpython3/wiki/Differences-from-CPython).

----

Mono.Unix has three different API schemes to handle signals. All three use the same pattern as the rest of Mono.Unix, that the constants are provided as platform-independent enums, which are then translated to platform specific constants by Mono.Unix through hard-coded switch statements. This means that only those constants are supported that were "known" at the time Mono.Unix was compiled.

Currently IronPython uses Mono.Unix version 7.1.0-final.1.21458.1. This is a pretty old version that is not aware of all signal constants. On macOS 15 it means that `SIGEMT` and `SIGINFO` are not supported. It looks like on Linux all signals are supported, but I haven't checked thoroughly.

### `signal`

The first way of handling signals with Mono.Unix is with `Mono.Unix.Native.Stdlib.signal`. This function is a thin wrapper over a direct syscall `signal` (in Mono.Unix aliased to `sys_signal`), and only adds a little bit of conversions between Mono-speak and the types that the systcall expects (e.g. marshalling). Unfortunately, since it is such a low level call, it puts the burden for all race conditions, thread blocking, and safety on the caller. It is also marked with `[Obsolete("This is not safe; use Mono.Unix.UnixSignal for signal delivery or SetSignalAction()")]`, and it looks to me with a good reason.

### `SetSignalAction`

Function `Mono.Unix.Native.Stdlib.SetSignalAction` is simple and safe to use, but it only allows to set actions `Default` and `Ignore`. It builds on top of `sys_signal` so it should work well with `signal` above. By itself it does not allow setting custom signal handlers, so it is insufficient to implement Python `signal` module.

### `UnixSignal`

This is a higher-level API presumably intended to replace the obsolete `signal`. It takes away a number of race conditions, although a few still remain (see below). Registering a custom handler for a signal happens by instantiating `Mono.Unix.UnixSignal`, which is a subclass of `WaitHandle`. The user code then can wait on that handle which is signalled when a signal occurs. Disposing it unregisters the handler for that signal. In this way, the user code is in full control on which thread it waits ant processes the signal, and this thread is fully decoupled from the low-level C thread reacting to the system signal. Passing the occurence of a signal from the C thread to the .NET thread is implemented by writing-to/waiting-on a set of Unix pipes, one per signal number.

This API is pretty convenient if the goal is to register a handler, wait for a signal, and unregister directly afterwards (e.g. with `using`). Unfortunately, to implement Python `signal`, we need something that permanently waits on those handles (permanently = until registration changes), so it requires creating a background thread that waits on a set of registered `UnixSignal`s. There basically two ways of doing it.
1. One thread that waits on all handlers registered so far (`WaitAny`). This means that signals can only be handled sequentially (arguably a small price to pay). The bigger problem is changing the registrations (e.g. adding/removing a handler for another signal). To change the array on which `WaitAny` is waiting, the thread wait has to be interrupted, and this is easier said than done. Despite `UnixSignal` deriving from `WaitHandle`, it does not play by regular `WaitHandle` rules and is not compatible with them. In practice it means that the only way it can wait on several `UnixSignal` handles is by using a custom `WaitAny` static method that only accepts `UnixSignal`s. It is not possible to use `Task.WaitAny` so it is not possible to wake up the signal handling thread by using an extra regular "control" handle. So the solution would require misusing one of the system signals to allow reconfiguration of the handle array. Can be done but it is a pretty clumsy way.
2. One thread per signal. The management of registrations becomes simple, but this is pretty inefficient in terms of resources. On Linux, there can be something like 50 different signal types, so this would mean 50 threads created, all sleeping on a pipe read.

Finally, this method doesn't seem to work well together with `SetSignalAction`, since `SetSignalAction` overrides the low level handler, and `UnixSignal` saves and restores the pre-existing handle in an internal structure. To make those two schemes work together, the sequence to switch from one to another must be first remove the old one, then set the new one, which leaves a short moment in between when the handler is set to the default action. For most signals the default action is to terminate the process, so if a signal arrives just in this short period, it will result with unexpected behaviour.

Another race condition with `UnixSignal` is that when one `UnixSignal` is unregistered and another one is immediately registered, the new `UnixSignal` may incorrectly receive arriving signals intended for the old one. This condition is acknowledged in the code comments but qualified as "unlikely". Maybe so, but still.