### PR TITLE
Add nullable annotations to Hosting APIs

### DIFF
--- a/src/core/IronPython/Hosting/Python.cs
+++ b/src/core/IronPython/Hosting/Python.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -198,11 +200,11 @@ namespace IronPython.Hosting {
         /// </summary>
         /// <param name="scope"></param>
         /// <param name="moduleName"></param>
-        public static void ImportModule (this ScriptScope/*!*/ scope, string/*!*/ moduleName) {
-            ContractUtils.RequiresNotNull (scope, nameof(scope));
-            ContractUtils.RequiresNotNull (moduleName, nameof(moduleName));
+        public static void ImportModule(this ScriptScope/*!*/ scope, string/*!*/ moduleName) {
+            ContractUtils.RequiresNotNull(scope, nameof(scope));
+            ContractUtils.RequiresNotNull(moduleName, nameof(moduleName));
 
-            scope.SetVariable (moduleName, scope.Engine.ImportModule (moduleName));
+            scope.SetVariable(moduleName, scope.Engine.ImportModule(moduleName));
         }
 
         /// <summary>
@@ -270,12 +272,12 @@ namespace IronPython.Hosting {
         /// 
         /// The ScriptRuntimeSetup object can then be additional configured and used to create a ScriptRuntime.
         /// </summary>
-        public static ScriptRuntimeSetup/*!*/ CreateRuntimeSetup(IDictionary<string, object> options) {
+        public static ScriptRuntimeSetup/*!*/ CreateRuntimeSetup(IDictionary<string, object>? options) {
             ScriptRuntimeSetup setup = new ScriptRuntimeSetup();
             setup.LanguageSetups.Add(CreateLanguageSetup(options));
 
             if (options != null) {
-                object value;
+                object? value;
                 if (options.TryGetValue("Debug", out value) &&
                     value is bool &&
                     (bool)value) {
@@ -298,7 +300,7 @@ namespace IronPython.Hosting {
         /// The LanguageSetup object can be used with other LanguageSetup objects from other languages to
         /// configure a ScriptRuntimeSetup object.
         /// </summary>
-        public static LanguageSetup/*!*/ CreateLanguageSetup(IDictionary<string, object> options) {
+        public static LanguageSetup/*!*/ CreateLanguageSetup(IDictionary<string, object>? options) {
             var setup = new LanguageSetup(
                 typeof(PythonContext).AssemblyQualifiedName,
                 PythonContext.IronPythonDisplayName,
@@ -360,7 +362,7 @@ namespace IronPython.Hosting {
         }
 
         private static PythonContext/*!*/ GetPythonContext(ScriptEngine/*!*/ engine) {
-            return HostingHelpers.GetLanguageContext(engine) as PythonContext;
+            return (PythonContext)HostingHelpers.GetLanguageContext(engine);
         }
 
         #endregion

--- a/src/core/IronPython/Hosting/PythonCodeDomCodeGen.cs
+++ b/src/core/IronPython/Hosting/PythonCodeDomCodeGen.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.CodeDom;
 using System.Collections.Generic;
+
 using Microsoft.Scripting.Runtime;
 
 #if FEATURE_CODEDOM
@@ -44,8 +47,7 @@ namespace IronPython.Hosting {
                 int indentLen = lastLine.Length;
                 if (indentLen > _indents.Peek()) {
                     _indents.Push(indentLen);
-                }
-                else {
+                } else {
                     while (indentLen < _indents.Peek()) {
                         _indents.Pop();
                     }

--- a/src/core/IronPython/Hosting/PythonConsoleOptions.cs
+++ b/src/core/IronPython/Hosting/PythonConsoleOptions.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
+
 using Microsoft.Scripting.Hosting.Shell; 
 
 namespace IronPython.Hosting {
@@ -12,7 +15,7 @@ namespace IronPython.Hosting {
 
         public bool SkipImportSite { get; set; }
 
-        public string ModuleToRun { get; set; }
+        public string? ModuleToRun { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to skip the first line of the code to execute.

--- a/src/core/IronPython/Hosting/PythonOptionsParser.cs
+++ b/src/core/IronPython/Hosting/PythonOptionsParser.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -16,7 +18,7 @@ using Microsoft.Scripting.Utils;
 namespace IronPython.Hosting {
 
     public sealed class PythonOptionsParser : OptionsParser<PythonConsoleOptions> {
-        private List<string> _warningFilters;
+        private List<string>? _warningFilters;
 
         public PythonOptionsParser() {
         }
@@ -205,8 +207,8 @@ namespace IronPython.Hosting {
             }
         }
 
-        protected override void HandleImplementationSpecificOption(string arg, string val) {
-            object frames;
+        protected override void HandleImplementationSpecificOption(string arg, string? val) {
+            object? frames;
             switch (arg) {
                 case "NoFrames":
                     if (LanguageSetup.Options.TryGetValue("Frames", out frames) && frames != ScriptingRuntimeHelpers.False) {

--- a/src/core/IronPython/Hosting/PythonService.cs
+++ b/src/core/IronPython/Hosting/PythonService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 #if FEATURE_REMOTING
 using System.Runtime.Remoting;
 #else
@@ -11,8 +13,10 @@ using MarshalByRefObject = System.Object;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
+
 using Microsoft.Scripting.Hosting;
 using Microsoft.Scripting.Hosting.Providers;
 using Microsoft.Scripting.Utils;
@@ -27,7 +31,7 @@ namespace IronPython.Hosting {
     public sealed class PythonService : MarshalByRefObject {
         private readonly ScriptEngine/*!*/ _engine;
         private readonly PythonContext/*!*/ _context;
-        private ScriptScope _sys, _builtins, _clr;
+        private ScriptScope? _sys, _builtins, _clr;
 
         public PythonService(PythonContext/*!*/ context, ScriptEngine/*!*/ engine) {
             Assert.NotNull(context, engine);
@@ -76,7 +80,7 @@ namespace IronPython.Hosting {
             _context.PublishModule(name, module);
             module.__init__(name, docString);
             module.__dict__["__file__"] = filename;
-            
+
             return HostingHelpers.CreateScriptScope(_engine, module.Scope);
         }
 
@@ -109,7 +113,7 @@ namespace IronPython.Hosting {
         }
 
 #if FEATURE_REMOTING
-        public ObjectHandle GetSetCommandDispatcher(ObjectHandle dispatcher) {
+        public ObjectHandle? GetSetCommandDispatcher(ObjectHandle dispatcher) {
             var res = _context.GetSetCommandDispatcher((Action<Action>)dispatcher.Unwrap());
             if (res != null) {
                 return new ObjectHandle(res);


### PR DESCRIPTION
Also fixes some related bugs:
- Use `string.IsNullOrEmpty` to check console environment variables.
- Don't crash when the running assembly is on the root.