### PR TITLE
Prevent test filename clashes when running tests in parallel

### DIFF
--- a/tests/suite/modules/io_related/test_marshal.py
+++ b/tests/suite/modules/io_related/test_marshal.py
@@ -108,15 +108,16 @@ class MarshalTest(IronPythonTestCase):
             l.append(marshal.dumps({i:i}))
 
         data = b''.join(l)
-        with open('tempfile.txt', 'wb') as f:
+        tmpfile = os.path.join(self.temporary_dir, 'tempfile_%d.txt' % os.getpid())
+        with open(tmpfile, 'wb') as f:
             f.write(data)
 
-        with open('tempfile.txt', 'rb') as f:
+        with open(tmpfile, 'rb') as f:
             for i in range(10):
                 obj = marshal.load(f)
                 self.assertEqual(obj, {i:i})
 
-        self.delete_files('tempfile.txt')
+        self.delete_files(tmpfile)
 
     def test_string_interning(self):
         self.assertEqual(marshal.dumps(['abc', 'abc'], 0), b'[\x02\x00\x00\x00u\x03\x00\x00\x00abcu\x03\x00\x00\x00abc')

--- a/tests/suite/modules/misc/test_zlib.py
+++ b/tests/suite/modules/misc/test_zlib.py
@@ -11,11 +11,11 @@ import zlib
 
 from iptest import IronPythonTestCase, run_test
 
-def create_gzip(text):
+def create_gzip(text, path):
     import gzip
-    with gzip.open('test_data.gz', 'wb') as f:
+    with gzip.open(path, 'wb') as f:
         f.write(text)
-    with open('test_data.gz', 'rb') as f:
+    with open(path, 'rb') as f:
         gzip_compress = f.read()
     return gzip_compress
 
@@ -48,11 +48,12 @@ Curabitur non eros. Nullam hendrerit bibendum justo. Fusce iaculis, est quis lac
         zlib_compress = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS)
         self.deflate_data = deflate_compress.compress(self.text) + deflate_compress.flush()
         self.zlib_data = zlib_compress.compress(self.text) + zlib_compress.flush()
-        self.gzip_data = create_gzip(self.text)
+        self.gzip_file = os.path.join(self.temporary_dir, "test_data_%d.gz" % os.getpid())
+        self.gzip_data = create_gzip(self.text, self.gzip_file)
 
     def tearDown(self):
         super(ZlibTest, self).tearDown()
-        os.remove("test_data.gz")
+        os.remove(self.gzip_file)
 
     def test_gzip(self):
         """decompression with gzip header"""

--- a/tests/suite/test_imp.py
+++ b/tests/suite/test_imp.py
@@ -913,33 +913,34 @@ called = 3.14
         import time
 
     def test_file_coding(self):
+        tmpdir = self.temporary_dir
         try:
             import os
-            with open('test_coding_mod.py', 'wb+') as f:
+            with open(os.path.join(tmpdir, 'test_coding_mod.py'), 'wb+') as f:
                 f.write(b"# coding: utf-8\nx = '\xc3\xa6ble'\n")
-            with path_modifier('.'):
+            with path_modifier(tmpdir):
                 import test_coding_mod
                 self.assertEqual(test_coding_mod.x[0], '\xe6')
         finally:
-            os.unlink('test_coding_mod.py')
+            os.unlink(os.path.join(tmpdir, 'test_coding_mod.py'))
 
         try:
-            with open('test_coding_2.py', 'wb+') as f:
+            with open(os.path.join(tmpdir, 'test_coding_2.py'), 'wb+') as f:
                 f.write(b"\xef\xbb\xbf# -*- coding: utf-8 -*-\n")
                 f.write(b"x = u'ABCDE'\n")
-            with path_modifier('.'):
+            with path_modifier(tmpdir):
                 import test_coding_2
                 self.assertEqual(test_coding_2.x, 'ABCDE')
         finally:
-            os.unlink('test_coding_2.py')
+            os.unlink(os.path.join(tmpdir, 'test_coding_2.py'))
 
         try:
-            with open('test_coding_3.py', 'wb+') as f:
+            with open(os.path.join(tmpdir, 'test_coding_3.py'), 'wb+') as f:
                 f.write(b"# -*- coding: utf-8 -*-\n")
                 f.write(b"raise Exception()")
             f.close()
             try:
-                with path_modifier('.'):
+                with path_modifier(tmpdir):
                     import test_coding_3
             except Exception as e:
                 tb = sys.exc_info()[2].tb_next
@@ -947,7 +948,7 @@ called = 3.14
                     while tb.tb_next is not None: tb = tb.tb_next # importlib has a longer traceback
                 self.assertEqual(tb.tb_lineno, 2)
         finally:
-            os.unlink('test_coding_3.py')
+            os.unlink(os.path.join(tmpdir, 'test_coding_3.py'))
 
     def test_module_subtype(self):
         class x(type(sys)):
@@ -1225,14 +1226,15 @@ X = 3.14
         mod.__file__ = 'does_not_exist.py'
         sys.modules['my_module_test'] = mod
 
-        with open('test.py', 'w+') as f:
+        tmpfile = os.path.join(self.temporary_dir, 'test_%d.py' % os.getpid())
+        with open(tmpfile, 'w+') as f:
             f.write('x = 42')
 
         try:
-            with open('test.py') as inp_file:
+            with open(tmpfile) as inp_file:
                 imp.load_module('my_module_test', inp_file, 'does_not_exist.py', ('', 'U', 1))
         finally:
-            os.unlink('test.py')
+            os.unlink(tmpfile)
 
         self.assertEqual(mod.x, 42)
 

--- a/tests/suite/test_isinstance.py
+++ b/tests/suite/test_isinstance.py
@@ -79,15 +79,17 @@ class IsInstanceTest(IronPythonTestCase):
     def test_redirect(self):
         """stdin, stdout redirect and input, raw_input tests"""
 
+        tmpfile = os.path.join(self.temporary_dir, "testfile_%d.tmp" % os.getpid())
+
         old_stdin = sys.stdin
         old_stdout = sys.stdout
-        sys.stdout = open("testfile.tmp", "w")
+        sys.stdout = open(tmpfile, "w")
         print("Into the file")
         print("2+2")
         sys.stdout.close()
         sys.stdout = old_stdout
 
-        sys.stdin = open("testfile.tmp", "r")
+        sys.stdin = open(tmpfile, "r")
         s = input()
         self.assertTrue(s == "Into the file")
         s = eval(input())
@@ -95,8 +97,8 @@ class IsInstanceTest(IronPythonTestCase):
         sys.stdin.close()
         sys.stdin = old_stdin
 
-        f = open("testfile.tmp", "r")
-        g = open("testfile.tmp", "r")
+        f = open(tmpfile, "r")
+        g = open(tmpfile, "r")
         s = f.readline()
         t = g.readline()
         self.assertTrue(s == t)
@@ -105,16 +107,15 @@ class IsInstanceTest(IronPythonTestCase):
         f.close()
         g.close()
 
-        f = open("testfile.tmp", "w")
+        f = open(tmpfile, "w")
         f.writelines(["1\n", "2\n", "2\n", "3\n", "4\n", "5\n", "6\n", "7\n", "8\n", "9\n", "0\n"])
         f.close()
-        f = open("testfile.tmp", "r")
+        f = open(tmpfile, "r")
         l = f.readlines()
         self.assertTrue(l == ["1\n", "2\n", "2\n", "3\n", "4\n", "5\n", "6\n", "7\n", "8\n", "9\n", "0\n"])
         f.close()
 
-        import os
-        os.remove("testfile.tmp")
+        os.remove(tmpfile)
 
     def test_conversions(self):
         success=False

--- a/tests/suite/test_python25.py
+++ b/tests/suite/test_python25.py
@@ -282,8 +282,14 @@ class Python25Test(unittest.TestCase):
 
 
     def test_with_open(self):
-        with open('abc.txt', 'w'):
-            pass
+        import tempfile, os
+        fd, path = tempfile.mkstemp(suffix='.txt', prefix='ipy_test_')
+        os.close(fd)
+        try:
+            with open(path, 'w'):
+                pass
+        finally:
+            os.remove(path)
 
     def test_try_catch_finally(self):
         # test try-catch-finally syntax


### PR DESCRIPTION
This is mostly useful when testing locally, because CI tests run in parallel on separate VMs.