### PR TITLE
First class span types

### DIFF
--- a/src/core/IronPython/Hosting/PythonOptionsParser.cs
+++ b/src/core/IronPython/Hosting/PythonOptionsParser.cs
@@ -150,12 +150,12 @@ namespace IronPython.Hosting {
             }
 
             if (arg == "/?" || arg == "--help") {
-                HandleOptions("h".AsSpan());
+                HandleOptions("h");
                 return;
             }
 
             if (arg == "--version") {
-                HandleOptions("V".AsSpan());
+                HandleOptions("V");
                 return;
             }
 

--- a/src/core/IronPython/Modules/_io/StringIO.cs
+++ b/src/core/IronPython/Modules/_io/StringIO.cs
@@ -114,7 +114,7 @@ namespace IronPython.Modules {
                         span = span.Slice(0, idx + 1);
                     }
                 } else if (_newline == string.Empty) {
-                    var idx = span.IndexOfAny("\r\n".AsSpan());
+                    var idx = span.IndexOfAny("\r\n");
                     if (idx != -1) {
                         if (span[idx++] == '\r') {
                             // ensure we don't split \r\n
@@ -377,7 +377,7 @@ namespace IronPython.Modules {
 
                 if (_newline is null) {
                     while (true) {
-                        var idx = span.IndexOfAny("\r\n".AsSpan());
+                        var idx = span.IndexOfAny("\r\n");
                         if (idx == -1)
                             break;
 

--- a/src/core/IronPython/Runtime/Bytes.cs
+++ b/src/core/IronPython/Runtime/Bytes.cs
@@ -375,7 +375,7 @@ namespace IronPython.Runtime {
             return PythonTypeOps.CallParams(context, cls, new Bytes(hex));
         }
 
-        public string hex() => ToHex(_bytes.AsSpan()); // new in CPython 3.5
+        public string hex() => ToHex(_bytes); // new in CPython 3.5
 
         internal static string ToHex(ReadOnlySpan<byte> bytes) {
             if (bytes.Length == 0) return string.Empty;
@@ -395,13 +395,13 @@ namespace IronPython.Runtime {
         // new in CPython 3.8
         public string hex([NotNone] string sep, int bytes_per_sep = 1) {
             if (sep.Length != 1) throw PythonOps.ValueError($"{nameof(sep)} must be length 1");
-            return ToHex(_bytes.AsSpan(), sep[0], bytes_per_sep);
+            return ToHex(_bytes, sep[0], bytes_per_sep);
         }
 
         // new in CPython 3.8
         public string hex([BytesLike, NotNone] IList<byte> sep, int bytes_per_sep = 1) {
             if (sep.Count != 1) throw PythonOps.ValueError($"{nameof(sep)} must be length 1");
-            return ToHex(_bytes.AsSpan(), (char)sep[0], bytes_per_sep);
+            return ToHex(_bytes, (char)sep[0], bytes_per_sep);
         }
 
         internal static string ToHex(ReadOnlySpan<byte> bytes, char sep, int bytes_per_sep) {
@@ -1077,9 +1077,9 @@ namespace IronPython.Runtime {
 
         #region Implementation Details
 
-        internal ReadOnlyMemory<byte> AsMemory() => _bytes.AsMemory();
+        internal ReadOnlyMemory<byte> AsMemory() => _bytes;
 
-        internal ReadOnlySpan<byte> AsSpan() => _bytes.AsSpan();
+        internal ReadOnlySpan<byte> AsSpan() => _bytes;
 
         internal static bool TryInvokeBytesOperator(CodeContext context, object? obj, [NotNullWhen(true)] out Bytes? bytes) {
             if (PythonTypeOps.TryInvokeUnaryOperator(context, obj, "__bytes__", out object? res)) {

--- a/src/core/IronPython/Runtime/LiteralParser.cs
+++ b/src/core/IronPython/Runtime/LiteralParser.cs
@@ -219,7 +219,7 @@ namespace IronPython.Runtime {
 #nullable enable
 
         private static bool TryParseExpression(Parser parser, ReadOnlySpan<char> data, [NotNullWhen(true)] out Expression? expression, [NotNullWhen(false)] out string? error) {
-            if (data.TrimStart(" \t\f\r\n".AsSpan()).Length == 0) {
+            if (data.TrimStart(" \t\f\r\n").Length == 0) {
                 expression = null;
                 error = "f-string: empty expression not allowed";
                 return false;
@@ -649,7 +649,7 @@ namespace IronPython.Runtime {
         }
 
         public static object ParseInteger(string text, int b) {
-            if (TryParseInteger(text.AsSpan(), b, false, out object val)) {
+            if (TryParseInteger(text, b, false, out object val)) {
                 return val;
             }
             throw new ValueErrorException($"invalid literal with base {b}: {text}");

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -3689,10 +3689,6 @@ namespace IronPython.Runtime.Operations {
             return StringOps.Latin1Encoding.GetString(byteArr, startIdx, maxBytes);
         }
 
-        internal static string MakeString(this Span<byte> bytes) {
-            return MakeString((ReadOnlySpan<byte>)bytes);
-        }
-
         internal static string MakeString(this ReadOnlySpan<byte> bytes) {
             if (bytes.IsEmpty) {
                 return string.Empty;


### PR DESCRIPTION
Now that we have target `net10.0` and all relevant projects use `LangVersion` _latest_, the code is compiled with C# 14, which introduces feature [First-class Span Types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-14.0/first-class-span-types). Consequently, the existing code can be simplified a bit — compiler takes over the span conversions.