### PR TITLE
Downgrade macOS runner to Sonoma

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-22.04, macos-latest]
+        os: [windows-latest, ubuntu-22.04, macos-14]
 
     steps:
       # Prerequisites
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-22.04, macos-latest]
+        os: [windows-latest, ubuntu-22.04, macos-14]
         framework: ['net462', 'net6.0', 'net8.0']
 
     steps:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -7,7 +7,7 @@ jobs:
           imageName: 'ubuntu-22.04'
         mac:
           osName: 'macOS'
-          imageName: 'macOS-latest'
+          imageName: 'macOS-14'
         windows:
           osName: 'Windows'
           imageName: 'windows-latest'
@@ -98,15 +98,15 @@ jobs:
           framework: net8.0
         macos_net462:
           osName: macOS
-          imageName: macOS-latest
+          imageName: macOS-14
           framework: net462
         macos_net6_0:
           osName: macOS
-          imageName: macOS-latest
+          imageName: macOS-14
           framework: net6.0
         macos_net8_0:
           osName: macOS
-          imageName: macOS-latest
+          imageName: macOS-14
           framework: net8.0
         windows_net462:
           osName: Windows


### PR DESCRIPTION
This is a temporary fix. macOS 14 Sonoma is the last [macOS runner image that comes with Mono pre-instaled](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md),
but will be [deprecated on 2026-07-06 and unsupported on 2026-11-02](https://github.com/actions/runner-images/issues/13518).

The Ubuntu runner has a similar problem.