### PR TITLE
Fall back to invariant culture

### DIFF
--- a/src/core/IronPython/Runtime/Operations/StringOps.cs
+++ b/src/core/IronPython/Runtime/Operations/StringOps.cs
@@ -824,8 +824,16 @@ namespace IronPython.Runtime.Operations {
             return ret.ToString();
         }
 
+        static StringOps() {
+            try {
+                CasingCultureInfo = new CultureInfo("en");
+            } catch (CultureNotFoundException) {
+                CasingCultureInfo = CultureInfo.InvariantCulture;
+            }
+        }
+
         // required for better match with cpython upper/lower
-        private static readonly CultureInfo CasingCultureInfo = new CultureInfo("en");
+        private static readonly CultureInfo CasingCultureInfo;
 
         public static string lower([NotNone] this string self) {
             return self.ToLower(CasingCultureInfo);


### PR DESCRIPTION
Fall back to invariant culture if `en` culture info is not available. This occurs when running in globalization-invariant mode. See https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization

Resolves https://github.com/IronLanguages/ironpython3/issues/1648