### PR TITLE
Unify 3.4 and 3.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,8 @@
     <FileVersion>$(MajorVersion).$(MinorVersion).$(MicroVersion).$(AssemblyFileRevision)</FileVersion>
     <InformationalVersion>$(MSBuildProjectName) $(MajorVersion).$(MinorVersion).$(MicroVersion) $(ReleaseLevel) $(ReleaseSerial)</InformationalVersion>
 
-    <DefineConstants>PYTHON_$(MajorVersion)$(MinorVersion)</DefineConstants>
+    <PythonSymbols>PYTHON_$(MajorVersion)$(MinorVersion)</PythonSymbols>
+    <PythonSymbols Condition="'$(MajorVersion)$(MinorVersion)' >= '36'">$(PythonSymbols);PYTHON_36_OR_GREATER</PythonSymbols>
 
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 
@@ -127,7 +128,7 @@
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <DefineConstants>$(DefineConstants);$(Features);$(SignedSym);TRACE</DefineConstants>
+    <DefineConstants>$(PythonSymbols);$(Features);$(SignedSym);TRACE</DefineConstants>
   </PropertyGroup>
 
   <!-- Debug -->
@@ -137,6 +138,6 @@
     <Optimize>false</Optimize>
     <!-- TODO: Python & zlib.net need some work -->
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <DefineConstants>$(DefineConstants);$(Features);$(SignedSym);DEBUG;TRACE</DefineConstants>
+    <DefineConstants>$(PythonSymbols);$(Features);$(SignedSym);DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/core/IronPython.Modules/_ctypes/CData.cs
+++ b/src/core/IronPython.Modules/_ctypes/CData.cs
@@ -72,8 +72,11 @@ namespace IronPython.Modules {
 
             internal void InitializeFromBuffer(object? data, int offset, int size) {
                 var bp = data as IBufferProtocol
+#if PYTHON_34
                     ?? throw PythonOps.TypeErrorForBadInstance("{0} object does not have the buffer interface", data);
-                    // Python 3.5: PythonOps.TypeErrorForBytesLikeTypeMismatch(data);
+#else
+                    ?? throw PythonOps.TypeErrorForBytesLikeTypeMismatch(data);
+#endif
 
                 IPythonBuffer buffer = bp.GetBuffer(BufferFlags.FullRO);
                 if (buffer.IsReadOnly) {
@@ -97,8 +100,11 @@ namespace IronPython.Modules {
 
             internal void InitializeFromBufferCopy(object? data, int offset, int size) {
                 var bp = data as IBufferProtocol
+#if PYTHON_34
                     ?? throw PythonOps.TypeErrorForBadInstance("{0} object does not have the buffer interface", data);
-                    // Python 3.5: PythonOps.TypeErrorForBytesLikeTypeMismatch(data);
+#else
+                    ?? throw PythonOps.TypeErrorForBytesLikeTypeMismatch(data);
+#endif
 
                 using IPythonBuffer buffer = bp.GetBuffer();
                 var span = buffer.AsReadOnlySpan();

--- a/src/core/IronPython.Modules/_ctypes/SimpleType.cs
+++ b/src/core/IronPython.Modules/_ctypes/SimpleType.cs
@@ -60,13 +60,13 @@ namespace IronPython.Modules {
                     case 'I': _type = SimpleTypeKind.UnsignedInt; break;
                     case 'l':
                         _type = SimpleTypeKind.SignedLong;
-#if !PYTHON_34
+#if PYTHON_36_OR_GREATER
                         _charType = TypecodeOps.IsCLong32Bit ? _charType : 'q';
 #endif
                         break;
                     case 'L':
                         _type = SimpleTypeKind.UnsignedLong;
-#if !PYTHON_34
+#if PYTHON_36_OR_GREATER
                         _charType = TypecodeOps.IsCLong32Bit ? _charType : 'Q';
 #endif
                         break;

--- a/src/core/IronPython.Modules/_datetime.cs
+++ b/src/core/IronPython.Modules/_datetime.cs
@@ -1237,7 +1237,7 @@ namespace IronPython.Modules {
                 );
             }
 
-#if PYTHON_34
+#if PYTHON_34 // removed in 3.5
             public bool __bool__() {
                 return this.UtcTime.TimeSpan.Ticks != 0 || this.UtcTime.LostMicroseconds != 0;
             }

--- a/src/core/IronPython.Modules/_heapq.cs
+++ b/src/core/IronPython.Modules/_heapq.cs
@@ -77,7 +77,7 @@ namespace IronPython.Modules {
             }
         }
 
-        // TODO: removed in Python 3.5
+#if PYTHON_34 // removed in 3.5
         [Documentation("Find the n largest elements in a dataset.\n\n"
             + "Equivalent to:  sorted(iterable, reverse=True)[:n]\n"
             )]
@@ -110,7 +110,6 @@ namespace IronPython.Modules {
             return ret;
         }
 
-        // TODO: removed in Python 3.5
         [Documentation("Find the n smallest elements in a dataset.\n\n"
             + "Equivalent to:  sorted(iterable)[:n]\n"
             )]
@@ -142,6 +141,7 @@ namespace IronPython.Modules {
             HeapSort(context, ret);
             return ret;
         }
+#endif
 
         #endregion
 

--- a/src/core/IronPython.Modules/_sre.cs
+++ b/src/core/IronPython.Modules/_sre.cs
@@ -14,7 +14,11 @@ namespace IronPython.Modules {
     public static class PythonSRegEx {
         public const string __doc__ = "non-functional _sre module.  Included only for completeness.";
 
+#if PYTHON_34
         public const int MAGIC = 20031017;
+#else
+        public const int MAGIC = 20140917;
+#endif
         public const int CODESIZE = 2;
         public const int MAXREPEAT = 65535;
         public const int MAXGROUPS = int.MaxValue;

--- a/src/core/IronPython.Modules/re.cs
+++ b/src/core/IronPython.Modules/re.cs
@@ -165,8 +165,9 @@ namespace IronPython.Modules {
             internal Pattern(CodeContext/*!*/ context, object pattern, ReFlags flags = 0, bool compiled = false) {
                 _prePattern = PreParseRegex(context, PatternAsString(pattern, ref flags), verbose: flags.HasFlag(ReFlags.VERBOSE), isBytes: !flags.HasFlag(ReFlags.UNICODE), out ReFlags options);
                 flags |= options;
-                // TODO: re-enable in 3.6
-                // if (flags.HasFlag(ReFlags.UNICODE | ReFlags.LOCALE)) throw PythonOps.ValueError("cannot use LOCALE flag with a str pattern");
+#if PYTHON_36_OR_GREATER
+                if (flags.HasFlag(ReFlags.UNICODE | ReFlags.LOCALE)) throw PythonOps.ValueError("cannot use LOCALE flag with a str pattern");
+#endif
                 if (flags.HasFlag(ReFlags.ASCII | ReFlags.LOCALE)) throw PythonOps.ValueError("ASCII and LOCALE flags are incompatible");
                 _re = GenRegex(context, _prePattern, flags, compiled, false);
                 this.pattern = pattern;
@@ -418,7 +419,7 @@ namespace IronPython.Modules {
                         //  only when not adjacent to a previous match
                         if (string.IsNullOrEmpty(match.Value) && match.Index == prevEnd) {
                             return "";
-                        };
+                        }
                         prevEnd = match.Index + match.Length;
 
                         if (replacement != null) return UnescapeGroups(context, match, replacement);
@@ -445,7 +446,7 @@ namespace IronPython.Modules {
                         //  only when not adjacent to a previous match
                         if (string.IsNullOrEmpty(match.Value) && match.Index == prevEnd) {
                             return "";
-                        };
+                        }
                         prevEnd = match.Index + match.Length;
 
                         totalCount++;

--- a/src/core/IronPython/Compiler/Ast/TupleExpression.cs
+++ b/src/core/IronPython/Compiler/Ast/TupleExpression.cs
@@ -17,17 +17,20 @@ namespace IronPython.Compiler.Ast {
         }
 
         internal override string? CheckAssign() {
+#if !PYTHON_36_OR_GREATER
             if (Items.Count == 0) {
-                //  TODO: remove this when we get to 3.6
                 return "can't assign to ()";
             }
+#endif
 
             return base.CheckAssign();
         }
 
         internal override string? CheckDelete() {
+#if !PYTHON_36_OR_GREATER
             if (Items.Count == 0)
-                return "can't delete ()"; //  TODO: remove this when we get to 3.6
+                return "can't delete ()";
+#endif
             return base.CheckDelete();
         }
 

--- a/src/core/IronPython/Modules/Builtin.cs
+++ b/src/core/IronPython/Modules/Builtin.cs
@@ -58,7 +58,11 @@ Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.";
 
             object ret = Importer.ImportModule(context, globals, name, from != null && from.Count > 0, level);
             if (ret == null) {
+#if PYTHON_36_OR_GREATER // ModuleNotFoundError since Python 3.6
+                var err = PythonOps.ModuleNotFoundError("No module named {0}", PythonOps.Repr(context, name));
+#else
                 var err = PythonOps.ImportError("No module named '{0}'", name);
+#endif
                 ((PythonExceptions._ImportError)err.GetPythonException()!).name = name;
                 return LightExceptions.Throw(err);
             }

--- a/src/core/IronPython/Runtime/Operations/StringOps.cs
+++ b/src/core/IronPython/Runtime/Operations/StringOps.cs
@@ -1219,8 +1219,11 @@ namespace IronPython.Runtime.Operations {
                     return;
                 case int mappedInt:
                     if (mappedInt > 0xFFFF) {
-                        // TODO: change to a ValueError in Python 3.5
+#if PYTHON_34
                         throw PythonOps.TypeError("character mapping must be in range(0x10000)");
+#else
+                        throw PythonOps.ValueError("character mapping must be in range(0x10000)");
+#endif
                     }
                     ret.Append((char)mappedInt);
                     break;

--- a/src/core/IronPython/Runtime/PythonContext.cs
+++ b/src/core/IronPython/Runtime/PythonContext.cs
@@ -299,7 +299,9 @@ namespace IronPython.Runtime {
 
                 try {
                     var _frozen_importlib = LoadModuleFromResource("_frozen_importlib", "IronPython.Modules._bootstrap.py");
-
+#if PYTHON_36_OR_GREATER
+                    LoadModuleFromResource("_frozen_importlib_external", "IronPython.Modules._bootstrap_external.py");
+#endif
                     PythonOps.Invoke(SharedClsContext, _frozen_importlib, "_install", SystemState, GetBuiltinModule("_imp"));
                 } catch { }
 

--- a/src/core/IronPython/Runtime/PythonDictionary.cs
+++ b/src/core/IronPython/Runtime/PythonDictionary.cs
@@ -1053,6 +1053,7 @@ namespace IronPython.Runtime {
         #region ICodeFormattable Members
 
         public string __repr__(CodeContext context) {
+#if PYTHON_34
             StringBuilder res = new StringBuilder(20);
             res.Append("dict_values([");
             string comma = "";
@@ -1069,6 +1070,36 @@ namespace IronPython.Runtime {
             res.Append("])");
 
             return res.ToString();
+#else
+            List<object> infinite = PythonOps.GetAndCheckInfinite(this);
+            if (infinite == null) {
+                return "...";
+            }
+
+            int index = infinite.Count;
+            infinite.Add(this);
+            try {
+                StringBuilder res = new StringBuilder(20);
+                res.Append("dict_values([");
+                string comma = "";
+                foreach (object value in this) {
+                    res.Append(comma);
+                    comma = ", ";
+                    try {
+                        PythonOps.FunctionPushFrame(context.LanguageContext);
+                        res.Append(PythonOps.Repr(context, value));
+                    } finally {
+                        PythonOps.FunctionPopFrame();
+                    }
+                }
+                res.Append("])");
+
+                return res.ToString();
+            } finally {
+                Debug.Assert(index == infinite.Count - 1);
+                infinite.RemoveAt(index);
+            }
+#endif
         }
 
         #endregion
@@ -1772,6 +1803,7 @@ namespace IronPython.Runtime {
         #region ICodeFormattable Members
 
         public string __repr__(CodeContext context) {
+#if PYTHON_34
             StringBuilder res = new StringBuilder(20);
             res.Append("dict_items([");
             string comma = "";
@@ -1788,6 +1820,36 @@ namespace IronPython.Runtime {
             res.Append("])");
 
             return res.ToString();
+#else
+            List<object> infinite = PythonOps.GetAndCheckInfinite(this);
+            if (infinite == null) {
+                return "...";
+            }
+
+            int index = infinite.Count;
+            infinite.Add(this);
+            try {
+                StringBuilder res = new StringBuilder(20);
+                res.Append("dict_items([");
+                string comma = "";
+                foreach (object item in this) {
+                    res.Append(comma);
+                    comma = ", ";
+                    try {
+                        PythonOps.FunctionPushFrame(context.LanguageContext);
+                        res.Append(PythonOps.Repr(context, item));
+                    } finally {
+                        PythonOps.FunctionPopFrame();
+                    }
+                }
+                res.Append("])");
+
+                return res.ToString();
+            } finally {
+                Debug.Assert(index == infinite.Count - 1);
+                infinite.RemoveAt(index);
+            }
+#endif
         }
 
         #endregion

--- a/src/core/IronPython/Runtime/StringFormatter.cs
+++ b/src/core/IronPython/Runtime/StringFormatter.cs
@@ -387,8 +387,11 @@ namespace IronPython.Runtime {
 
         private object GetIntegerValue(char format, out bool fPos, bool allowDouble = true) {
             if (!allowDouble && (_opts.Value is float || _opts.Value is double || _opts.Value is Extensible<double>)) {
-                // TODO: this should fail in 3.5
+#if PYTHON_34
                 PythonOps.Warn(_context, PythonExceptions.DeprecationWarning, "automatic int conversions have been deprecated");
+#else
+                throw PythonOps.TypeError($"an integer is required, not {PythonOps.GetPythonTypeName(_opts.Value)}");
+#endif
             }
 
             switch (_opts.Value) {


### PR DESCRIPTION
Unify (most of) the C# codebase for 3.4 and 3.6.

Diff can be obtained using:
```
git diff main..3.6 -- :!src/core/IronPython.StdLib/lib :!*_stdlib.py
```