### PR TITLE
Remove SourceLink package

### DIFF
--- a/src/core/IronPython.Modules/IronPython.Modules.csproj
+++ b/src/core/IronPython.Modules/IronPython.Modules.csproj
@@ -21,10 +21,6 @@
     <ProjectReference Include="..\IronPython\IronPython.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup Condition=" $(TargetFrameworkIdentifier) != '.NETFramework' ">
     <ProjectReference Include="..\..\roslyn\IronPython.Analyzer\IronPython.Analyzer.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/core/IronPython/IronPython.csproj
+++ b/src/core/IronPython/IronPython.csproj
@@ -50,7 +50,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/IronPython.SQLite/IronPython.SQLite.csproj
+++ b/src/extensions/IronPython.SQLite/IronPython.SQLite.csproj
@@ -43,10 +43,6 @@
     <ProjectReference Include="..\..\dlr\Src\Microsoft.Dynamic\Microsoft.Dynamic.csproj" Private="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
   <Import Project="$(AfterTargetFiles)" />
   <Target Name="AfterBuildEnds" AfterTargets="AfterBuild" DependsOnTargets="$(AfterTargets)" />
 

--- a/src/extensions/IronPython.Wpf/IronPython.Wpf.csproj
+++ b/src/extensions/IronPython.Wpf/IronPython.Wpf.csproj
@@ -25,10 +25,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
   <Import Project="$(AfterTargetFiles)" />
   <Target Name="AfterBuildEnds" AfterTargets="AfterBuild" DependsOnTargets="$(AfterTargets)" />
 


### PR DESCRIPTION
Source Link is included by default since the .NET 8 SDK so this dependency is no longer required.

Similar to https://github.com/IronLanguages/dlr/pull/304