### PR TITLE
Prefer PythonCalls.Call

### DIFF
--- a/src/core/IronPython.Modules/_csv.cs
+++ b/src/core/IronPython.Modules/_csv.cs
@@ -943,7 +943,7 @@ elements will be converted to string.")]
 
                 _rec.Append(_dialect.lineterminator);
 
-                PythonOps.CallWithContext(context, _writeline, _rec.ToString());
+                PythonCalls.Call(context, _writeline, _rec.ToString());
             }
 
             [Documentation(@"writerows(sequence of sequences)

--- a/src/core/IronPython.Modules/_ctypes/SimpleCData.cs
+++ b/src/core/IronPython.Modules/_ctypes/SimpleCData.cs
@@ -89,7 +89,7 @@ namespace IronPython.Modules {
                             }
 
                             if (__float__ != null) {
-                                value = PythonOps.CallWithContext(context, __float__);
+                                value = PythonCalls.Call(context, __float__);
                             }
                         }
                         break;

--- a/src/core/IronPython.Modules/_datetime.cs
+++ b/src/core/IronPython.Modules/_datetime.cs
@@ -1065,7 +1065,7 @@ namespace IronPython.Modules {
             public static datetime strptime(CodeContext/*!*/ context, [NotNone] PythonType cls, [NotNone] string date_string, [NotNone] string format) {
                 var module = context.LanguageContext.GetStrptimeModule();
                 var _strptime_datetime = PythonOps.GetBoundAttr(context, module, "_strptime_datetime");
-                return (datetime)PythonOps.CallWithContext(context, _strptime_datetime, cls, date_string, format)!;
+                return (datetime)PythonCalls.Call(context, _strptime_datetime, cls, date_string, format)!;
             }
 
             #region IRichComparable Members
@@ -1503,7 +1503,7 @@ namespace IronPython.Modules {
             public PythonTuple __reduce__(CodeContext/*!*/ context) {
                 object? args = PythonTuple.EMPTY;
                 if (PythonOps.TryGetBoundAttr(context, this, "__getinitargs__", out var getinitargs)) {
-                    args = PythonOps.CallWithContext(context, getinitargs);
+                    args = PythonCalls.Call(context, getinitargs);
                 }
 
                 if (GetType() == typeof(tzinfo) ||

--- a/src/core/IronPython.Modules/_operator.cs
+++ b/src/core/IronPython.Modules/_operator.cs
@@ -149,7 +149,7 @@ namespace IronPython.Modules {
             public object? Call(CodeContext/*!*/ context, object? param) {
                 object method = PythonOps.GetBoundAttr(context, param, _name);
                 if (_dict == null) {
-                    return PythonOps.CallWithContext(context, method, _args);
+                    return PythonCalls.Call(context, method, _args);
                 } else {
                     return PythonCalls.CallWithKeywordArgs(context, method, _args, _dict);
                 }

--- a/src/core/IronPython.Modules/math.cs
+++ b/src/core/IronPython.Modules/math.cs
@@ -556,7 +556,7 @@ namespace IronPython.Modules {
         public static object? trunc(CodeContext/*!*/ context, object? value) {
             object? func;
             if (PythonOps.TryGetBoundAttr(value, "__trunc__", out func)) {
-                return PythonOps.CallWithContext(context, func);
+                return PythonCalls.Call(context, func);
             } else {
                 throw PythonOps.TypeError("type {0} doesn't define __trunc__ method", PythonOps.GetPythonTypeName(value));
             }

--- a/src/core/IronPython.Modules/pyexpat.cs
+++ b/src/core/IronPython.Modules/pyexpat.cs
@@ -639,7 +639,7 @@ namespace IronPython.Modules {
                 if (!PythonOps.TryGetBoundAttr(context, file, "read", out object _readMethod))
                     throw PythonOps.TypeError("argument must have 'read' attribute");
 
-                object readResult = PythonOps.CallWithContext(context, _readMethod);
+                object readResult = PythonCalls.Call(context, _readMethod);
                 if (readResult is Bytes b) {
                     using (var stream = new MemoryStream(b.UnsafeByteArray, writable: false)) {
                         var settings = new XmlReaderSettings() { DtdProcessing = DtdProcessing.Parse, XmlResolver = null };

--- a/src/core/IronPython.Modules/re.cs
+++ b/src/core/IronPython.Modules/re.cs
@@ -40,7 +40,7 @@ namespace IronPython.Modules {
             var module = context.GetCopyRegModule();
             if (module != null) {
                 var pickle = PythonOps.GetBoundAttr(context.SharedContext, module, "pickle");
-                PythonOps.CallWithContext(context.SharedContext, pickle, DynamicHelpers.GetPythonTypeFromType(typeof(Pattern)), dict["_pickle"]);
+                PythonCalls.Call(context.SharedContext, pickle, DynamicHelpers.GetPythonTypeFromType(typeof(Pattern)), dict["_pickle"]);
             }
         }
 

--- a/src/core/IronPython.Modules/time.cs
+++ b/src/core/IronPython.Modules/time.cs
@@ -177,13 +177,13 @@ namespace IronPython.Modules {
         public static object? strptime(CodeContext/*!*/ context, [NotNone] string @string) {
             var module = context.LanguageContext.GetStrptimeModule();
             var _strptime_time = PythonOps.GetBoundAttr(context, module, "_strptime_time");
-            return PythonOps.CallWithContext(context, _strptime_time, @string);
+            return PythonCalls.Call(context, _strptime_time, @string);
         }
 
         public static object? strptime(CodeContext/*!*/ context, [NotNone] string @string, [NotNone] string format) {
             var module = context.LanguageContext.GetStrptimeModule();
             var _strptime_time = PythonOps.GetBoundAttr(context, module, "_strptime_time");
-            return PythonOps.CallWithContext(context, _strptime_time, @string, format);
+            return PythonCalls.Call(context, _strptime_time, @string, format);
         }
 
         internal static string strftime(CodeContext/*!*/ context, string format, DateTime dt, int? microseconds, TimeZoneInfo? tzinfo = null, bool errorOnF = false) {

--- a/src/core/IronPython/Modules/_fileio.cs
+++ b/src/core/IronPython/Modules/_fileio.cs
@@ -166,7 +166,7 @@ namespace IronPython.Modules {
                         }
                     }
                 } else {  // opener is not null
-                    object? fdobj = PythonOps.CallWithContext(context, opener, name, flags);
+                    object? fdobj = PythonCalls.Call(context, opener, name, flags);
                     if (fdobj is int fd) {
                         if (fd < 0) {
                             throw PythonOps.ValueError("opener returned {0}", fd);

--- a/src/core/IronPython/Modules/_io.cs
+++ b/src/core/IronPython/Modules/_io.cs
@@ -544,7 +544,7 @@ namespace IronPython.Modules {
                 object setter;
                 if (PythonOps.TryGetBoundAttr(buf, "__setitem__", out setter)) {
                     for (int i = 0; i < data.Count; i++) {
-                        PythonOps.CallWithContext(context, setter, i, data[i]);
+                        PythonCalls.Call(context, setter, i, data[i]);
                     }
                     GC.KeepAlive(this);
                     return data.Count;
@@ -2707,7 +2707,7 @@ namespace IronPython.Modules {
                     throw PythonOps.LookupError(_encoding);
                 }
 
-                _encoder = PythonOps.CallWithContext(context, factory, _errors);
+                _encoder = PythonCalls.Call(context, factory, _errors);
                 return _encoder;
             }
 
@@ -2718,7 +2718,7 @@ namespace IronPython.Modules {
                     throw PythonOps.LookupError(_encoding);
                 }
 
-                _decoder = PythonOps.CallWithContext(context, factory, _errors);
+                _decoder = PythonCalls.Call(context, factory, _errors);
                 if (_readUniversal) {
                     _decoder = new IncrementalNewlineDecoder(_decoder, _readTranslate, "strict");
                 }

--- a/src/core/IronPython/Runtime/ClrModule.cs
+++ b/src/core/IronPython/Runtime/ClrModule.cs
@@ -678,9 +678,9 @@ import Namespace.")]
                 ValidateArgs(args);
 
                 if (_inst != null) {
-                    return PythonOps.CallWithContext(context, _func, ArrayUtils.Insert(_inst, args));
+                    return PythonCalls.Call(context, _func, ArrayUtils.Insert(_inst, args));
                 } else {
-                    return PythonOps.CallWithContext(context, _func, args);
+                    return PythonCalls.Call(context, _func, args);
                 }
             }
 
@@ -762,7 +762,7 @@ import Namespace.")]
             #region ICallableWithCodeContext Members
             [SpecialName]
             public object Call(CodeContext context, params object[] args) {
-                object ret = PythonOps.CallWithContext(
+                object ret = PythonCalls.Call(
                     context,
                     _func,
                     _inst != null ? ArrayUtils.Insert(_inst, args) : args);

--- a/src/core/IronPython/Runtime/Map.cs
+++ b/src/core/IronPython/Runtime/Map.cs
@@ -56,7 +56,7 @@ each of the iterables.  Stops when the shortest iterable is exhausted.")]
         public bool MoveNext() {
             if (_enumerator is null) {
                 if (_enumerators.All(x => x.MoveNext())) {
-                    Current = PythonOps.CallWithContext(_context, _func, _enumerators.Select(x => x.Current).ToArray());
+                    Current = PythonCalls.Call(_context, _func, _enumerators.Select(x => x.Current).ToArray());
                     return true;
                 }
             } else if (_enumerator.MoveNext()) {

--- a/src/core/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/src/core/IronPython/Runtime/Operations/ArrayOps.cs
@@ -60,7 +60,7 @@ namespace IronPython.Runtime.Operations {
             if (!PythonOps.TryGetBoundAttr(items, "__len__", out object? lenFunc))
                 throw PythonOps.TypeErrorForBadInstance("expected object with __len__ function, got {0}", items);
 
-            int len = context.LanguageContext.ConvertToInt32(PythonOps.CallWithContext(context, lenFunc));
+            int len = context.LanguageContext.ConvertToInt32(PythonCalls.Call(context, lenFunc));
 
             Array res = @base == 0 ?
                 Array.CreateInstance(type, len) : Array.CreateInstance(type, [len], [@base]);

--- a/src/core/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/src/core/IronPython/Runtime/Operations/ObjectOps.cs
@@ -140,7 +140,7 @@ namespace IronPython.Runtime.Operations {
                     // A derived class overrode __reduce__ but not __reduce_ex__, so call
                     // specialized __reduce__ instead of generic __reduce_ex__.
                     // (see the "The __reduce_ex__ API" section of PEP 307)
-                    return PythonOps.CallWithContext(context, myReduce, self)!;
+                    return PythonCalls.Call(context, myReduce, self)!;
                 }
             }
 
@@ -325,7 +325,7 @@ namespace IronPython.Runtime.Operations {
         internal static object? ReduceProtocol0(CodeContext/*!*/ context, object self) {
             var copyreg = context.LanguageContext.GetCopyRegModule();
             var _reduce_ex = PythonOps.GetBoundAttr(context, copyreg, "_reduce_ex");
-            return PythonOps.CallWithContext(context, _reduce_ex, self, 0);
+            return PythonCalls.Call(context, _reduce_ex, self, 0);
         }
 
         /// <summary>
@@ -347,7 +347,7 @@ namespace IronPython.Runtime.Operations {
 
             if (PythonOps.TryGetBoundAttr(context, myType, "__getnewargs__", out object? getNewArgsCallable)) {
                 // TypeError will bubble up if __getnewargs__ isn't callable
-                if (!(PythonOps.CallWithContext(context, getNewArgsCallable, self) is PythonTuple newArgs)) {
+                if (!(PythonCalls.Call(context, getNewArgsCallable, self) is PythonTuple newArgs)) {
                     throw PythonOps.TypeError("__getnewargs__ should return a tuple");
                 }
                 funcArgs = new object[1 + newArgs.Count];

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -969,6 +969,7 @@ namespace IronPython.Runtime.Operations {
             return false;
         }
 
+        [Obsolete("Use PythonCalls.Call")]
         public static object? CallWithContext(CodeContext/*!*/ context, object? func, params object?[] args) {
             return PythonCalls.Call(context, func, args);
         }
@@ -979,9 +980,10 @@ namespace IronPython.Runtime.Operations {
         /// that supports calling with 'this'. If not, the 'this' object is dropped
         /// and a normal call is made.
         /// </summary>
+        [Obsolete("Use PythonCalls.Call")]
         public static object? CallWithContextAndThis(CodeContext/*!*/ context, object? func, object? instance, params object?[] args) {
             // drop the 'this' and make the call
-            return CallWithContext(context, func, args);
+            return PythonCalls.Call(context, func, args);
         }
 
         [Obsolete("Use ObjectOperations instead")]
@@ -995,7 +997,7 @@ namespace IronPython.Runtime.Operations {
                     foreach (object? arg in PythonOps.GetCollection(argsTuple))
                         largs.Add(arg);
                 }
-                return CallWithContext(context, func, largs.ToArray());
+                return PythonCalls.Call(context, func, largs.ToArray());
             } else {
                 List<object?> largs;
 
@@ -1195,8 +1197,16 @@ namespace IronPython.Runtime.Operations {
                 out _);
         }
 
+        public static object? Invoke(CodeContext/*!*/ context, object? target, string name) {
+            return PythonCalls.Call(context, PythonOps.GetBoundAttr(context, target, name));
+        }
+
         public static object? Invoke(CodeContext/*!*/ context, object? target, string name, object? arg0) {
             return PythonCalls.Call(context, PythonOps.GetBoundAttr(context, target, name), arg0);
+        }
+
+        public static object? Invoke(CodeContext/*!*/ context, object? target, string name, object? arg0, object? arg1) {
+            return PythonCalls.Call(context, PythonOps.GetBoundAttr(context, target, name), arg0, arg1);
         }
 
         public static object? Invoke(CodeContext/*!*/ context, object? target, string name, params object?[] args) {
@@ -3420,7 +3430,7 @@ namespace IronPython.Runtime.Operations {
             if (warn == null) {
                 PythonOps.PrintWithDest(context, pc.SystemStandardError, $"warning: {category.Name}: {message}");
             } else {
-                PythonOps.CallWithContext(context, warn, message, category);
+                PythonCalls.Call(context, warn, message, category);
             }
         }
 
@@ -3436,7 +3446,7 @@ namespace IronPython.Runtime.Operations {
             if (warn == null) {
                 PythonOps.PrintWithDest(context, pc.SystemStandardError, $"{filename}:{lineNo}: {category.Name}: {message}");
             } else {
-                PythonOps.CallWithContext(context, warn, message, category, filename ?? "", lineNo);
+                PythonCalls.Call(context, warn, message, category, filename ?? "", lineNo);
             }
         }
 

--- a/src/core/IronPython/Runtime/Operations/PythonTypeOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonTypeOps.cs
@@ -64,10 +64,10 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static object CallWorker(CodeContext/*!*/ context, PythonType dt, object[] args) {
-            object newObject = PythonOps.CallWithContext(context, GetTypeNew(context, dt), ArrayUtils.Insert<object>(dt, args));
+            object newObject = PythonCalls.Call(context, GetTypeNew(context, dt), ArrayUtils.Insert<object>(dt, args));
 
             if (ShouldInvokeInit(dt, DynamicHelpers.GetPythonType(newObject), args.Length)) {
-                PythonOps.CallWithContext(context, GetInitMethod(context, dt, newObject), args);
+                PythonCalls.Call(context, GetInitMethod(context, dt, newObject), args);
 
                 AddFinalizer(context, dt, newObject);
             }

--- a/src/core/IronPython/Runtime/Types/PythonType.cs
+++ b/src/core/IronPython/Runtime/Types/PythonType.cs
@@ -3127,7 +3127,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 
                 object res;
                 if (_slot.TryGetValue(_context, self, ipo.PythonType, out res)) {
-                    return PythonOps.CallWithContext(_context, res, _name, value);
+                    return PythonCalls.Call(_context, res, _name, value);
                 }
 
                 return TypeError(ipo);


### PR DESCRIPTION
Prefer `PythonCalls.Call` and add `PythonOps.Invoke` overloads. This reduce the number of splatted calls.