### PR TITLE
Implement Support for Chocolatey-style Install

### DIFF
--- a/eng/scripts/Install-IronPython.ps1
+++ b/eng/scripts/Install-IronPython.ps1
@@ -40,7 +40,7 @@
 Param(
     # Target directory to which IronPython is to be installed.
     [Parameter(Position=0, Mandatory)]
-    [string] $Path,
+    [string] $Path = ".",
 
     # The path to the downloaded zip file with IronPython binaries. If empty, the script will try to grab the package directly produced by the local build.
     [string] $ZipFile,
@@ -105,7 +105,7 @@ if (Test-Path $Path) {
         }
         Remove-Item -Path $Path -Force -Recurse
     } else {
-        Write-Error "Path already exists: $Path"
+        Write-Warning "Path already exists: $Path"
     }
 }
 New-Item $Path -ItemType Directory | Out-Null

--- a/eng/scripts/Install-IronPython.ps1
+++ b/eng/scripts/Install-IronPython.ps1
@@ -16,6 +16,10 @@
     PS>Expand-Archive -Path IronPython.3.4.0.zip -DestinationPath IronPython-unzipped
     PS>./IronPython-unzipped/scripts/Install-IronPython -Path ~/ipyenv/v3.4.0
 
+    or with a one-liner
+
+    PS>iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/IronLanguages/ironpython3/22d006e3612291e716fc21438ef12fe5f89c23a0/eng/scripts/Install-IronPython.ps1'))
+
     The official binaries are downloaded from GitHub to the current directory, unzipped, and then the installation proceeds using the script from the unzipped directory. IronPython is installed into ~/ipyenv/v3.4.0.
 
 .EXAMPLE


### PR DESCRIPTION
This PR attempts to add one-liner install support to Install-IronPython.ps1

This makes it possible for Iron-Python to be installed via one-liner based on Chocolatey's method:
- see: https://stackoverflow.com/a/43905715/10534510

```pwsh
# Production
# - This is NOT live
# - This is just a demonstration of what said one-liner will eventually look like
iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/IronLanguages/ironpython3/refs/heads/main/eng/scripts/Install-IronPython.ps1'))

# Testing
# - This is live and ready for testing
iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/anonhostpi/ironpython3/refs/heads/iex-web-support/eng/scripts/Install-IronPython.ps1'))
```