### PR TITLE
Fix test_urllibnet

### DIFF
--- a/src/core/IronPython.StdLib/lib/test/test_urllibnet.py
+++ b/src/core/IronPython.StdLib/lib/test/test_urllibnet.py
@@ -172,7 +172,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
             self.assertIsInstance(info, email.message.Message,
                                   "info is not an instance of email.message.Message")
 
-    logo = "http://www.example.com/"
+    logo = "http://www.pythontest.net/"
 
     def test_data_header(self):
         with self.urlretrieve(self.logo) as (file_location, fileheaders):


### PR DESCRIPTION
Update test_urllibnet to use pythontest.net domain instead of example.com. This is what's used in newer versions of CPython.