### PR TITLE
Postpone variadic support check till .NET 12

### DIFF
--- a/src/core/IronPython.Modules/fcntl.cs
+++ b/src/core/IronPython.Modules/fcntl.cs
@@ -121,7 +121,7 @@ public static class PythonFcntl {
     // so as a workaround, nonvararg prototypes are defined for each architecture.
     // [1]: https://github.com/dotnet/runtime/issues/48796
 
-#if NET11_0_OR_GREATER
+#if NET12_0_OR_GREATER
 #error Check if this version of .NET supports P/Invoke of variadic functions; if not, change the condition to recheck at next major .NET version
 #endif
 


### PR DESCRIPTION
[Variadic P/Invoke](https://github.com/dotnet/runtime/issues/48796) support did not make it to [.NET 11](https://github.com/dotnet/runtime/milestone/176), which is now in Preview 4.

The re-check is now gated on .NET 12.