### PR TITLE
Replace Dictionary with HashSet

### DIFF
--- a/src/core/IronPython/Compiler/Ast/ClassDefinition.cs
+++ b/src/core/IronPython/Compiler/Ast/ClassDefinition.cs
@@ -407,10 +407,10 @@ namespace IronPython.Compiler.Ast {
 
                 var finder = new SelfNameFinder(function, parameters[0]);
                 function.Body.Walk(finder);
-                return ArrayUtils.ToArray(finder._names.Keys);
+                return [..finder._names];
             }
 
-            private readonly Dictionary<string, bool> _names = new Dictionary<string, bool>(StringComparer.Ordinal);
+            private readonly HashSet<string> _names = new(StringComparer.Ordinal);
 
             private bool IsSelfReference(Expression expr) {
                 return expr is NameExpression ne
@@ -426,7 +426,7 @@ namespace IronPython.Compiler.Ast {
                 foreach (Expression lhs in node.Left) {
                     if (lhs is MemberExpression me) {
                         if (IsSelfReference(me.Target)) {
-                            _names[me.Name] = true;
+                            _names.Add(me.Name);
                         }
                     }
                 }

--- a/src/core/IronPython/Runtime/Types/NewTypeMaker.cs
+++ b/src/core/IronPython/Runtime/Types/NewTypeMaker.cs
@@ -274,7 +274,7 @@ namespace IronPython.Runtime.Types {
 
             ImplementProtectedFieldAccessors(specialNames);
 
-            Dictionary<Type, bool> doneTypes = new Dictionary<Type, bool>();
+            var doneTypes = new HashSet<Type>();
             foreach (Type interfaceType in _interfaceTypes) {
                 DoInterfaceType(interfaceType, doneTypes, specialNames);
             }
@@ -364,15 +364,15 @@ namespace IronPython.Runtime.Types {
             return true;
         }
 
-        private void DoInterfaceType(Type interfaceType, Dictionary<Type, bool> doneTypes, Dictionary<string, string[]> specialNames) {
+        private void DoInterfaceType(Type interfaceType, HashSet<Type> doneTypes, Dictionary<string, string[]> specialNames) {
             if (interfaceType == typeof(IDynamicMetaObjectProvider)) {
                 // very tricky, we'll handle it when we're creating
                 // our own IDynamicMetaObjectProvider interface
                 return;
             }
 
-            if (doneTypes.ContainsKey(interfaceType)) return;
-            doneTypes.Add(interfaceType, true);
+            if (doneTypes.Contains(interfaceType)) return;
+            doneTypes.Add(interfaceType);
             OverrideMethods(interfaceType, specialNames);
 
             foreach (Type t in interfaceType.GetInterfaces()) {

--- a/src/extensions/IronPython.SQLite/Connection.cs
+++ b/src/extensions/IronPython.SQLite/Connection.cs
@@ -58,7 +58,7 @@ namespace IronPython.SQLite
             private List<WeakReference> statements = new List<WeakReference>();
             private int created_statements = 0;
 
-            private Dictionary<object, object> function_pinboard = new Dictionary<object, object>();
+            private readonly HashSet<object> function_pinboard = new();
 
             internal Sqlite3.sqlite3 db;
 
@@ -286,7 +286,7 @@ namespace IronPython.SQLite
                 if(rc != Sqlite3.SQLITE_OK)
                     throw MakeOperationalError("Error creating function");
                 else
-                    this.function_pinboard[func] = null;
+                    this.function_pinboard.Add(func);
             }
 
             private static void callUserFunction(Sqlite3.sqlite3_context ctx, int argc, sqlite3_value[] argv)
@@ -459,7 +459,7 @@ namespace IronPython.SQLite
                 if(rc != Sqlite3.SQLITE_OK)
                     throw MakeOperationalError("Error creating aggregate");
                 else
-                    this.function_pinboard[aggregate_class] = null;
+                    this.function_pinboard.Add(aggregate_class);
             }
 
             #endregion


### PR DESCRIPTION
This is the equivalent of IronLanguages/dlr#322 on the IronPython side. Maybe `HashSet` did not exist yet when this code was written.

It is a very opportunistic and straightforward change. Perhaps more possibilities for optimizations exist. One such place is `FunctionCode.cs`, which contains class `PythonDebuggingPayload.TracingWalker`. It defines several dictionaries where the value is `bool`. They look like sets, if the value is always, `true`, `false`, or ignored. Maybe this can be simplified somehow or maybe it is unfinished work, but will require more code analysis than what I am doing here for such a mechanical upgrade. Besides, this seems to be used only for debugging/tracing, when performance is not that important.