### PR TITLE
Implement async functions and generators (.NET)

### DIFF
--- a/eng/net10.0.props
+++ b/eng/net10.0.props
@@ -23,6 +23,7 @@
     <Features>$(Features);FEATURE_METADATA_READER</Features>
     <Features>$(Features);FEATURE_MMAP</Features>
     <Features>$(Features);FEATURE_NATIVE</Features>
+    <Features>$(Features);FEATURE_NET_ASYNC</Features>
     <Features>$(Features);FEATURE_OSPLATFORMATTRIBUTE</Features>
     <Features>$(Features);FEATURE_PIPES</Features>
     <Features>$(Features);FEATURE_PROCESS</Features>

--- a/eng/net8.0.props
+++ b/eng/net8.0.props
@@ -23,6 +23,7 @@
     <Features>$(Features);FEATURE_METADATA_READER</Features>
     <Features>$(Features);FEATURE_MMAP</Features>
     <Features>$(Features);FEATURE_NATIVE</Features>
+    <Features>$(Features);FEATURE_NET_ASYNC</Features>
     <Features>$(Features);FEATURE_OSPLATFORMATTRIBUTE</Features>
     <Features>$(Features);FEATURE_PIPES</Features>
     <Features>$(Features);FEATURE_PROCESS</Features>

--- a/eng/net9.0.props
+++ b/eng/net9.0.props
@@ -23,6 +23,7 @@
     <Features>$(Features);FEATURE_METADATA_READER</Features>
     <Features>$(Features);FEATURE_MMAP</Features>
     <Features>$(Features);FEATURE_NATIVE</Features>
+    <Features>$(Features);FEATURE_NET_ASYNC</Features>
     <Features>$(Features);FEATURE_OSPLATFORMATTRIBUTE</Features>
     <Features>$(Features);FEATURE_PIPES</Features>
     <Features>$(Features);FEATURE_PROCESS</Features>

--- a/src/core/IronPython/Compiler/Ast/AstMethods.cs
+++ b/src/core/IronPython/Compiler/Ast/AstMethods.cs
@@ -80,6 +80,10 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo FormatString = GetMethod((Func<CodeContext, string, object, string>)PythonOps.FormatString);
         public static readonly MethodInfo GeneratorCheckThrowableAndReturnSendValue = GetMethod((Func<object, object>)PythonOps.GeneratorCheckThrowableAndReturnSendValue);
         public static readonly MethodInfo MakeCoroutine = GetMethod((Func<PythonFunction, MutableTuple, object, PythonCoroutine>)PythonOps.MakeCoroutine);
+#if FEATURE_NET_ASYNC
+        public static readonly MethodInfo AsTaskForAwait = GetMethod((Func<object, System.Threading.Tasks.Task<object>>)PythonOps.AsTaskForAwait);
+        public static readonly MethodInfo MakeAsyncCoroutine = GetMethod((Func<PythonFunction, System.Threading.Tasks.Task<object>, System.Threading.CancellationTokenSource, System.Runtime.CompilerServices.StrongBox<System.Exception>, PythonCoroutine>)PythonOps.MakeAsyncCoroutine);
+#endif
 
         // builtins
         public static readonly MethodInfo Format = GetMethod((Func<CodeContext, object, string, string>)PythonOps.Format);

--- a/src/core/IronPython/Compiler/Ast/AstMethods.cs
+++ b/src/core/IronPython/Compiler/Ast/AstMethods.cs
@@ -82,7 +82,7 @@ namespace IronPython.Compiler.Ast {
         public static readonly MethodInfo MakeCoroutine = GetMethod((Func<PythonFunction, MutableTuple, object, PythonCoroutine>)PythonOps.MakeCoroutine);
 #if FEATURE_NET_ASYNC
         public static readonly MethodInfo AsTaskForAwait = GetMethod((Func<object, System.Threading.Tasks.Task<object>>)PythonOps.AsTaskForAwait);
-        public static readonly MethodInfo MakeAsyncCoroutine = GetMethod((Func<PythonFunction, System.Threading.Tasks.Task<object>, System.Threading.CancellationTokenSource, System.Runtime.CompilerServices.StrongBox<System.Exception>, PythonCoroutine>)PythonOps.MakeAsyncCoroutine);
+        public static readonly MethodInfo MakeAsyncCoroutine = GetMethod((Func<PythonFunction, Func<System.Threading.Tasks.Task<object>>, System.Threading.CancellationTokenSource, System.Runtime.CompilerServices.StrongBox<System.Exception>, PythonCoroutine>)PythonOps.MakeAsyncCoroutine);
         public static readonly MethodInfo MakeAsyncGenerator = GetMethod((Func<PythonFunction, System.Collections.Generic.IAsyncEnumerable<object>, System.Runtime.CompilerServices.StrongBox<object>, System.Runtime.CompilerServices.StrongBox<System.Exception>, System.Threading.CancellationTokenSource, PythonAsyncGenerator>)PythonOps.MakeAsyncGenerator);
 #endif
 

--- a/src/core/IronPython/Compiler/Ast/AstMethods.cs
+++ b/src/core/IronPython/Compiler/Ast/AstMethods.cs
@@ -83,6 +83,7 @@ namespace IronPython.Compiler.Ast {
 #if FEATURE_NET_ASYNC
         public static readonly MethodInfo AsTaskForAwait = GetMethod((Func<object, System.Threading.Tasks.Task<object>>)PythonOps.AsTaskForAwait);
         public static readonly MethodInfo MakeAsyncCoroutine = GetMethod((Func<PythonFunction, System.Threading.Tasks.Task<object>, System.Threading.CancellationTokenSource, System.Runtime.CompilerServices.StrongBox<System.Exception>, PythonCoroutine>)PythonOps.MakeAsyncCoroutine);
+        public static readonly MethodInfo MakeAsyncGenerator = GetMethod((Func<PythonFunction, System.Collections.Generic.IAsyncEnumerable<object>, System.Runtime.CompilerServices.StrongBox<object>, System.Runtime.CompilerServices.StrongBox<System.Exception>, System.Threading.CancellationTokenSource, PythonAsyncGenerator>)PythonOps.MakeAsyncGenerator);
 #endif
 
         // builtins

--- a/src/core/IronPython/Compiler/Ast/AwaitExpression.cs
+++ b/src/core/IronPython/Compiler/Ast/AwaitExpression.cs
@@ -6,15 +6,43 @@
 
 using MSAst = System.Linq.Expressions;
 
+using IronPython.Runtime.Operations;
+
 using AstUtils = Microsoft.Scripting.Ast.Utils;
 
 namespace IronPython.Compiler.Ast {
     using Ast = MSAst.Expression;
 
     /// <summary>
-    /// Represents an await expression. Implemented as yield from expr.__await__().
+    /// Represents <c>await expr</c>. Under <c>FEATURE_NET_ASYNC</c> this compiles
+    /// directly to a DLR runtime-async suspension point. Otherwise it is
+    /// desugared into <c>yield from expr.__await__()</c> against the enclosing
+    /// generator-shaped coroutine state machine.
     /// </summary>
     public class AwaitExpression : Expression {
+#if FEATURE_NET_ASYNC
+        public AwaitExpression(Expression expression) {
+            Expression = expression;
+        }
+
+        public Expression Expression { get; }
+
+        public override MSAst.Expression Reduce() {
+            // await x -> AsyncHelpers-driven suspension on the Task produced by
+            // PythonOps.AsTaskForAwait(x).
+            return AstUtils.Await(
+                Ast.Call(
+                    AstMethods.AsTaskForAwait,
+                    AstUtils.Convert(Expression, typeof(object))));
+        }
+
+        public override void Walk(PythonWalker walker) {
+            if (walker.Walk(this)) {
+                Expression?.Walk(walker);
+            }
+            walker.PostWalk(this);
+        }
+#else
         private readonly Statement _statement;
         private readonly NameExpression _result;
 
@@ -60,6 +88,7 @@ namespace IronPython.Compiler.Ast {
             }
             walker.PostWalk(this);
         }
+#endif
 
         public override string NodeName => "await expression";
     }

--- a/src/core/IronPython/Compiler/Ast/AwaitExpression.cs
+++ b/src/core/IronPython/Compiler/Ast/AwaitExpression.cs
@@ -14,10 +14,8 @@ namespace IronPython.Compiler.Ast {
     using Ast = MSAst.Expression;
 
     /// <summary>
-    /// Represents <c>await expr</c>. Under <c>FEATURE_NET_ASYNC</c> this compiles
-    /// directly to a DLR runtime-async suspension point. Otherwise it is
-    /// desugared into <c>yield from expr.__await__()</c> against the enclosing
-    /// generator-shaped coroutine state machine.
+    /// Represents <c>await expr</c>. Under <c>FEATURE_NET_ASYNC</c> this compiles directly to a DLR async suspension point.
+    /// Otherwise it is desugared into <c>yield from expr.__await__()</c> against the enclosing generator-shaped coroutine state machine.
     /// </summary>
     public class AwaitExpression : Expression {
 #if FEATURE_NET_ASYNC

--- a/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -760,6 +760,11 @@ namespace IronPython.Compiler.Ast {
                             cts));
                 } else {
                     // Plain async def: the body returns a PythonCoroutine wrapping a Task<object?>.
+                    // Lazy start: hand MakeAsyncCoroutine a thunk (Func<Task<object?>>) instead of an
+                    // already-running Task, so the body doesn't execute until the coroutine is first driven
+                    // (send/AsTask). This makes calling an async def side-effect-free (PEP 492) and lets the
+                    // body's first await capture the driver's SynchronizationContext rather than whatever
+                    // context happened to be current at construction.
                     body = MSAst.Expression.Block(
                         new[] { cts, excBox },
                         MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(System.Threading.CancellationTokenSource))),
@@ -767,7 +772,8 @@ namespace IronPython.Compiler.Ast {
                         Ast.Call(
                             AstMethods.MakeAsyncCoroutine,
                             _functionParam,
-                            AstUtils.Async(Name, body, ctToken, excBox),
+                            MSAst.Expression.Lambda<Func<System.Threading.Tasks.Task<object>>>(
+                                AstUtils.Async(Name, body, ctToken, excBox)),
                             cts,
                             excBox));
                 }

--- a/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -117,7 +117,15 @@ namespace IronPython.Compiler.Ast {
 
         public Expression ReturnAnnotation { get; internal set; }
 
+#if FEATURE_NET_ASYNC
+        // Under runtime-async, async functions are compiled directly to a
+        // Task<object?> via the DLR's AsyncExpression rather than reused
+        // through the generator state machine, so IsAsync no longer implies
+        // generator-shaped emission.
+        internal override bool IsGeneratorMethod => IsGenerator;
+#else
         internal override bool IsGeneratorMethod => IsGenerator || IsAsync;
+#endif
 
         /// <summary>
         /// The function is a generator
@@ -182,9 +190,15 @@ namespace IronPython.Compiler.Ast {
                     fa |= FunctionAttributes.ContainsTryFinally;
                 }
 
+#if FEATURE_NET_ASYNC
+                if (IsGenerator) {
+                    fa |= FunctionAttributes.Generator;
+                }
+#else
                 if (IsGenerator || IsAsync) {
                     fa |= FunctionAttributes.Generator;
                 }
+#endif
 
                 if (IsAsync) {
                     fa |= FunctionAttributes.Coroutine;
@@ -357,9 +371,15 @@ namespace IronPython.Compiler.Ast {
                                 annotations
                             )
                         ),
+#if FEATURE_NET_ASYNC
+                    IsGenerator ?
+                        (MSAst.Expression)new PythonGeneratorExpression(code, GlobalParent.PyContext.Options.CompilationThreshold, IsAsync) :
+                        (MSAst.Expression)code
+#else
                     (IsGenerator || IsAsync) ?
                         (MSAst.Expression)new PythonGeneratorExpression(code, GlobalParent.PyContext.Options.CompilationThreshold, IsAsync) :
                         (MSAst.Expression)code
+#endif
                 );
             } else {
                 ret = Ast.Call(
@@ -659,10 +679,17 @@ namespace IronPython.Compiler.Ast {
             // For generators/coroutines, we need to do a check before the first statement for Generator.Throw() / Generator.Close().
             // The exception traceback needs to come from the generator's method body, and so we must do the check and throw
             // from inside the generator.
+#if FEATURE_NET_ASYNC
+            if (IsGenerator) {
+                MSAst.Expression s1 = YieldExpression.CreateCheckThrowExpression(SourceSpan.None);
+                statements.Add(s1);
+            }
+#else
             if (IsGenerator || IsAsync) {
                 MSAst.Expression s1 = YieldExpression.CreateCheckThrowExpression(SourceSpan.None);
                 statements.Add(s1);
             }
+#endif
 
             if (Body.CanThrow && !(Body is SuiteStatement) && Body.StartIndex != -1) {
                 statements.Add(UpdateLineNumber(GlobalParent.IndexToLocation(Body.StartIndex).Line));
@@ -680,6 +707,31 @@ namespace IronPython.Compiler.Ast {
             body = WrapScopeStatements(body, Body.CanThrow);
             body = Ast.Block(body, AstUtils.Empty());
             body = AddReturnTarget(body);
+
+#if FEATURE_NET_ASYNC
+            // Under runtime-async, an `async def` body returns a PythonCoroutine wrapping a
+            // Task<object?>. We pre-allocate a CancellationTokenSource and a StrongBox<Exception?>
+            // here so the same instances are shared with both AsyncExpression (which threads them into
+            // AsyncHelpers.DriveAsync) and PythonCoroutine (which uses them to implement
+            // coro.throw(exc) on a running coroutine: write the exception to the box, cancel the CTS,
+            // and DriveAsync surfaces that exception in place of OperationCanceledException).
+            if (IsAsync) {
+                var cts = MSAst.Expression.Variable(typeof(System.Threading.CancellationTokenSource), "$cts");
+                var excBox = MSAst.Expression.Variable(typeof(System.Runtime.CompilerServices.StrongBox<Exception>), "$cancelExc");
+                body = MSAst.Expression.Block(
+                    new[] { cts, excBox },
+                    MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(System.Threading.CancellationTokenSource))),
+                    MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
+                    Ast.Call(
+                        AstMethods.MakeAsyncCoroutine,
+                        _functionParam,
+                        AstUtils.Async(Name, body,
+                            MSAst.Expression.Property(cts, nameof(System.Threading.CancellationTokenSource.Token)),
+                            excBox),
+                        cts,
+                        excBox));
+            }
+#endif
 
             MSAst.Expression bodyStmt = body;
             if (localContext != null) {

--- a/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -123,6 +123,19 @@ namespace IronPython.Compiler.Ast {
         // through the generator state machine, so IsAsync no longer implies
         // generator-shaped emission.
         internal override bool IsGeneratorMethod => IsGenerator;
+
+        // Async-generator (PEP 525) channels, one StrongBox per async-generator instance (per stack frame
+        // at runtime — not static). Created when lowering the async generator; declared/assigned in the
+        // function body, captured by the generator (the body's yields read them through Parent), and handed
+        // to the PythonAsyncGenerator wrapper, which writes them before each resume:
+        //   AsyncSendSlot  — the value of `x = yield z` (asend(v); None for __anext__/async for).
+        //   AsyncThrowSlot — an exception to rethrow at the yield resume point (athrow/aclose).
+        private MSAst.ParameterExpression _asyncSendSlot;
+        private MSAst.ParameterExpression _asyncThrowSlot;
+        internal MSAst.ParameterExpression AsyncSendSlot
+            => _asyncSendSlot ??= MSAst.Expression.Variable(typeof(System.Runtime.CompilerServices.StrongBox<object>), "$asyncSend");
+        internal MSAst.ParameterExpression AsyncThrowSlot
+            => _asyncThrowSlot ??= MSAst.Expression.Variable(typeof(System.Runtime.CompilerServices.StrongBox<Exception>), "$asyncThrow");
 #else
         internal override bool IsGeneratorMethod => IsGenerator || IsAsync;
 #endif
@@ -372,7 +385,9 @@ namespace IronPython.Compiler.Ast {
                             )
                         ),
 #if FEATURE_NET_ASYNC
-                    IsGenerator ?
+                    // Async generators are lowered via AsyncEnumerableExpression in the body, so they must not
+                    // be wrapped as a PythonGenerator here — only plain (non-async) generators are.
+                    (IsGenerator && !IsAsync) ?
                         (MSAst.Expression)new PythonGeneratorExpression(code, GlobalParent.PyContext.Options.CompilationThreshold, IsAsync) :
                         (MSAst.Expression)code
 #else
@@ -680,7 +695,9 @@ namespace IronPython.Compiler.Ast {
             // The exception traceback needs to come from the generator's method body, and so we must do the check and throw
             // from inside the generator.
 #if FEATURE_NET_ASYNC
-            if (IsGenerator) {
+            // Async generators have no backing PythonGenerator (they lower to IAsyncEnumerable via
+            // AsyncEnumerableExpression), so skip the $generator.CheckThrowable() prologue for them.
+            if (IsGenerator && !IsAsync) {
                 MSAst.Expression s1 = YieldExpression.CreateCheckThrowExpression(SourceSpan.None);
                 statements.Add(s1);
             }
@@ -718,18 +735,42 @@ namespace IronPython.Compiler.Ast {
             if (IsAsync) {
                 var cts = MSAst.Expression.Variable(typeof(System.Threading.CancellationTokenSource), "$cts");
                 var excBox = MSAst.Expression.Variable(typeof(System.Runtime.CompilerServices.StrongBox<Exception>), "$cancelExc");
-                body = MSAst.Expression.Block(
-                    new[] { cts, excBox },
-                    MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(System.Threading.CancellationTokenSource))),
-                    MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
-                    Ast.Call(
-                        AstMethods.MakeAsyncCoroutine,
-                        _functionParam,
-                        AstUtils.Async(Name, body,
-                            MSAst.Expression.Property(cts, nameof(System.Threading.CancellationTokenSource.Token)),
-                            excBox),
-                        cts,
-                        excBox));
+                var ctToken = MSAst.Expression.Property(cts, nameof(System.Threading.CancellationTokenSource.Token));
+                if (IsGenerator) {
+                    // Async generator: the body has both `await` and `yield`. Lower it to an
+                    // IAsyncEnumerable<object?> via AsyncEnumerableExpression, sharing the generator label so
+                    // the body's yields and the rewritten awaits land in one generator, then wrap it in a
+                    // PythonAsyncGenerator. The send/throw slots are per-generator StrongBoxes captured by the
+                    // generator (the body's yields read them) AND handed to the wrapper, which writes them
+                    // before each resume — see AsyncSendSlot / AsyncThrowSlot.
+                    var sendSlot = AsyncSendSlot;
+                    var throwSlot = AsyncThrowSlot;
+                    body = MSAst.Expression.Block(
+                        new[] { cts, excBox, sendSlot, throwSlot },
+                        MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(System.Threading.CancellationTokenSource))),
+                        MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
+                        MSAst.Expression.Assign(sendSlot, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<object>))),
+                        MSAst.Expression.Assign(throwSlot, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
+                        Ast.Call(
+                            AstMethods.MakeAsyncGenerator,
+                            _functionParam,
+                            AstUtils.AsyncEnumerable(Name, body, GeneratorLabel, ctToken, excBox),
+                            sendSlot,
+                            throwSlot,
+                            cts));
+                } else {
+                    // Plain async def: the body returns a PythonCoroutine wrapping a Task<object?>.
+                    body = MSAst.Expression.Block(
+                        new[] { cts, excBox },
+                        MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(System.Threading.CancellationTokenSource))),
+                        MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
+                        Ast.Call(
+                            AstMethods.MakeAsyncCoroutine,
+                            _functionParam,
+                            AstUtils.Async(Name, body, ctToken, excBox),
+                            cts,
+                            excBox));
+                }
             }
 #endif
 

--- a/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 using IronPython.Runtime;
 using IronPython.Runtime.Operations;
@@ -118,24 +119,21 @@ namespace IronPython.Compiler.Ast {
         public Expression ReturnAnnotation { get; internal set; }
 
 #if FEATURE_NET_ASYNC
-        // Under runtime-async, async functions are compiled directly to a
-        // Task<object?> via the DLR's AsyncExpression rather than reused
-        // through the generator state machine, so IsAsync no longer implies
-        // generator-shaped emission.
+        // Under .NET-async, async functions are compiled directly to a Task<object?> via the DLR's AsyncExpression
+        // rather than reused through the generator state machine, so IsAsync does not imply generator-shaped emission.
         internal override bool IsGeneratorMethod => IsGenerator;
 
-        // Async-generator (PEP 525) channels, one StrongBox per async-generator instance (per stack frame
-        // at runtime — not static). Created when lowering the async generator; declared/assigned in the
-        // function body, captured by the generator (the body's yields read them through Parent), and handed
-        // to the PythonAsyncGenerator wrapper, which writes them before each resume:
+        // Async-generator (PEP 525) channels. The StrongBox *values* are per-async-generator instance,
+        // allocated per stack frame at runtime in the function body. 
+        // Declared/assigned in the body, captured by the generator (its yields read them through Parent),
+        // and handed to the PythonAsyncGenerator wrapper, which writes them before each resume:
         //   AsyncSendSlot  — the value of `x = yield z` (asend(v); None for __anext__/async for).
         //   AsyncThrowSlot — an exception to rethrow at the yield resume point (athrow/aclose).
-        private MSAst.ParameterExpression _asyncSendSlot;
-        private MSAst.ParameterExpression _asyncThrowSlot;
-        internal MSAst.ParameterExpression AsyncSendSlot
-            => _asyncSendSlot ??= MSAst.Expression.Variable(typeof(System.Runtime.CompilerServices.StrongBox<object>), "$asyncSend");
-        internal MSAst.ParameterExpression AsyncThrowSlot
-            => _asyncThrowSlot ??= MSAst.Expression.Variable(typeof(System.Runtime.CompilerServices.StrongBox<Exception>), "$asyncThrow");
+        private readonly MSAst.ParameterExpression _asyncSendSlot = MSAst.Expression.Variable(typeof(StrongBox<object>), "$asyncSend");
+        private readonly MSAst.ParameterExpression _asyncThrowSlot = MSAst.Expression.Variable(typeof(StrongBox<Exception>), "$asyncThrow");
+
+        internal MSAst.ParameterExpression AsyncSendSlot => _asyncSendSlot;
+        internal MSAst.ParameterExpression AsyncThrowSlot => _asyncThrowSlot;
 #else
         internal override bool IsGeneratorMethod => IsGenerator || IsAsync;
 #endif
@@ -385,16 +383,14 @@ namespace IronPython.Compiler.Ast {
                             )
                         ),
 #if FEATURE_NET_ASYNC
-                    // Async generators are lowered via AsyncEnumerableExpression in the body, so they must not
-                    // be wrapped as a PythonGenerator here — only plain (non-async) generators are.
+                    // Async generators are lowered via AsyncEnumerableExpression in the body,
+                    // so they must not be wrapped as a PythonGenerator here — only plain (non-async) generators are.
                     (IsGenerator && !IsAsync) ?
-                        (MSAst.Expression)new PythonGeneratorExpression(code, GlobalParent.PyContext.Options.CompilationThreshold, IsAsync) :
-                        (MSAst.Expression)code
 #else
                     (IsGenerator || IsAsync) ?
+#endif
                         (MSAst.Expression)new PythonGeneratorExpression(code, GlobalParent.PyContext.Options.CompilationThreshold, IsAsync) :
                         (MSAst.Expression)code
-#endif
                 );
             } else {
                 ret = Ast.Call(
@@ -695,18 +691,15 @@ namespace IronPython.Compiler.Ast {
             // The exception traceback needs to come from the generator's method body, and so we must do the check and throw
             // from inside the generator.
 #if FEATURE_NET_ASYNC
-            // Async generators have no backing PythonGenerator (they lower to IAsyncEnumerable via
-            // AsyncEnumerableExpression), so skip the $generator.CheckThrowable() prologue for them.
+            // Async generators have no backing PythonGenerator (they lower to IAsyncEnumerable via AsyncEnumerableExpression),
+            // so skip the $generator.CheckThrowable() prologue for them.
             if (IsGenerator && !IsAsync) {
-                MSAst.Expression s1 = YieldExpression.CreateCheckThrowExpression(SourceSpan.None);
-                statements.Add(s1);
-            }
 #else
             if (IsGenerator || IsAsync) {
+#endif
                 MSAst.Expression s1 = YieldExpression.CreateCheckThrowExpression(SourceSpan.None);
                 statements.Add(s1);
             }
-#endif
 
             if (Body.CanThrow && !(Body is SuiteStatement) && Body.StartIndex != -1) {
                 statements.Add(UpdateLineNumber(GlobalParent.IndexToLocation(Body.StartIndex).Line));
@@ -726,16 +719,15 @@ namespace IronPython.Compiler.Ast {
             body = AddReturnTarget(body);
 
 #if FEATURE_NET_ASYNC
-            // Under runtime-async, an `async def` body returns a PythonCoroutine wrapping a
-            // Task<object?>. We pre-allocate a CancellationTokenSource and a StrongBox<Exception?>
-            // here so the same instances are shared with both AsyncExpression (which threads them into
-            // AsyncHelpers.DriveAsync) and PythonCoroutine (which uses them to implement
-            // coro.throw(exc) on a running coroutine: write the exception to the box, cancel the CTS,
-            // and DriveAsync surfaces that exception in place of OperationCanceledException).
+            // Under .NET-async, an `async def` body returns a PythonCoroutine wrapping a Task<object?>.
+            // We pre-allocate a CancellationTokenSource and a StrongBox<Exception?> here
+            // so the same instances are shared with both AsyncExpression, which threads them into AsyncHelpers.DriveAsync
+            // and PythonCoroutine, which uses them to implement coro.throw(exc) on a running coroutine:
+            // write the exception to the box, cancel the CTS, and DriveAsync surfaces that exception in place of OperationCanceledException.
             if (IsAsync) {
-                var cts = MSAst.Expression.Variable(typeof(System.Threading.CancellationTokenSource), "$cts");
-                var excBox = MSAst.Expression.Variable(typeof(System.Runtime.CompilerServices.StrongBox<Exception>), "$cancelExc");
-                var ctToken = MSAst.Expression.Property(cts, nameof(System.Threading.CancellationTokenSource.Token));
+                var cts = MSAst.Expression.Variable(typeof(CancellationTokenSource), "$cts");
+                var excBox = MSAst.Expression.Variable(typeof(StrongBox<Exception>), "$cancelExc");
+                var ctToken = MSAst.Expression.Property(cts, nameof(CancellationTokenSource.Token));
                 if (IsGenerator) {
                     // Async generator: the body has both `await` and `yield`. Lower it to an
                     // IAsyncEnumerable<object?> via AsyncEnumerableExpression, sharing the generator label so
@@ -746,11 +738,11 @@ namespace IronPython.Compiler.Ast {
                     var sendSlot = AsyncSendSlot;
                     var throwSlot = AsyncThrowSlot;
                     body = MSAst.Expression.Block(
-                        new[] { cts, excBox, sendSlot, throwSlot },
-                        MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(System.Threading.CancellationTokenSource))),
-                        MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
-                        MSAst.Expression.Assign(sendSlot, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<object>))),
-                        MSAst.Expression.Assign(throwSlot, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
+                        [cts, excBox, sendSlot, throwSlot],
+                        MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(CancellationTokenSource))),
+                        MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(StrongBox<Exception>))),
+                        MSAst.Expression.Assign(sendSlot, MSAst.Expression.New(typeof(StrongBox<object>))),
+                        MSAst.Expression.Assign(throwSlot, MSAst.Expression.New(typeof(StrongBox<Exception>))),
                         Ast.Call(
                             AstMethods.MakeAsyncGenerator,
                             _functionParam,
@@ -760,19 +752,18 @@ namespace IronPython.Compiler.Ast {
                             cts));
                 } else {
                     // Plain async def: the body returns a PythonCoroutine wrapping a Task<object?>.
-                    // Lazy start: hand MakeAsyncCoroutine a thunk (Func<Task<object?>>) instead of an
-                    // already-running Task, so the body doesn't execute until the coroutine is first driven
-                    // (send/AsTask). This makes calling an async def side-effect-free (PEP 492) and lets the
-                    // body's first await capture the driver's SynchronizationContext rather than whatever
-                    // context happened to be current at construction.
+                    // Lazy start: hand MakeAsyncCoroutine a thunk (Func<Task<object?>>) instead of an already-running Task,
+                    // so the body doesn't execute until the coroutine is first driven (send/AsTask).
+                    // This makes calling an async def side-effect-free (PEP 492) and lets the body's first await capture the driver's SynchronizationContext
+                    // rather than whatever context happened to be current at construction.
                     body = MSAst.Expression.Block(
-                        new[] { cts, excBox },
-                        MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(System.Threading.CancellationTokenSource))),
-                        MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(System.Runtime.CompilerServices.StrongBox<Exception>))),
+                        [cts, excBox],
+                        MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(CancellationTokenSource))),
+                        MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(StrongBox<Exception>))),
                         Ast.Call(
                             AstMethods.MakeAsyncCoroutine,
                             _functionParam,
-                            MSAst.Expression.Lambda<Func<System.Threading.Tasks.Task<object>>>(
+                            MSAst.Expression.Lambda<Func<Task<object>>>(
                                 AstUtils.Async(Name, body, ctToken, excBox)),
                             cts,
                             excBox));

--- a/src/core/IronPython/Compiler/Ast/ReturnStatement.cs
+++ b/src/core/IronPython/Compiler/Ast/ReturnStatement.cs
@@ -17,6 +17,15 @@ namespace IronPython.Compiler.Ast {
 
         public override MSAst.Expression Reduce() {
             if (Parent.IsGeneratorMethod) {
+#if FEATURE_NET_ASYNC
+                // An async generator (`async def` with `yield`) lowers through the DLR generator via
+                // AsyncEnumerableExpression, which doesn't understand IronPython's -2 "generator-return"
+                // marker. `return` there is always bare (`return value` is a SyntaxError in async
+                // generators) and simply ends the async iteration — map it to a YieldBreak.
+                if (Parent is FunctionDefinition { IsAsync: true }) {
+                    return GlobalParent.AddDebugInfo(AstUtils.YieldBreak(GeneratorLabel), Span);
+                }
+#endif
                 // Reduce to a yield return with a marker of -2, this will be interpreted as a yield break with a return value
                 return GlobalParent.AddDebugInfo(AstUtils.YieldReturn(GeneratorLabel, TransformOrConstantNull(Expression, typeof(object)), -2), Span);
             }

--- a/src/core/IronPython/Compiler/Ast/ReturnStatement.cs
+++ b/src/core/IronPython/Compiler/Ast/ReturnStatement.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 using MSAst = System.Linq.Expressions;
 
 namespace IronPython.Compiler.Ast {
@@ -18,11 +20,12 @@ namespace IronPython.Compiler.Ast {
         public override MSAst.Expression Reduce() {
             if (Parent.IsGeneratorMethod) {
 #if FEATURE_NET_ASYNC
-                // An async generator (`async def` with `yield`) lowers through the DLR generator via
-                // AsyncEnumerableExpression, which doesn't understand IronPython's -2 "generator-return"
-                // marker. `return` there is always bare (`return value` is a SyntaxError in async
-                // generators) and simply ends the async iteration — map it to a YieldBreak.
+                // An async generator (`async def` with `yield`) lowers through the DLR generator via AsyncEnumerableExpression,
+                // which doesn't understand IronPython's -2 "generator-return" marker.
+                // `return` there is always bare (`return value` is a SyntaxError in async generators)
+                // and simply ends the async iteration — map it to a YieldBreak without a value.
                 if (Parent is FunctionDefinition { IsAsync: true }) {
+                    Debug.Assert(Expression == null, "async generators should not have a return value");
                     return GlobalParent.AddDebugInfo(AstUtils.YieldBreak(GeneratorLabel), Span);
                 }
 #endif

--- a/src/core/IronPython/Compiler/Ast/YieldExpression.cs
+++ b/src/core/IronPython/Compiler/Ast/YieldExpression.cs
@@ -7,6 +7,8 @@
 using MSAst = System.Linq.Expressions;
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Diagnostics;
 using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
@@ -21,9 +23,9 @@ namespace IronPython.Compiler.Ast {
     public class YieldExpression : Expression {
 #if FEATURE_NET_ASYNC
         private static readonly System.Reflection.MethodInfo s_captureMethod
-            = typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo).GetMethod(nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture))!;
+            = typeof(ExceptionDispatchInfo).GetMethod(nameof(ExceptionDispatchInfo.Capture))!;
         private static readonly System.Reflection.MethodInfo s_throwMethod
-            = typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo).GetMethod(nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw), Type.EmptyTypes)!;
+            = typeof(ExceptionDispatchInfo).GetMethod(nameof(ExceptionDispatchInfo.Throw), Type.EmptyTypes)!;
 #endif
 
         public YieldExpression(Expression? expression) {
@@ -53,11 +55,11 @@ namespace IronPython.Compiler.Ast {
             MSAst.Expression yieldValue = Expression == null ? AstUtils.Constant(null) : AstUtils.Convert(Expression, typeof(object));
 
 #if FEATURE_NET_ASYNC
-            // An async generator (`async def` with `yield`) is lowered via AsyncEnumerableExpression and has no
-            // backing PythonGenerator, so there is no `$generator` to call CheckThrowable() on. Instead the
-            // resume reads two per-generator cells that PythonAsyncGenerator writes before advancing:
-            //   AsyncThrowSlot — if set (athrow/aclose), rethrow it here (preserving stack); cleared first so a
-            //                    body that catches it and yields again doesn't re-throw on the next resume.
+            // An async generator (`async def` with `yield`) is lowered via AsyncEnumerableExpression
+            // and has no backing PythonGenerator, so there is no `$generator` to call CheckThrowable() on.
+            // Instead the resume reads two per-generator cells that PythonAsyncGenerator writes before advancing:
+            //   AsyncThrowSlot — if set (athrow/aclose), rethrow it here (preserving stack);
+            //                    cleared first so a body that catches it and yields again doesn't re-throw on the next resume.
             //   AsyncSendSlot  — the value of the yield expression: the asend(v) value, or None.
             if (Parent is FunctionDefinition { IsAsync: true } fd) {
                 MSAst.ParameterExpression sendSlot = fd.AsyncSendSlot;
@@ -65,14 +67,14 @@ namespace IronPython.Compiler.Ast {
                 MSAst.ParameterExpression pending = Ast.Variable(typeof(Exception), "$athrow");
                 return Ast.Block(
                     typeof(object),
-                    new[] { pending },
+                    [pending],
                     AstUtils.YieldReturn(GeneratorLabel, yieldValue),
-                    Ast.Assign(pending, Ast.Field(throwSlot, nameof(System.Runtime.CompilerServices.StrongBox<Exception>.Value))),
-                    Ast.Assign(Ast.Field(throwSlot, nameof(System.Runtime.CompilerServices.StrongBox<Exception>.Value)), Ast.Constant(null, typeof(Exception))),
+                    Ast.Assign(pending, Ast.Field(throwSlot, nameof(StrongBox<Exception>.Value))),
+                    Ast.Assign(Ast.Field(throwSlot, nameof(StrongBox<Exception>.Value)), Ast.Constant(null, typeof(Exception))),
                     Ast.IfThen(
                         Ast.ReferenceNotEqual(pending, Ast.Constant(null, typeof(Exception))),
                         Ast.Call(Ast.Call(s_captureMethod, pending), s_throwMethod)),
-                    Ast.Field(sendSlot, nameof(System.Runtime.CompilerServices.StrongBox<object>.Value))
+                    Ast.Field(sendSlot, nameof(StrongBox<object>.Value))
                 );
             }
 #endif

--- a/src/core/IronPython/Compiler/Ast/YieldExpression.cs
+++ b/src/core/IronPython/Compiler/Ast/YieldExpression.cs
@@ -19,6 +19,13 @@ namespace IronPython.Compiler.Ast {
     //    x = yield z
     // The return value (x) is provided by calling Generator.Send()
     public class YieldExpression : Expression {
+#if FEATURE_NET_ASYNC
+        private static readonly System.Reflection.MethodInfo s_captureMethod
+            = typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo).GetMethod(nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture))!;
+        private static readonly System.Reflection.MethodInfo s_throwMethod
+            = typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo).GetMethod(nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw), Type.EmptyTypes)!;
+#endif
+
         public YieldExpression(Expression? expression) {
             Expression = expression;
         }
@@ -43,16 +50,40 @@ namespace IronPython.Compiler.Ast {
         }
 
         public override MSAst.Expression Reduce() {
+            MSAst.Expression yieldValue = Expression == null ? AstUtils.Constant(null) : AstUtils.Convert(Expression, typeof(object));
+
+#if FEATURE_NET_ASYNC
+            // An async generator (`async def` with `yield`) is lowered via AsyncEnumerableExpression and has no
+            // backing PythonGenerator, so there is no `$generator` to call CheckThrowable() on. Instead the
+            // resume reads two per-generator cells that PythonAsyncGenerator writes before advancing:
+            //   AsyncThrowSlot — if set (athrow/aclose), rethrow it here (preserving stack); cleared first so a
+            //                    body that catches it and yields again doesn't re-throw on the next resume.
+            //   AsyncSendSlot  — the value of the yield expression: the asend(v) value, or None.
+            if (Parent is FunctionDefinition { IsAsync: true } fd) {
+                MSAst.ParameterExpression sendSlot = fd.AsyncSendSlot;
+                MSAst.ParameterExpression throwSlot = fd.AsyncThrowSlot;
+                MSAst.ParameterExpression pending = Ast.Variable(typeof(Exception), "$athrow");
+                return Ast.Block(
+                    typeof(object),
+                    new[] { pending },
+                    AstUtils.YieldReturn(GeneratorLabel, yieldValue),
+                    Ast.Assign(pending, Ast.Field(throwSlot, nameof(System.Runtime.CompilerServices.StrongBox<Exception>.Value))),
+                    Ast.Assign(Ast.Field(throwSlot, nameof(System.Runtime.CompilerServices.StrongBox<Exception>.Value)), Ast.Constant(null, typeof(Exception))),
+                    Ast.IfThen(
+                        Ast.ReferenceNotEqual(pending, Ast.Constant(null, typeof(Exception))),
+                        Ast.Call(Ast.Call(s_captureMethod, pending), s_throwMethod)),
+                    Ast.Field(sendSlot, nameof(System.Runtime.CompilerServices.StrongBox<object>.Value))
+                );
+            }
+#endif
+
             // (yield z) becomes:
             // .comma (1) {
             //    .void ( .yield_statement (_expression) ),
-            //    $gen.CheckThrowable() // <-- has return result from send            
+            //    $gen.CheckThrowable() // <-- has return result from send
             //  }
             return Ast.Block(
-                AstUtils.YieldReturn(
-                    GeneratorLabel,
-                    Expression == null ? AstUtils.Constant(null) : AstUtils.Convert(Expression, typeof(object))
-                ),
+                AstUtils.YieldReturn(GeneratorLabel, yieldValue),
                 CreateCheckThrowExpression(Span) // emits ($gen.CheckThrowable())
             );
         }

--- a/src/core/IronPython/Compiler/Parser.cs
+++ b/src/core/IronPython/Compiler/Parser.cs
@@ -2000,11 +2000,10 @@ namespace IronPython.Compiler {
                     ReportSyntaxError("'await' outside async function");
                 }
 #if !FEATURE_NET_ASYNC
-                // Under the async-generator path, `await` desugars to `yield from`, so the
-                // enclosing function must be marked a generator. Under FEATURE_NET_ASYNC
-                // the body is lowered through AsyncExpression and is *not*
-                // a Python generator — leaving IsGenerator false here is what keeps
-                // ReturnStatement out of the yield branch.
+                // Under the generator-based async path, `await` desugars to `yield from`,
+                // so the enclosing function must be marked a generator.
+                // Under FEATURE_NET_ASYNC, the body is lowered through AsyncExpression and is *not* a Python generator
+                // so this mark assignment is being skipped here.
                 if (current is not null) {
                     current.IsGenerator = true;
                     current.GeneratorStop = GeneratorStop;

--- a/src/core/IronPython/Compiler/Parser.cs
+++ b/src/core/IronPython/Compiler/Parser.cs
@@ -1999,10 +1999,17 @@ namespace IronPython.Compiler {
                 if (current is null || !current.IsAsync) {
                     ReportSyntaxError("'await' outside async function");
                 }
+#if !FEATURE_NET_ASYNC
+                // Under the async-generator path, `await` desugars to `yield from`, so the
+                // enclosing function must be marked a generator. Under FEATURE_NET_ASYNC
+                // the body is lowered through AsyncExpression and is *not*
+                // a Python generator — leaving IsGenerator false here is what keeps
+                // ReturnStatement out of the yield branch.
                 if (current is not null) {
                     current.IsGenerator = true;
                     current.GeneratorStop = GeneratorStop;
                 }
+#endif
             }
 
             Expression ret = ParseAtom();

--- a/src/core/IronPython/Runtime/AsyncGenerator.cs
+++ b/src/core/IronPython/Runtime/AsyncGenerator.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+#if FEATURE_NET_ASYNC
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Scripting.Runtime;
+
+using IronPython.Runtime.Exceptions;
+using IronPython.Runtime.Operations;
+using IronPython.Runtime.Types;
+
+namespace IronPython.Runtime {
+    /// <summary>
+    /// PEP 525 async generator object — what an <c>async def</c> with <c>yield</c> returns.
+    /// Façade over the DLR's <c>IAsyncEnumerable&lt;object&gt;</c> (produced by AsyncEnumerableExpression /
+    /// AsyncHelpers.DriveAsyncEnumerable) plus the channels that let the consumer drive it:
+    /// <list type="bullet">
+    ///   <item><c>_sendSlot</c> — the value delivered into the body at the next <c>yield</c> resume
+    ///   (<c>x = yield z</c>). Set by <see cref="asend"/> / <see cref="__anext__"/> before advancing.</item>
+    ///   <item><c>_throwSlot</c> — an exception rethrown at the next <c>yield</c> resume (athrow/aclose).</item>
+    ///   <item><c>_cts</c> — backs the underlying enumerator's cancellation.</item>
+    /// </list>
+    /// </summary>
+    [PythonType("async_generator")]
+    public sealed class PythonAsyncGenerator {
+        private readonly IAsyncEnumerator<object?> _enumerator;
+        private readonly StrongBox<object?> _sendSlot;
+        private readonly StrongBox<Exception?> _throwSlot;
+        private readonly CancellationTokenSource _cts;
+        private readonly string _name;
+        private bool _started;
+        private bool _closed;
+
+        internal PythonAsyncGenerator(IAsyncEnumerable<object?> source,
+                                       StrongBox<object?> sendSlot,
+                                       StrongBox<Exception?> throwSlot,
+                                       CancellationTokenSource cts,
+                                       string name) {
+            _enumerator = source.GetAsyncEnumerator(cts.Token);
+            _sendSlot = sendSlot;
+            _throwSlot = throwSlot;
+            _cts = cts;
+            _name = name;
+        }
+
+        public PythonAsyncGenerator __aiter__() => this;
+
+        /// <summary>
+        /// Advance the generator with no value sent in (equivalent to <c>asend(None)</c>). Returns an
+        /// awaitable yielding the next produced value or raising StopAsyncIteration.
+        /// </summary>
+        public object __anext__() {
+            _sendSlot.Value = null;
+            return new AsyncEnumeratorAwaitable<object?>(_enumerator);
+        }
+
+        /// <summary>
+        /// Send a value into the generator; it becomes the value of the <c>yield</c> the body is suspended
+        /// at (<c>x = yield z</c>). The first call after creation must send None (the body hasn't reached a
+        /// yield yet), matching CPython.
+        /// </summary>
+        public object asend(object? value) {
+            if (!_started) {
+                _started = true;
+                if (value is not null) {
+                    throw PythonOps.TypeError("can't send non-None value to a just-started async generator");
+                }
+            }
+            _sendSlot.Value = value;
+            return new AsyncEnumeratorAwaitable<object?>(_enumerator);
+        }
+
+        [LightThrowing]
+        public object athrow(object? type) => athrow(type, null, null);
+
+        [LightThrowing]
+        public object athrow(object? type, object? value) => athrow(type, value, null);
+
+        /// <summary>
+        /// Throw an exception into the generator at the suspended <c>yield</c>. Returns an awaitable; when
+        /// awaited the exception is rethrown at the resume point — if the body catches it and yields again
+        /// that value is produced, otherwise the exception propagates (or StopAsyncIteration if the body
+        /// finishes).
+        /// </summary>
+        [LightThrowing]
+        public object athrow(object? type, object? value, object? traceback) {
+            // Validate shape (mirrors PythonGenerator/PythonCoroutine.throw).
+            if (type is Exception || type is PythonExceptions.BaseException) {
+                if (value is not null)
+                    return LightExceptions.Throw(PythonOps.TypeError("instance exception may not have a separate value"));
+            } else if (type is PythonType pt && typeof(PythonExceptions.BaseException).IsAssignableFrom(pt.UnderlyingSystemType)) {
+                // ok — class form
+            } else {
+                return LightExceptions.Throw(PythonOps.TypeError(
+                    "exceptions must be classes or instances deriving from BaseException, not {0}",
+                    PythonOps.GetPythonTypeName(type)));
+            }
+
+            Exception ex = PythonOps.MakeExceptionForGenerator(DefaultContext.Default, type, value, traceback, cause: null);
+            _started = true;
+            _throwSlot.Value = ex;
+            _sendSlot.Value = null;
+            return new AsyncEnumeratorAwaitable<object?>(_enumerator);
+        }
+
+        /// <summary>
+        /// Close the generator: returns an awaitable that injects GeneratorExit at the suspended <c>yield</c>
+        /// (running the body's try/finally), then disposes the underlying async iterator. Idempotent.
+        /// </summary>
+        public object aclose() {
+            return AcloseAsync();
+        }
+
+        private async Task<object?> AcloseAsync() {
+            if (_closed) return null;
+            _closed = true;
+            if (_started) {
+                _throwSlot.Value = new GeneratorExitException();
+                _sendSlot.Value = null;
+                try {
+                    bool produced = await _enumerator.MoveNextAsync();
+                    if (produced) {
+                        throw PythonOps.RuntimeError("async generator ignored GeneratorExit");
+                    }
+                } catch (GeneratorExitException) {
+                    // expected — the body let GeneratorExit propagate
+                } catch (StopIterationException) {
+                    // body finished — also fine
+                }
+            }
+            await _enumerator.DisposeAsync();
+            _cts.Cancel();
+            return null;
+        }
+
+        public string __name__ => _name;
+
+        public string __qualname__ => _name;
+
+        public bool ag_running => _started && !_closed;
+    }
+}
+
+#endif

--- a/src/core/IronPython/Runtime/AsyncGenerator.cs
+++ b/src/core/IronPython/Runtime/AsyncGenerator.cs
@@ -85,7 +85,7 @@ namespace IronPython.Runtime {
 
 
         [LightThrowing]
-        public object athrow(object? type) => athrow(type, null, null);
+        public object athrow(object? value) => athrow(value, null, null);
 
         [LightThrowing]
         public object athrow(object? type, object? value) => athrow(type, value, null);
@@ -97,6 +97,9 @@ namespace IronPython.Runtime {
         ///   When awaited the exception is rethrown at the resume point:
         ///   if the body catches it and yields again that value is produced;
         ///   otherwise the exception propagates (or StopAsyncIteration if the body finishes).
+        ///   <br/>
+        ///   Changed in CPython 3.12: The signature (type[, value[, traceback]]) is deprecated
+        ///   and may be removed in a future version of Python.
         /// </remarks>
         [LightThrowing]
         public object athrow(object? type, object? value, object? traceback) {

--- a/src/core/IronPython/Runtime/AsyncGenerator.cs
+++ b/src/core/IronPython/Runtime/AsyncGenerator.cs
@@ -20,16 +20,18 @@ using IronPython.Runtime.Types;
 
 namespace IronPython.Runtime {
     /// <summary>
-    /// PEP 525 async generator object — what an <c>async def</c> with <c>yield</c> returns.
-    /// Façade over the DLR's <c>IAsyncEnumerable&lt;object&gt;</c> (produced by AsyncEnumerableExpression /
-    /// AsyncHelpers.DriveAsyncEnumerable) plus the channels that let the consumer drive it:
-    /// <list type="bullet">
-    ///   <item><c>_sendSlot</c> — the value delivered into the body at the next <c>yield</c> resume
-    ///   (<c>x = yield z</c>). Set by <see cref="asend"/> / <see cref="__anext__"/> before advancing.</item>
-    ///   <item><c>_throwSlot</c> — an exception rethrown at the next <c>yield</c> resume (athrow/aclose).</item>
-    ///   <item><c>_cts</c> — backs the underlying enumerator's cancellation.</item>
-    /// </list>
+    ///   PEP 525 async generator object — what an <c>async def</c> with <c>yield</c> returns.
     /// </summary>
+    /// <remarks>
+    ///   Wrapper over the DLR's <c>IAsyncEnumerable&lt;object&gt;</c> (produced by AsyncEnumerableExpression /
+    ///   AsyncHelpers.DriveAsyncEnumerable) plus the channels that let the consumer drive it:
+    ///   <list type="bullet">
+    ///     <item><c>_sendSlot</c> — the value delivered into the body at the next <c>yield</c> resume
+    ///       (<c>x = yield z</c>). Set by <see cref="asend"/> / <see cref="__anext__"/> before advancing.</item>
+    ///     <item><c>_throwSlot</c> — an exception rethrown at the next <c>yield</c> resume (athrow/aclose).</item>
+    ///     <item><c>_cts</c> — backs the underlying enumerator's cancellation.</item>
+    ///   </list>
+    /// </remarks>
     [PythonType("async_generator")]
     public sealed class PythonAsyncGenerator {
         private readonly IAsyncEnumerator<object?> _enumerator;
@@ -54,19 +56,21 @@ namespace IronPython.Runtime {
 
         public PythonAsyncGenerator __aiter__() => this;
 
+
         /// <summary>
-        /// Advance the generator with no value sent in (equivalent to <c>asend(None)</c>). Returns an
-        /// awaitable yielding the next produced value or raising StopAsyncIteration.
+        ///   Advance the generator with no value sent in (equivalent to <c>asend(None)</c>).
+        ///   Returns an awaitable yielding the next produced value or raising StopAsyncIteration.
         /// </summary>
         public object __anext__() {
             _sendSlot.Value = null;
             return new AsyncEnumeratorAwaitable<object?>(_enumerator);
         }
 
+
         /// <summary>
-        /// Send a value into the generator; it becomes the value of the <c>yield</c> the body is suspended
-        /// at (<c>x = yield z</c>). The first call after creation must send None (the body hasn't reached a
-        /// yield yet), matching CPython.
+        ///   Send a value into the generator; it becomes the value of the <c>yield</c> the body is suspended
+        ///   at (<c>x = yield z</c>). The first call after creation must send None (the body hasn't reached a
+        ///   yield yet), matching CPython.
         /// </summary>
         public object asend(object? value) {
             if (!_started) {
@@ -79,6 +83,7 @@ namespace IronPython.Runtime {
             return new AsyncEnumeratorAwaitable<object?>(_enumerator);
         }
 
+
         [LightThrowing]
         public object athrow(object? type) => athrow(type, null, null);
 
@@ -86,11 +91,13 @@ namespace IronPython.Runtime {
         public object athrow(object? type, object? value) => athrow(type, value, null);
 
         /// <summary>
-        /// Throw an exception into the generator at the suspended <c>yield</c>. Returns an awaitable; when
-        /// awaited the exception is rethrown at the resume point — if the body catches it and yields again
-        /// that value is produced, otherwise the exception propagates (or StopAsyncIteration if the body
-        /// finishes).
+        ///   Throw an exception into the generator at the suspended <c>yield</c>. Returns an awaitable.
         /// </summary>
+        /// <remarks>
+        ///   When awaited the exception is rethrown at the resume point:
+        ///   if the body catches it and yields again that value is produced;
+        ///   otherwise the exception propagates (or StopAsyncIteration if the body finishes).
+        /// </remarks>
         [LightThrowing]
         public object athrow(object? type, object? value, object? traceback) {
             // Validate shape (mirrors PythonGenerator/PythonCoroutine.throw).
@@ -113,8 +120,8 @@ namespace IronPython.Runtime {
         }
 
         /// <summary>
-        /// Close the generator: returns an awaitable that injects GeneratorExit at the suspended <c>yield</c>
-        /// (running the body's try/finally), then disposes the underlying async iterator. Idempotent.
+        ///   Close the generator: returns an awaitable that injects GeneratorExit at the suspended <c>yield</c>
+        ///   (running the body's try/finally), then disposes the underlying async iterator.
         /// </summary>
         public object aclose() {
             return AcloseAsync();

--- a/src/core/IronPython/Runtime/Coroutine.cs
+++ b/src/core/IronPython/Runtime/Coroutine.cs
@@ -31,22 +31,33 @@ namespace IronPython.Runtime {
         //                            at cancellation time, that exception is surfaced
         //                            to the body instead of OperationCanceledException.
         //                            throw(non-OCE) writes here before cancelling.
-        private readonly Task<object?> _task;
+        //
+        // Lazy start: the body is not executed at construction. _factory is the thunk
+        // that creates (and thereby starts driving) the Task on first access; _task
+        // caches the materialized Task. Calling an async def is therefore side-effect
+        // free until the coroutine is first driven (send/AsTask/GetAwaiter) — PEP 492.
+        private readonly Func<Task<object?>> _factory;
+        private Task<object?>? _task;
         private readonly string _name;
         private readonly FunctionCode? _code;
         private readonly CancellationTokenSource _cts;
         private readonly StrongBox<Exception?> _cancellationException;
         private WeakRefTracker? _tracker;
 
-        internal PythonCoroutine(Task<object?> task, string name, FunctionCode? code,
+        internal PythonCoroutine(Func<Task<object?>> factory, string name, FunctionCode? code,
                                   CancellationTokenSource cts,
                                   StrongBox<Exception?> cancellationException) {
-            _task = task;
+            _factory = factory;
             _name = name;
             _code = code;
             _cts = cts;
             _cancellationException = cancellationException;
         }
+
+        /// <summary>
+        /// Materialize (and start) the underlying Task on first access, caching it thereafter.
+        /// </summary>
+        private Task<object?> EnsureTask() => _task ??= _factory();
 
         [LightThrowing]
         public object send(object? value) {
@@ -58,18 +69,20 @@ namespace IronPython.Runtime {
             // not pay for exception unwinding (GetAwaiter().GetResult() would observe
             // and rethrow cancel/fault). After waiting, the same terminal-state
             // dispatch below applies.
-            if (!_task.IsCompleted) {
-                ((IAsyncResult)_task).AsyncWaitHandle.WaitOne();
+            var task = EnsureTask();
+            if (!task.IsCompleted) {
+                // TODO: coroutines should be steppable via send(), one await at a time.
+                ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
             }
-            if (_task.IsCanceled) {
+            if (task.IsCanceled) {
                 // Surfaces as Python CancelledError via the OCE -> CancelledError mapping in PythonExceptions.
                 // We need an OperationCanceledException instance because the Canceled task carries no Exception object.
-                return LightExceptions.Throw(new TaskCanceledException(_task));
+                return LightExceptions.Throw(new TaskCanceledException(task));
             }
-            if (_task.IsFaulted) {
-                return LightExceptions.Throw(_task.Exception?.InnerException ?? _task.Exception);
+            if (task.IsFaulted) {
+                return LightExceptions.Throw(task.Exception?.InnerException ?? task.Exception);
             }
-            return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(_task.Result!));
+            return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(task.Result!));
         }
 
         [LightThrowing]
@@ -99,7 +112,8 @@ namespace IronPython.Runtime {
             Exception ex = PythonOps.MakeExceptionForGenerator(
                 DefaultContext.Default, type, value, traceback, cause: null);
 
-            if (_task.IsCompleted) {
+            var task = EnsureTask();
+            if (task.IsCompleted) {
                 // Regime 1: coroutine has finished. throw() raises the exception immediately —
                 // the body has nothing left to observe it. Matches CPython.
                 return LightExceptions.Throw(ex);
@@ -115,18 +129,19 @@ namespace IronPython.Runtime {
             // Wait for the body to settle. After this the task is in a terminal state — dispatch via
             // the same logic as send() so the body's reaction (catch-and-return, propagate, etc.) is
             // reflected back to the caller of throw().
-            ((IAsyncResult)_task).AsyncWaitHandle.WaitOne();
+            ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
             return SettleCompletedTask();
         }
 
         private object SettleCompletedTask() {
-            if (_task.IsCanceled) {
-                return LightExceptions.Throw(new TaskCanceledException(_task));
+            var task = EnsureTask();
+            if (task.IsCanceled) {
+                return LightExceptions.Throw(new TaskCanceledException(task));
             }
-            if (_task.IsFaulted) {
-                return LightExceptions.Throw(_task.Exception?.InnerException ?? _task.Exception);
+            if (task.IsFaulted) {
+                return LightExceptions.Throw(task.Exception?.InnerException ?? task.Exception);
             }
-            return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(_task.Result!));
+            return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(task.Result!));
         }
 
         [LightThrowing]
@@ -136,7 +151,9 @@ namespace IronPython.Runtime {
 
         public FunctionCode? cr_code => _code;
 
-        public int cr_running => _task.IsCompleted ? 0 : 1;
+        // A not-yet-driven coroutine reports 0 (not running) without materializing the
+        // Task — merely inspecting cr_running must not start the body.
+        public int cr_running => _task is null || _task.IsCompleted ? 0 : 1;
 
         public TraceBackFrame? cr_frame => null;
 
@@ -144,13 +161,13 @@ namespace IronPython.Runtime {
 
         public string __qualname__ => _name;
 
-        /// <summary>Returns the underlying <see cref="Task{Object}"/>.</summary>
-        public Task<object?> AsTask() => _task;
+        /// <summary>Returns the underlying <see cref="Task{Object}"/>, starting the body on first call.</summary>
+        public Task<object?> AsTask() => EnsureTask();
 
         /// <summary>Enables <c>await coroutine</c> from C# code.</summary>
-        public TaskAwaiter<object?> GetAwaiter() => _task.GetAwaiter();
+        public TaskAwaiter<object?> GetAwaiter() => EnsureTask().GetAwaiter();
 
-        internal Task<object?> Task => _task;
+        internal Task<object?> Task => EnsureTask();
 #else
     [PythonType("coroutine")]
     [DontMapIDisposableToContextManager, DontMapIEnumerableToContains]

--- a/src/core/IronPython/Runtime/Coroutine.cs
+++ b/src/core/IronPython/Runtime/Coroutine.cs
@@ -16,26 +16,23 @@ using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
 
 namespace IronPython.Runtime {
+
 #if FEATURE_NET_ASYNC
+
     [PythonType("coroutine")]
     [DontMapIDisposableToContextManager, DontMapIEnumerableToContains]
     public sealed class PythonCoroutine : ICodeFormattable, IWeakReferenceable {
-        // Under .NET async, `async def` is compiled directly to a Task<object?>
-        // via the DLR's AsyncExpression + AsyncHelpers. PythonCoroutine is a
-        // facade over the Task with two cancellation channels pre-bound at the
-        // codegen level (see FunctionDefinition):
-        //   _cts                  — CancellationTokenSource whose Token was passed
-        //                            into AsyncExpression. throw(exc) cancels this.
-        //   _cancellationException — StrongBox<Exception?> shared with DriveAsync's
-        //                            `cancellationException` parameter; when non-null
-        //                            at cancellation time, that exception is surfaced
-        //                            to the body instead of OperationCanceledException.
-        //                            throw(non-OCE) writes here before cancelling.
+        // Under .NET async, `async def` is compiled directly to a Task<object?> via the DLR's AsyncExpression + AsyncHelpers.
+        // PythonCoroutine is a wrapper over the Task with two cancellation channels pre-bound at the codegen level:
         //
-        // Lazy start: the body is not executed at construction. _factory is the thunk
-        // that creates (and thereby starts driving) the Task on first access; _task
-        // caches the materialized Task. Calling an async def is therefore side-effect
-        // free until the coroutine is first driven (send/AsTask/GetAwaiter) — PEP 492.
+        //   _cts                   — CancellationTokenSource whose Token was passed into AsyncExpression. throw(exc) cancels this.
+        //   _cancellationException — StrongBox<Exception?> shared with DriveAsync's `cancellationException` parameter;
+        //                            when non-null at cancellation time, that exception is surfaced to the body
+        //                            instead of OperationCanceledException. 
+        //
+        // Lazy start: the body is not executed at construction. _factory is the thunk that creates (and thereby starts driving) the Task on
+        // first access; _task caches the materialized Task. Calling an async def is therefore side-effect free until the coroutine is first
+        // driven (send/AsTask/GetAwaiter) — PEP 492.
         private readonly Func<Task<object?>> _factory;
         private Task<object?>? _task;
         private readonly string _name;
@@ -54,10 +51,8 @@ namespace IronPython.Runtime {
             _cancellationException = cancellationException;
         }
 
-        /// <summary>
-        /// Materialize (and start) the underlying Task on first access, caching it thereafter.
-        /// </summary>
         private Task<object?> EnsureTask() => _task ??= _factory();
+
 
         [LightThrowing]
         public object send(object? value) {
@@ -69,21 +64,16 @@ namespace IronPython.Runtime {
             // not pay for exception unwinding (GetAwaiter().GetResult() would observe
             // and rethrow cancel/fault). After waiting, the same terminal-state
             // dispatch below applies.
+
             var task = EnsureTask();
             if (!task.IsCompleted) {
                 // TODO: coroutines should be steppable via send(), one await at a time.
                 ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
             }
-            if (task.IsCanceled) {
-                // Surfaces as Python CancelledError via the OCE -> CancelledError mapping in PythonExceptions.
-                // We need an OperationCanceledException instance because the Canceled task carries no Exception object.
-                return LightExceptions.Throw(new TaskCanceledException(task));
-            }
-            if (task.IsFaulted) {
-                return LightExceptions.Throw(task.Exception?.InnerException ?? task.Exception);
-            }
-            return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(task.Result!));
+
+            return SettleCompletedTask(task);
         }
+
 
         [LightThrowing]
         public object @throw(object? type) => @throw(type, null, null);
@@ -114,15 +104,14 @@ namespace IronPython.Runtime {
 
             var task = EnsureTask();
             if (task.IsCompleted) {
-                // Regime 1: coroutine has finished. throw() raises the exception immediately —
+                // Case 1: coroutine has finished. throw() raises the exception immediately —
                 // the body has nothing left to observe it. Matches CPython.
                 return LightExceptions.Throw(ex);
             }
 
-            // Regime 2: body is still running (or suspended at an await). Stash the exception in the
+            // Case 2: body is still running (or suspended at an await). Stash the exception in the
             // shared StrongBox so DriveAsync surfaces it (instead of OCE) the moment it observes the
-            // cancellation, then cancel. The body sees `ex` rethrown at its next resume point via the
-            // rewriter's per-await ExceptionDispatchInfo block.
+            // cancellation, then cancel. The body sees `ex` rethrown at its next resume point.
             _cancellationException.Value = ex;
             _cts.Cancel();
 
@@ -130,12 +119,13 @@ namespace IronPython.Runtime {
             // the same logic as send() so the body's reaction (catch-and-return, propagate, etc.) is
             // reflected back to the caller of throw().
             ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
-            return SettleCompletedTask();
+            return SettleCompletedTask(task);
         }
 
-        private object SettleCompletedTask() {
-            var task = EnsureTask();
+
+        private static object SettleCompletedTask(Task<object?> task) {
             if (task.IsCanceled) {
+                // Surfaces as Python CancelledError via the OCE -> CancelledError mapping in PythonExceptions.
                 return LightExceptions.Throw(new TaskCanceledException(task));
             }
             if (task.IsFaulted) {
@@ -144,6 +134,7 @@ namespace IronPython.Runtime {
             return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(task.Result!));
         }
 
+
         [LightThrowing]
         public object? close() => null;
 
@@ -151,8 +142,8 @@ namespace IronPython.Runtime {
 
         public FunctionCode? cr_code => _code;
 
-        // A not-yet-driven coroutine reports 0 (not running) without materializing the
-        // Task — merely inspecting cr_running must not start the body.
+        // A not-yet-driven coroutine reports 0 (not running) without materializing the Task.
+        // Merely inspecting cr_running must not start the body.
         public int cr_running => _task is null || _task.IsCompleted ? 0 : 1;
 
         public TraceBackFrame? cr_frame => null;
@@ -168,7 +159,9 @@ namespace IronPython.Runtime {
         public TaskAwaiter<object?> GetAwaiter() => EnsureTask().GetAwaiter();
 
         internal Task<object?> Task => EnsureTask();
-#else
+
+#else  // !FEATURE_NET_ASYNC
+
     [PythonType("coroutine")]
     [DontMapIDisposableToContextManager, DontMapIEnumerableToContains]
     public sealed class PythonCoroutine : ICodeFormattable, IWeakReferenceable {
@@ -253,7 +246,8 @@ namespace IronPython.Runtime {
         public TaskAwaiter<object?> GetAwaiter() => AsTask().GetAwaiter();
 
         internal PythonGenerator Generator => _generator;
-#endif
+
+#endif  // FEATURE_NET_ASYNC - the rest of the members are shared between both implementations of PythonCoroutine
 
         #region ICodeFormattable Members
 
@@ -280,6 +274,7 @@ namespace IronPython.Runtime {
 
         #endregion
     }
+
 
     [PythonType("coroutine_wrapper")]
     public sealed class CoroutineWrapper {

--- a/src/core/IronPython/Runtime/Coroutine.cs
+++ b/src/core/IronPython/Runtime/Coroutine.cs
@@ -17,11 +17,12 @@ using IronPython.Runtime.Types;
 
 namespace IronPython.Runtime {
 
-#if FEATURE_NET_ASYNC
-
     [PythonType("coroutine")]
     [DontMapIDisposableToContextManager, DontMapIEnumerableToContains]
     public sealed class PythonCoroutine : ICodeFormattable, IWeakReferenceable {
+
+#if FEATURE_NET_ASYNC
+
         // Under .NET async, `async def` is compiled directly to a Task<object?> via the DLR's AsyncExpression + AsyncHelpers.
         // PythonCoroutine is a wrapper over the Task with two cancellation channels pre-bound at the codegen level:
         //
@@ -76,11 +77,24 @@ namespace IronPython.Runtime {
 
 
         [LightThrowing]
-        public object @throw(object? type) => @throw(type, null, null);
+        public object @throw(object? value) => @throw(value, null, null);
 
         [LightThrowing]
         public object @throw(object? type, object? value) => @throw(type, value, null);
 
+        /// <summary>
+        ///   Throw an exception into the generator at the suspended <c>yield</c>. Returns an awaitable.
+        /// </summary>
+        /// <remarks>
+        ///   When awaited the exception is rethrown at the resume point:
+        ///   if the body catches it and yields again that value is produced;
+        ///   otherwise the exception propagates (or StopAsyncIteration if the body finishes).
+        ///   <br/>
+        ///   In typical use, this is called with a single exception instance similar to the way the raise keyword is used.
+        ///   <br/>
+        ///   Changed in CPython 3.12: The signature (type[, value[, traceback]]) is deprecated
+        ///   and may be removed in a future version of Python.
+        /// </remarks>
         [LightThrowing]
         public object @throw(object? type, object? value, object? traceback) {
             // Validate the shape of (type, value, traceback) up front. Mirrors PythonGenerator.@throw
@@ -162,9 +176,6 @@ namespace IronPython.Runtime {
 
 #else  // !FEATURE_NET_ASYNC
 
-    [PythonType("coroutine")]
-    [DontMapIDisposableToContextManager, DontMapIEnumerableToContains]
-    public sealed class PythonCoroutine : ICodeFormattable, IWeakReferenceable {
         private readonly PythonGenerator _generator;
         private WeakRefTracker? _tracker;
 
@@ -188,6 +199,7 @@ namespace IronPython.Runtime {
         }
 
         [LightThrowing]
+        // The signature (type[, value[, traceback]]) is deprecated in CPython 3.12
         public object @throw(object? type, object? value, object? traceback) {
             return _generator.@throw(type, value, traceback);
         }

--- a/src/core/IronPython/Runtime/Coroutine.cs
+++ b/src/core/IronPython/Runtime/Coroutine.cs
@@ -4,7 +4,9 @@
 
 #nullable enable
 
+using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Scripting.Runtime;
@@ -14,6 +16,142 @@ using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
 
 namespace IronPython.Runtime {
+#if FEATURE_NET_ASYNC
+    [PythonType("coroutine")]
+    [DontMapIDisposableToContextManager, DontMapIEnumerableToContains]
+    public sealed class PythonCoroutine : ICodeFormattable, IWeakReferenceable {
+        // Under .NET async, `async def` is compiled directly to a Task<object?>
+        // via the DLR's AsyncExpression + AsyncHelpers. PythonCoroutine is a
+        // facade over the Task with two cancellation channels pre-bound at the
+        // codegen level (see FunctionDefinition):
+        //   _cts                  — CancellationTokenSource whose Token was passed
+        //                            into AsyncExpression. throw(exc) cancels this.
+        //   _cancellationException — StrongBox<Exception?> shared with DriveAsync's
+        //                            `cancellationException` parameter; when non-null
+        //                            at cancellation time, that exception is surfaced
+        //                            to the body instead of OperationCanceledException.
+        //                            throw(non-OCE) writes here before cancelling.
+        private readonly Task<object?> _task;
+        private readonly string _name;
+        private readonly FunctionCode? _code;
+        private readonly CancellationTokenSource _cts;
+        private readonly StrongBox<Exception?> _cancellationException;
+        private WeakRefTracker? _tracker;
+
+        internal PythonCoroutine(Task<object?> task, string name, FunctionCode? code,
+                                  CancellationTokenSource cts,
+                                  StrongBox<Exception?> cancellationException) {
+            _task = task;
+            _name = name;
+            _code = code;
+            _cts = cts;
+            _cancellationException = cancellationException;
+        }
+
+        [LightThrowing]
+        public object send(object? value) {
+            // Fast path: task already completed. Dispatch on terminal state without
+            // any try/catch — Result on a Faulted/Canceled task throws, so we must
+            // check IsCanceled / IsFaulted before reading it.
+            //
+            // Slow path: not completed. Block via AsyncWaitHandle.WaitOne() so we do
+            // not pay for exception unwinding (GetAwaiter().GetResult() would observe
+            // and rethrow cancel/fault). After waiting, the same terminal-state
+            // dispatch below applies.
+            if (!_task.IsCompleted) {
+                ((IAsyncResult)_task).AsyncWaitHandle.WaitOne();
+            }
+            if (_task.IsCanceled) {
+                // Surfaces as Python CancelledError via the OCE -> CancelledError mapping in PythonExceptions.
+                // We need an OperationCanceledException instance because the Canceled task carries no Exception object.
+                return LightExceptions.Throw(new TaskCanceledException(_task));
+            }
+            if (_task.IsFaulted) {
+                return LightExceptions.Throw(_task.Exception?.InnerException ?? _task.Exception);
+            }
+            return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(_task.Result!));
+        }
+
+        [LightThrowing]
+        public object @throw(object? type) => @throw(type, null, null);
+
+        [LightThrowing]
+        public object @throw(object? type, object? value) => @throw(type, value, null);
+
+        [LightThrowing]
+        public object @throw(object? type, object? value, object? traceback) {
+            // Validate the shape of (type, value, traceback) up front. Mirrors PythonGenerator.@throw
+            // so we don't mutate any state on bad input.
+            if (type is Exception || type is PythonExceptions.BaseException) {
+                if (value is not null)
+                    return LightExceptions.Throw(PythonOps.TypeError("instance exception may not have a separate value"));
+            } else if (type is PythonType pt && typeof(PythonExceptions.BaseException).IsAssignableFrom(pt.UnderlyingSystemType)) {
+                // ok — class form, MakeExceptionForGenerator will construct.
+            } else {
+                return LightExceptions.Throw(PythonOps.TypeError(
+                    "exceptions must be classes or instances deriving from BaseException, not {0}",
+                    PythonOps.GetPythonTypeName(type)));
+            }
+
+            // Construct the actual exception object. DefaultContext.Default suffices here — throw()'s
+            // CodeContext role is limited to resolving class-form exception construction, and the
+            // coroutine's own context will re-bind the chain when the exception unwinds inside the body.
+            Exception ex = PythonOps.MakeExceptionForGenerator(
+                DefaultContext.Default, type, value, traceback, cause: null);
+
+            if (_task.IsCompleted) {
+                // Regime 1: coroutine has finished. throw() raises the exception immediately —
+                // the body has nothing left to observe it. Matches CPython.
+                return LightExceptions.Throw(ex);
+            }
+
+            // Regime 2: body is still running (or suspended at an await). Stash the exception in the
+            // shared StrongBox so DriveAsync surfaces it (instead of OCE) the moment it observes the
+            // cancellation, then cancel. The body sees `ex` rethrown at its next resume point via the
+            // rewriter's per-await ExceptionDispatchInfo block.
+            _cancellationException.Value = ex;
+            _cts.Cancel();
+
+            // Wait for the body to settle. After this the task is in a terminal state — dispatch via
+            // the same logic as send() so the body's reaction (catch-and-return, propagate, etc.) is
+            // reflected back to the caller of throw().
+            ((IAsyncResult)_task).AsyncWaitHandle.WaitOne();
+            return SettleCompletedTask();
+        }
+
+        private object SettleCompletedTask() {
+            if (_task.IsCanceled) {
+                return LightExceptions.Throw(new TaskCanceledException(_task));
+            }
+            if (_task.IsFaulted) {
+                return LightExceptions.Throw(_task.Exception?.InnerException ?? _task.Exception);
+            }
+            return LightExceptions.Throw(new PythonExceptions._StopIteration().InitAndGetClrException(_task.Result!));
+        }
+
+        [LightThrowing]
+        public object? close() => null;
+
+        public object __await__() => new CoroutineWrapper(this);
+
+        public FunctionCode? cr_code => _code;
+
+        public int cr_running => _task.IsCompleted ? 0 : 1;
+
+        public TraceBackFrame? cr_frame => null;
+
+        public string __name__ => _name;
+
+        public string __qualname__ => _name;
+
+        /// <summary>Returns the underlying <see cref="Task{Object}"/>.</summary>
+        public Task<object?> AsTask() => _task;
+
+        /// <summary>Enables <c>await coroutine</c> from C# code.</summary>
+        public TaskAwaiter<object?> GetAwaiter() => _task.GetAwaiter();
+
+        internal Task<object?> Task => _task;
+#else
     [PythonType("coroutine")]
     [DontMapIDisposableToContextManager, DontMapIEnumerableToContains]
     public sealed class PythonCoroutine : ICodeFormattable, IWeakReferenceable {
@@ -98,6 +236,7 @@ namespace IronPython.Runtime {
         public TaskAwaiter<object?> GetAwaiter() => AsTask().GetAwaiter();
 
         internal PythonGenerator Generator => _generator;
+#endif
 
         #region ICodeFormattable Members
 

--- a/src/core/IronPython/Runtime/FunctionCode.cs
+++ b/src/core/IronPython/Runtime/FunctionCode.cs
@@ -751,11 +751,12 @@ namespace IronPython.Runtime {
             );
 
 #if FEATURE_NET_ASYNC
-            // Under runtime-async, Coroutine is informational (kept for
-            // __code__.co_flags) — async function bodies are already lowered
-            // through AsyncExpression and must not go through the
-            // generator rewriter here.
-            if ((Flags & FunctionAttributes.Generator) == 0) {
+            // Under runtime-async, async bodies are lowered before they reach here and must NOT go through
+            // the generator rewriter: plain async (Coroutine, no Generator) via AsyncExpression, and async
+            // generators (Generator+Coroutine) via AsyncEnumerableExpression. Only a plain generator
+            // (Generator without Coroutine) is rewritten here. Coroutine is otherwise informational
+            // (kept for __code__.co_flags).
+            if ((Flags & FunctionAttributes.Generator) == 0 || (Flags & FunctionAttributes.Coroutine) != 0) {
 #else
             if ((Flags & (FunctionAttributes.Generator | FunctionAttributes.Coroutine)) == 0) {
 #endif
@@ -794,7 +795,9 @@ namespace IronPython.Runtime {
         private LightLambdaExpression GetGeneratorOrNormalLambda() {
             LightLambdaExpression finalCode;
 #if FEATURE_NET_ASYNC
-            if ((Flags & FunctionAttributes.Generator) == 0) {
+            // See GetGeneratorOrNormalLambda's sibling in MakeDebuggableFunctionCode: only a plain generator
+            // (Generator without Coroutine) is rewritten; plain async and async generators are lowered earlier.
+            if ((Flags & FunctionAttributes.Generator) == 0 || (Flags & FunctionAttributes.Coroutine) != 0) {
 #else
             if ((Flags & (FunctionAttributes.Generator | FunctionAttributes.Coroutine)) == 0) {
 #endif

--- a/src/core/IronPython/Runtime/FunctionCode.cs
+++ b/src/core/IronPython/Runtime/FunctionCode.cs
@@ -751,11 +751,10 @@ namespace IronPython.Runtime {
             );
 
 #if FEATURE_NET_ASYNC
-            // Under runtime-async, async bodies are lowered before they reach here and must NOT go through
-            // the generator rewriter: plain async (Coroutine, no Generator) via AsyncExpression, and async
-            // generators (Generator+Coroutine) via AsyncEnumerableExpression. Only a plain generator
-            // (Generator without Coroutine) is rewritten here. Coroutine is otherwise informational
-            // (kept for __code__.co_flags).
+            // Under .NET-async, async bodies are lowered before they reach here and must NOT go through the generator rewriter:
+            //  * plain async (Coroutine, no Generator) via AsyncExpression,
+            //  * async generators (Generator+Coroutine) via AsyncEnumerableExpression.
+            //  Only a plain generator (Generator without Coroutine) is rewritten here.
             if ((Flags & FunctionAttributes.Generator) == 0 || (Flags & FunctionAttributes.Coroutine) != 0) {
 #else
             if ((Flags & (FunctionAttributes.Generator | FunctionAttributes.Coroutine)) == 0) {
@@ -763,11 +762,7 @@ namespace IronPython.Runtime {
                 return context.DebugContext.TransformLambda((LambdaExpression)Compiler.Ast.Node.RemoveFrame(_lambda.GetLambda()), debugInfo);
             }
 
-#if FEATURE_NET_ASYNC
-            const bool isCoroutine = false;
-#else
             bool isCoroutine = (Flags & FunctionAttributes.Coroutine) != 0;
-#endif
             return Expression.Lambda(
                 Code.Type,
                 new GeneratorRewriter(
@@ -803,11 +798,7 @@ namespace IronPython.Runtime {
 #endif
                 finalCode = Code;
             } else {
-#if FEATURE_NET_ASYNC
-                const bool isCoroutine = false;
-#else
                 bool isCoroutine = (Flags & FunctionAttributes.Coroutine) != 0;
-#endif
                 finalCode = Code.ToGenerator(
                     _lambda.ShouldInterpret,
                     _lambda.EmitDebugSymbols,

--- a/src/core/IronPython/Runtime/FunctionCode.cs
+++ b/src/core/IronPython/Runtime/FunctionCode.cs
@@ -750,11 +750,23 @@ namespace IronPython.Runtime {
                 debugProperties // custom payload
             );
 
+#if FEATURE_NET_ASYNC
+            // Under runtime-async, Coroutine is informational (kept for
+            // __code__.co_flags) — async function bodies are already lowered
+            // through AsyncExpression and must not go through the
+            // generator rewriter here.
+            if ((Flags & FunctionAttributes.Generator) == 0) {
+#else
             if ((Flags & (FunctionAttributes.Generator | FunctionAttributes.Coroutine)) == 0) {
+#endif
                 return context.DebugContext.TransformLambda((LambdaExpression)Compiler.Ast.Node.RemoveFrame(_lambda.GetLambda()), debugInfo);
             }
 
+#if FEATURE_NET_ASYNC
+            const bool isCoroutine = false;
+#else
             bool isCoroutine = (Flags & FunctionAttributes.Coroutine) != 0;
+#endif
             return Expression.Lambda(
                 Code.Type,
                 new GeneratorRewriter(
@@ -781,10 +793,18 @@ namespace IronPython.Runtime {
         /// </summary>
         private LightLambdaExpression GetGeneratorOrNormalLambda() {
             LightLambdaExpression finalCode;
+#if FEATURE_NET_ASYNC
+            if ((Flags & FunctionAttributes.Generator) == 0) {
+#else
             if ((Flags & (FunctionAttributes.Generator | FunctionAttributes.Coroutine)) == 0) {
+#endif
                 finalCode = Code;
             } else {
+#if FEATURE_NET_ASYNC
+                const bool isCoroutine = false;
+#else
                 bool isCoroutine = (Flags & FunctionAttributes.Coroutine) != 0;
+#endif
                 finalCode = Code.ToGenerator(
                     _lambda.ShouldInterpret,
                     _lambda.EmitDebugSymbols,

--- a/src/core/IronPython/Runtime/Generator.cs
+++ b/src/core/IronPython/Runtime/Generator.cs
@@ -105,6 +105,7 @@ namespace IronPython.Runtime {
         }
 
         [LightThrowing]
+        // The signature (type[, value[, traceback]]) is deprecated in CPython 3.12
         public object @throw(object? type, object? value, object? traceback) {
             return @throw(type, value, traceback, false);
         }

--- a/src/core/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/src/core/IronPython/Runtime/Operations/InstanceOps.cs
@@ -242,6 +242,27 @@ namespace IronPython.Runtime.Operations {
         public static object AsyncIterMethod<T>(System.Collections.Generic.IAsyncEnumerable<T> self) {
             return new AsyncEnumeratorWrapper<T>(self.GetAsyncEnumerator());
         }
+
+        /// <summary>
+        /// Provides the implementation of __aenter__ for objects implementing <see cref="System.IAsyncDisposable"/>.
+        /// IAsyncDisposable has no async-enter step — entering just yields the resource itself, wrapped in an
+        /// already-completed Task so the desugared <c>await mgr.__aenter__()</c> resolves to <c>self</c>.
+        /// </summary>
+        public static object AEnterMethod(System.IAsyncDisposable self) {
+            // Task<object> is the same runtime type as Task<object?>, so AsTaskForAwait's
+            // Task<object?> fast path picks it up. (InstanceOps isn't a #nullable context.)
+            return System.Threading.Tasks.Task.FromResult<object>(self);
+        }
+
+        /// <summary>
+        /// Provides the implementation of __aexit__ for objects implementing <see cref="System.IAsyncDisposable"/>.
+        /// Calls <see cref="System.IAsyncDisposable.DisposeAsync"/>; the returned ValueTask is awaited by the
+        /// desugared <c>await mgr.__aexit__(...)</c>. Returns a falsy result (the ValueTask completes with no
+        /// value) so the exception, if any, is not suppressed.
+        /// </summary>
+        public static object AExitMethod(System.IAsyncDisposable self, object exc_type, object exc_value, object exc_back) {
+            return self.DisposeAsync().AsTask();
+        }
 #endif
 
         #endregion

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -3197,12 +3197,136 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static PythonCoroutine MakeCoroutine(PythonFunction function, MutableTuple data, object generatorCode) {
+#if FEATURE_NET_ASYNC
+            // Under runtime-async, async functions never produce a PythonGenerator;
+            // FunctionDefinition compiles them through AsyncExpression and
+            // PythonOps.MakeAsyncCoroutine.  This path is for plain generators
+            // only, kept here for ABI parity with non-FEATURE_NET_ASYNC builds.
+            throw new System.InvalidOperationException("MakeCoroutine is unused under FEATURE_NET_ASYNC");
+#else
             return new PythonCoroutine(MakeGenerator(function, data, generatorCode));
+#endif
         }
 
         public static object MakeCoroutineWrapper(PythonGenerator generator) {
+#if FEATURE_NET_ASYNC
+            throw new System.InvalidOperationException("MakeCoroutineWrapper is unused under FEATURE_NET_ASYNC");
+#else
             return new PythonCoroutine(generator);
+#endif
         }
+
+#if FEATURE_NET_ASYNC
+        /// <summary>
+        /// Converts an arbitrary value yielded into an <c>await</c> expression
+        /// to a <see cref="System.Threading.Tasks.Task{T}"/> of object that the
+        /// DLR runtime-async runner can drive.
+        /// </summary>
+        public static System.Threading.Tasks.Task<object?> AsTaskForAwait(object? value) {
+            if (value is PythonCoroutine coro) return coro.AsTask();
+            if (value is System.Threading.Tasks.Task<object?> typedTask) return typedTask;
+            if (value is System.Threading.Tasks.Task task) return BoxTaskResult(task);
+
+#if NETCOREAPP
+            // TODO : simplify
+            // ValueTask / ValueTask<T>: convert to a regular Task via AsTask() and box through the same path.
+            if (value is System.Threading.Tasks.ValueTask vt) return BoxTaskResult(vt.AsTask());
+
+            System.Type? valueType = value?.GetType();
+            if (valueType is not null
+                && valueType.IsGenericType
+                && valueType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.ValueTask<>)) {
+
+                if (value is System.Threading.Tasks.ValueTask<object?> vtObj) return vtObj.AsTask();
+                var asTask = (System.Threading.Tasks.Task)valueType.GetMethod("AsTask")!.Invoke(value, null)!;
+                // ValueTask<object?>.AsTask() is already Task<object?> — return it directly (same fast
+                // path as the top-level Task<object?> check); only box when the result type differs.
+                return asTask is System.Threading.Tasks.Task<object?> already ? already : BoxTaskResult(asTask);
+            }
+#endif
+
+            // PEP 492 awaitable protocol fallback: any object exposing __await__ that returns an
+            // iterator (user-defined awaitables, and the AsyncEnumeratorAwaitable produced by
+            // `async for` over IAsyncEnumerable<T>). The native Task/coroutine/ValueTask fast paths
+            // above mean a plain `await Task` never reaches here.
+            if (TryGetBoundAttr(value, "__await__", out object? awaitMethod)) {
+                object? iterator = PythonCalls.Call(DefaultContext.Default, awaitMethod);
+                return DriveAwaitIterator(iterator);
+            }
+
+            throw TypeError("object of type '{0}' can't be used in 'await' expression", PythonOps.GetPythonTypeName(value));
+        }
+
+        /// <summary>
+        /// Drives a Python awaitable's <c>__await__()</c> iterator to completion, returning a
+        /// <see cref="System.Threading.Tasks.Task{T}"/> of object that yields the awaitable's result.
+        /// The iterator follows the generator/yield-from protocol: each step yields an awaitable
+        /// (typically a Task) and the chain terminates with <c>StopIteration</c> whose value is the
+        /// <c>await</c> result. Mirrors the legacy generator-pump <c>AsTask</c>, but async and at the
+        /// Python-iterator level.
+        /// </summary>
+        private static async System.Threading.Tasks.Task<object?> DriveAwaitIterator(object? iterator) {
+            CodeContext context = DefaultContext.Default;
+            // Generators feed the awaited result back via send(); plain iterators (e.g. iter([]))
+            // only support __next__() and ignore sent values.
+            bool hasSend = TryGetBoundAttr(context, iterator, "send", out object? sendMethod);
+            object? sendValue = null;
+            while (true) {
+                object? yielded;
+                try {
+                    yielded = hasSend
+                        ? PythonCalls.Call(context, sendMethod, sendValue)
+                        : Invoke(context, iterator, "__next__");
+                } catch (StopIterationException e) {
+                    return StopIterationValue(e);
+                }
+                // A [LightThrowing] __next__/send may return a light-exception sentinel rather than
+                // throwing — handle both forms.
+                if (LightExceptions.IsLightException(yielded)) {
+                    var clrExc = LightExceptions.GetLightException(yielded!);
+                    if (clrExc is StopIterationException si) return StopIterationValue(si);
+                    throw clrExc;
+                }
+                // The yielded value is itself awaitable — drive it and feed the result back in.
+                sendValue = await AsTaskForAwait(yielded);
+            }
+
+            static object? StopIterationValue(StopIterationException e)
+                => ((IPythonAwareException)e).PythonException is PythonExceptions._StopIteration si ? si.value : null;
+        }
+
+        private static async System.Threading.Tasks.Task<object?> BoxTaskResult(System.Threading.Tasks.Task task) {
+            await task;
+            // Generic Task<T>: pull the result out and box it. The runtime type
+            // may be a Task<T> subclass (e.g. AsyncStateMachineBox<...>), so
+            // walk up to find Task<T>.
+            System.Type? t = task.GetType();
+            while (t is not null) {
+                if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>)) {
+                    if (!t.GenericTypeArguments[0].IsVisible) return null; // VoidTaskResult etc.
+                    return t.GetProperty("Result")!.GetValue(task);
+                }
+                t = t.BaseType;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Wraps a runtime-async function's <see cref="System.Threading.Tasks.Task"/>
+        /// in a <see cref="PythonCoroutine"/> for the caller of <c>async def</c>.
+        /// The supplied <see cref="System.Threading.CancellationTokenSource"/> and exception-override
+        /// box are pre-bound to <see cref="Microsoft.Scripting.Runtime.AsyncHelpers.DriveAsync"/>'s
+        /// cancellation channel — the coroutine uses them to implement <c>coro.throw(exc)</c> on a
+        /// running body (set the box, cancel the CTS).
+        /// </summary>
+        public static PythonCoroutine MakeAsyncCoroutine(
+                PythonFunction function,
+                System.Threading.Tasks.Task<object?> task,
+                System.Threading.CancellationTokenSource cts,
+                System.Runtime.CompilerServices.StrongBox<System.Exception?> cancellationException) {
+            return new PythonCoroutine(task, function.__name__, function.__code__, cts, cancellationException);
+        }
+#endif
 
         public static object MakeGeneratorExpression(object function, object input) {
             PythonFunction func = (PythonFunction)function;

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -22,6 +22,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Actions;
@@ -3196,17 +3197,15 @@ namespace IronPython.Runtime.Operations {
             return new PythonGenerator(function, next, data);
         }
 
+
         public static PythonCoroutine MakeCoroutine(PythonFunction function, MutableTuple data, object generatorCode) {
 #if FEATURE_NET_ASYNC
-            // Under runtime-async, async functions never produce a PythonGenerator;
-            // FunctionDefinition compiles them through AsyncExpression and
-            // PythonOps.MakeAsyncCoroutine.  This path is for plain generators
-            // only, kept here for ABI parity with non-FEATURE_NET_ASYNC builds.
             throw new System.InvalidOperationException("MakeCoroutine is unused under FEATURE_NET_ASYNC");
 #else
             return new PythonCoroutine(MakeGenerator(function, data, generatorCode));
 #endif
         }
+
 
         public static object MakeCoroutineWrapper(PythonGenerator generator) {
 #if FEATURE_NET_ASYNC
@@ -3216,39 +3215,40 @@ namespace IronPython.Runtime.Operations {
 #endif
         }
 
+
 #if FEATURE_NET_ASYNC
         /// <summary>
-        /// Converts an arbitrary value yielded into an <c>await</c> expression
-        /// to a <see cref="System.Threading.Tasks.Task{T}"/> of object that the
-        /// DLR runtime-async runner can drive.
+        /// Converts an arbitrary value yielded into an <c>await</c> expression to a <see cref="Task{T}"/> of object
+        /// that the DLR async runner can drive.
         /// </summary>
-        public static System.Threading.Tasks.Task<object?> AsTaskForAwait(object? value) {
-            if (value is PythonCoroutine coro) return coro.AsTask();
-            if (value is System.Threading.Tasks.Task<object?> typedTask) return typedTask;
-            if (value is System.Threading.Tasks.Task task) return BoxTaskResult(task);
+        public static Task<object?> AsTaskForAwait(object? value) {
+
+            Task<object?>? task = value switch {
+                null                    => Task.FromResult<object?>(null),
+                PythonCoroutine coro    => coro.AsTask(),
+                Task<object?> to        => to,
+                Task t                  => BoxTaskResult(t),
+#if NETCOREAPP
+                // ValueTask / ValueTask<T>: convert to a regular Task via AsTask() and box Result if needed
+                ValueTask<object?> vto  => vto.AsTask(),
+                ValueTask vt            => BoxTaskResult(vt.AsTask()),
+#endif
+                _                       => null,
+            };
+            if (task is not null) return task;
 
 #if NETCOREAPP
-            // TODO : simplify
-            // ValueTask / ValueTask<T>: convert to a regular Task via AsTask() and box through the same path.
-            if (value is System.Threading.Tasks.ValueTask vt) return BoxTaskResult(vt.AsTask());
-
-            System.Type? valueType = value?.GetType();
-            if (valueType is not null
-                && valueType.IsGenericType
-                && valueType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.ValueTask<>)) {
-
-                if (value is System.Threading.Tasks.ValueTask<object?> vtObj) return vtObj.AsTask();
-                var asTask = (System.Threading.Tasks.Task)valueType.GetMethod("AsTask")!.Invoke(value, null)!;
-                // ValueTask<object?>.AsTask() is already Task<object?> — return it directly (same fast
-                // path as the top-level Task<object?> check); only box when the result type differs.
-                return asTask is System.Threading.Tasks.Task<object?> already ? already : BoxTaskResult(asTask);
+            // ValueTask<T> of arbitrary T
+            Type valueType = value!.GetType();
+            if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(ValueTask<>)) {
+                var asTask = (Task)valueType.GetMethod("AsTask")!.Invoke(value, null)!;
+                return BoxTaskResult(asTask);
             }
 #endif
 
-            // PEP 492 awaitable protocol fallback: any object exposing __await__ that returns an
-            // iterator (user-defined awaitables, and the AsyncEnumeratorAwaitable produced by
-            // `async for` over IAsyncEnumerable<T>). The native Task/coroutine/ValueTask fast paths
-            // above mean a plain `await Task` never reaches here.
+            // PEP 492 awaitable protocol fallback: any object exposing __await__ that returns an iterator
+            // (user-defined awaitables, and the AsyncEnumeratorAwaitable produced by `async for` over IAsyncEnumerable<T>).
+            // The native Task/coroutine/ValueTask fast paths above mean a plain `await Task` never reaches here.
             if (TryGetBoundAttr(value, "__await__", out object? awaitMethod)) {
                 object? iterator = PythonCalls.Call(DefaultContext.Default, awaitMethod);
                 return DriveAwaitIterator(iterator);
@@ -3257,18 +3257,20 @@ namespace IronPython.Runtime.Operations {
             throw TypeError("object of type '{0}' can't be used in 'await' expression", PythonOps.GetPythonTypeName(value));
         }
 
+
         /// <summary>
-        /// Drives a Python awaitable's <c>__await__()</c> iterator to completion, returning a
-        /// <see cref="System.Threading.Tasks.Task{T}"/> of object that yields the awaitable's result.
-        /// The iterator follows the generator/yield-from protocol: each step yields an awaitable
-        /// (typically a Task) and the chain terminates with <c>StopIteration</c> whose value is the
-        /// <c>await</c> result. Mirrors the legacy generator-pump <c>AsTask</c>, but async and at the
-        /// Python-iterator level.
+        ///   Drives a Python awaitable's <c>__await__()</c> iterator to completion,
+        ///   returning a Task{object?} that yields the awaitable's result.
         /// </summary>
-        private static async System.Threading.Tasks.Task<object?> DriveAwaitIterator(object? iterator) {
+        /// <remarks>
+        ///   The iterator follows the generator/yield-from protocol: each step yields an awaitable (typically a Task) and the chain
+        ///   terminates with <c>StopIteration</c> whose value is the <c>await</c> result. Mirrors the generator-pump <c>AsTask</c>,
+        ///   but is async and at the Python-iterator level.
+        /// </remarks>
+        private static async Task<object?> DriveAwaitIterator(object? iterator) {
             CodeContext context = DefaultContext.Default;
-            // Generators feed the awaited result back via send(); plain iterators (e.g. iter([]))
-            // only support __next__() and ignore sent values.
+            // Generators feed the awaited result back via send();
+            // plain iterators (e.g. iter([])) only support __next__() and ignore sent values.
             bool hasSend = TryGetBoundAttr(context, iterator, "send", out object? sendMethod);
             object? sendValue = null;
             while (true) {
@@ -3280,8 +3282,7 @@ namespace IronPython.Runtime.Operations {
                 } catch (StopIterationException e) {
                     return StopIterationValue(e);
                 }
-                // A [LightThrowing] __next__/send may return a light-exception sentinel rather than
-                // throwing — handle both forms.
+                // A [LightThrowing] __next__/send may return a light-exception sentinel rather than throwing — handle both forms.
                 if (LightExceptions.IsLightException(yielded)) {
                     var clrExc = LightExceptions.GetLightException(yielded!);
                     if (clrExc is StopIterationException si) return StopIterationValue(si);
@@ -3295,54 +3296,50 @@ namespace IronPython.Runtime.Operations {
                 => ((IPythonAwareException)e).PythonException is PythonExceptions._StopIteration si ? si.value : null;
         }
 
-        private static async System.Threading.Tasks.Task<object?> BoxTaskResult(System.Threading.Tasks.Task task) {
-            await task;
-            // Generic Task<T>: pull the result out and box it. The runtime type
-            // may be a Task<T> subclass (e.g. AsyncStateMachineBox<...>), so
-            // walk up to find Task<T>.
-            System.Type? t = task.GetType();
-            while (t is not null) {
-                if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>)) {
-                    if (!t.GenericTypeArguments[0].IsVisible) return null; // VoidTaskResult etc.
-                    return t.GetProperty("Result")!.GetValue(task);
-                }
-                t = t.BaseType;
-            }
-            return null;
+
+        /// <summary>
+        ///   Converts any Task/Task{T} to a Task{object?}, boxing the Result if needed, and propagating cancellation and exceptions.
+        /// </summary>
+        private static Task<object?> BoxTaskResult(Task task) {
+            Debug.Assert(task is not Task<object?>, "BoxTaskResult is suboptimal for Task<object?>");
+            Type tp = task.GetType();
+            var tcs = new TaskCompletionSource<object?>();
+            task.ContinueWith(t => {
+                if (t.IsCanceled)  tcs.SetCanceled();
+                else if (t.IsFaulted) tcs.SetException(t.Exception!.InnerException ?? t.Exception);
+                else tcs.SetResult(!tp.IsGenericType ? null : (object?)tp.GetProperty("Result")!.GetValue(t));
+            }, TaskContinuationOptions.ExecuteSynchronously);
+            return tcs.Task;
         }
 
         /// <summary>
-        /// Wraps a runtime-async function's deferred <see cref="System.Threading.Tasks.Task"/>
-        /// thunk in a <see cref="PythonCoroutine"/> for the caller of <c>async def</c>.
-        /// The thunk is invoked lazily on first drive (send/AsTask), so calling an
-        /// <c>async def</c> is side-effect-free until the coroutine is awaited (PEP 492).
-        /// The supplied <see cref="System.Threading.CancellationTokenSource"/> and exception-override
-        /// box are pre-bound to <see cref="Microsoft.Scripting.Runtime.AsyncHelpers.DriveAsync"/>'s
-        /// cancellation channel — the coroutine uses them to implement <c>coro.throw(exc)</c> on a
-        /// running body (set the box, cancel the CTS).
+        ///   Wraps an sync function's deferred <see cref="Task"/> thunk in a <see cref="PythonCoroutine"/>
+        ///   for the caller of <c>async def</c>.
         /// </summary>
-        public static PythonCoroutine MakeAsyncCoroutine(
-                PythonFunction function,
-                Func<System.Threading.Tasks.Task<object?>> taskFactory,
-                System.Threading.CancellationTokenSource cts,
-                System.Runtime.CompilerServices.StrongBox<System.Exception?> cancellationException) {
+        /// <remarks>
+        ///   The thunk is invoked lazily on first drive (send/AsTask), so calling an <c>async def</c> is side-effect-free until the coroutine
+        ///   is awaited (PEP 492).
+        ///   The supplied <see cref="CancellationTokenSource"/> and exception-override box are pre-bound
+        ///   to <see cref="Microsoft.Scripting.Runtime.AsyncHelpers.DriveAsync"/>'s cancellation channel — the coroutine uses them to implement
+        ///   <c>coro.throw(exc)</c> on a running body (set the box, cancel the CTS).
+        /// </remarks>
+        public static PythonCoroutine MakeAsyncCoroutine(PythonFunction function, Func<Task<object?>> taskFactory, CancellationTokenSource cts, StrongBox<System.Exception?> cancellationException) {
             return new PythonCoroutine(taskFactory, function.__name__, function.__code__, cts, cancellationException);
         }
 
+
         /// <summary>
-        /// Wraps an async-generator's <see cref="System.Collections.Generic.IAsyncEnumerable{T}"/> (from
-        /// AsyncEnumerableExpression / DriveAsyncEnumerable) in a <see cref="PythonAsyncGenerator"/> for the
-        /// caller of an <c>async def</c> with <c>yield</c>. <paramref name="sendSlot"/> carries the value of
-        /// <c>x = yield z</c> (asend); <paramref name="throwSlot"/> carries an exception to rethrow at the
-        /// yield resume (athrow/aclose); both are read by the body's yields and written by the wrapper before
-        /// each resume. <paramref name="cts"/> backs the enumerator's cancellation.
+        ///   Wraps an async-generator's <see cref="IAsyncEnumerable{T}"/> (from
+        ///   AsyncEnumerableExpression / DriveAsyncEnumerable) in a <see cref="PythonAsyncGenerator"/> for the
+        ///   caller of an <c>async def</c> with <c>yield</c>.
         /// </summary>
-        public static PythonAsyncGenerator MakeAsyncGenerator(
-                PythonFunction function,
-                System.Collections.Generic.IAsyncEnumerable<object?> source,
-                System.Runtime.CompilerServices.StrongBox<object?> sendSlot,
-                System.Runtime.CompilerServices.StrongBox<System.Exception?> throwSlot,
-                System.Threading.CancellationTokenSource cts) {
+        /// <param name="sendSlot">
+        ///   carries the value of yield to deliver: <c>x = yield z</c> (asend).
+        /// </param>
+        /// <param name="throwSlot">
+        ///   carries an exception to rethrow at the yield resume (athrow/aclose).
+        /// </param>
+        public static PythonAsyncGenerator MakeAsyncGenerator(PythonFunction function, IAsyncEnumerable<object?> source, StrongBox<object?> sendSlot, StrongBox<System.Exception?> throwSlot, CancellationTokenSource cts) {
             return new PythonAsyncGenerator(source, sendSlot, throwSlot, cts, function.__name__);
         }
 #endif

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -3326,6 +3326,23 @@ namespace IronPython.Runtime.Operations {
                 System.Runtime.CompilerServices.StrongBox<System.Exception?> cancellationException) {
             return new PythonCoroutine(task, function.__name__, function.__code__, cts, cancellationException);
         }
+
+        /// <summary>
+        /// Wraps an async-generator's <see cref="System.Collections.Generic.IAsyncEnumerable{T}"/> (from
+        /// AsyncEnumerableExpression / DriveAsyncEnumerable) in a <see cref="PythonAsyncGenerator"/> for the
+        /// caller of an <c>async def</c> with <c>yield</c>. <paramref name="sendSlot"/> carries the value of
+        /// <c>x = yield z</c> (asend); <paramref name="throwSlot"/> carries an exception to rethrow at the
+        /// yield resume (athrow/aclose); both are read by the body's yields and written by the wrapper before
+        /// each resume. <paramref name="cts"/> backs the enumerator's cancellation.
+        /// </summary>
+        public static PythonAsyncGenerator MakeAsyncGenerator(
+                PythonFunction function,
+                System.Collections.Generic.IAsyncEnumerable<object?> source,
+                System.Runtime.CompilerServices.StrongBox<object?> sendSlot,
+                System.Runtime.CompilerServices.StrongBox<System.Exception?> throwSlot,
+                System.Threading.CancellationTokenSource cts) {
+            return new PythonAsyncGenerator(source, sendSlot, throwSlot, cts, function.__name__);
+        }
 #endif
 
         public static object MakeGeneratorExpression(object function, object input) {

--- a/src/core/IronPython/Runtime/Operations/PythonOps.cs
+++ b/src/core/IronPython/Runtime/Operations/PythonOps.cs
@@ -3312,8 +3312,10 @@ namespace IronPython.Runtime.Operations {
         }
 
         /// <summary>
-        /// Wraps a runtime-async function's <see cref="System.Threading.Tasks.Task"/>
-        /// in a <see cref="PythonCoroutine"/> for the caller of <c>async def</c>.
+        /// Wraps a runtime-async function's deferred <see cref="System.Threading.Tasks.Task"/>
+        /// thunk in a <see cref="PythonCoroutine"/> for the caller of <c>async def</c>.
+        /// The thunk is invoked lazily on first drive (send/AsTask), so calling an
+        /// <c>async def</c> is side-effect-free until the coroutine is awaited (PEP 492).
         /// The supplied <see cref="System.Threading.CancellationTokenSource"/> and exception-override
         /// box are pre-bound to <see cref="Microsoft.Scripting.Runtime.AsyncHelpers.DriveAsync"/>'s
         /// cancellation channel — the coroutine uses them to implement <c>coro.throw(exc)</c> on a
@@ -3321,10 +3323,10 @@ namespace IronPython.Runtime.Operations {
         /// </summary>
         public static PythonCoroutine MakeAsyncCoroutine(
                 PythonFunction function,
-                System.Threading.Tasks.Task<object?> task,
+                Func<System.Threading.Tasks.Task<object?>> taskFactory,
                 System.Threading.CancellationTokenSource cts,
                 System.Runtime.CompilerServices.StrongBox<System.Exception?> cancellationException) {
-            return new PythonCoroutine(task, function.__name__, function.__code__, cts, cancellationException);
+            return new PythonCoroutine(taskFactory, function.__name__, function.__code__, cts, cancellationException);
         }
 
         /// <summary>

--- a/src/core/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/src/core/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -676,6 +676,8 @@ namespace IronPython.Runtime.Types {
                 new OneOffResolver("__await__", AwaitResolver),
                 new OneOffResolver("__aiter__", AsyncIterResolver),
                 new OneOffResolver("__anext__", AsyncNextResolver),
+                new OneOffResolver("__aenter__", AsyncEnterResolver),
+                new OneOffResolver("__aexit__", AsyncExitResolver),
 
                 new OneOffResolver("__complex__", ComplexResolver),
                 new OneOffResolver("__float__", FloatResolver),
@@ -1049,6 +1051,42 @@ namespace IronPython.Runtime.Types {
         /// Not auto-mapped from interfaces; the wrapper class provides __anext__ directly.
         /// </summary>
         private static MemberGroup/*!*/ AsyncNextResolver(MemberBinder/*!*/ binder, Type/*!*/ type) {
+            return MemberGroup.EmptyGroup;
+        }
+
+        /// <summary>
+        /// Provides a resolution for __aenter__ on types implementing <c>IAsyncDisposable</c>,
+        /// so that <c>async with</c> works seamlessly over .NET async-disposable resources.
+        /// </summary>
+        private static MemberGroup/*!*/ AsyncEnterResolver(MemberBinder/*!*/ binder, Type/*!*/ type) {
+#if NET
+            foreach (Type t in binder.GetContributingTypes(type)) {
+                if (t.GetMember("__aenter__").Length > 0) {
+                    return MemberGroup.EmptyGroup;
+                }
+            }
+            if (typeof(IAsyncDisposable).IsAssignableFrom(type)) {
+                return GetInstanceOpsMethod(type, nameof(InstanceOps.AEnterMethod));
+            }
+#endif
+            return MemberGroup.EmptyGroup;
+        }
+
+        /// <summary>
+        /// Provides a resolution for __aexit__ on types implementing <c>IAsyncDisposable</c>.
+        /// Maps to <c>InstanceOps.AExitMethod</c>, which awaits DisposeAsync().
+        /// </summary>
+        private static MemberGroup/*!*/ AsyncExitResolver(MemberBinder/*!*/ binder, Type/*!*/ type) {
+#if NET
+            foreach (Type t in binder.GetContributingTypes(type)) {
+                if (t.GetMember("__aexit__").Length > 0) {
+                    return MemberGroup.EmptyGroup;
+                }
+            }
+            if (typeof(IAsyncDisposable).IsAssignableFrom(type)) {
+                return GetInstanceOpsMethod(type, nameof(InstanceOps.AExitMethod));
+            }
+#endif
             return MemberGroup.EmptyGroup;
         }
 

--- a/tests/IronPython.Tests/Cases/IronPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/IronPythonCasesManifest.ini
@@ -4,6 +4,11 @@ WorkingDirectory=$(TEST_FILE_DIR)
 Redirect=false
 Timeout=120000 # 2 minute timeout
 
+[IronPython.test_asyncgen]
+Ignore=true
+RunCondition='$(FRAMEWORK)' <> '.NETFramework,Version=v4.6.2'
+Reason=Requires IAsyncEnumerable & IAsyncDisposable
+
 [IronPython.test_builtin_stdlib]
 RunCondition=NOT $(IS_MONO)
 Reason=Exception on adding DocTestSuite

--- a/tests/suite/test_async.py
+++ b/tests/suite/test_async.py
@@ -94,6 +94,24 @@ class AsyncDefTest(unittest.TestCase):
             coro.throw(ValueError('boom'))
         self.assertEqual(str(cm.exception), 'boom')
 
+    def test_lazy_evaluation(self):
+        """The body of an async def must not run until the coroutine is first driven."""
+        log = []
+
+        async def noop():
+            return
+
+        async def lazy():
+            log.append('before')
+            await noop()
+            log.append('after')
+            return 'done'
+
+        coro = lazy()
+        self.assertEqual(log, [])  # constructing the coroutine runs nothing
+        self.assertEqual(run_coro(coro), 'done')
+        self.assertEqual(log, ['before', 'after'])
+
 
 class AwaitTest(unittest.TestCase):
     """Tests for await expression."""
@@ -138,6 +156,20 @@ class AwaitTest(unittest.TestCase):
             return 'done'
 
         self.assertEqual(run_coro(test()), 'done')
+
+    def test_exception_across_await(self):
+        """An exception raised in an awaited coroutine propagates and is catchable."""
+        async def fails():
+            raise ValueError('boom')
+
+        async def test():
+            try:
+                await fails()
+            except ValueError as e:
+                return 'caught: ' + str(e)
+            return 'not caught'
+
+        self.assertEqual(run_coro(test()), 'caught: boom')
 
 
 class AsyncWithTest(unittest.TestCase):

--- a/tests/suite/test_asyncgen.py
+++ b/tests/suite/test_asyncgen.py
@@ -1,0 +1,257 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+"""Tests for async constructs that lower to .NET IAsyncEnumerable / IAsyncDisposable:
+async generators (PEP 525) and `async with` over a .NET IAsyncDisposable."""
+
+import unittest
+
+from iptest import run_test, skipUnlessIronPython
+
+
+def run_coro(coro):
+    """Run a coroutine to completion, blocking on yielded .NET Tasks."""
+    value = None
+    while True:
+        try:
+            task = coro.send(value)
+            # .NET Task yielded — block on it (test runner is synchronous)
+            task.Wait()
+            value = None
+        except StopIteration as e:
+            return e.value
+
+
+@skipUnlessIronPython()
+class DotNetAsyncDisposableTest(unittest.TestCase):
+    """Tests for async with over a .NET IAsyncDisposable."""
+
+    def test_async_with_dotnet_disposable(self):
+        """async with over a .NET IAsyncDisposable enters with the resource and disposes on exit."""
+        from System.IO import MemoryStream
+        s = MemoryStream()
+        self.assertTrue(hasattr(s, '__aenter__'))
+        self.assertTrue(hasattr(s, '__aexit__'))
+
+        async def test():
+            async with s as entered:
+                self.assertIs(entered, s)
+                self.assertTrue(entered.CanWrite)
+            return s.CanWrite  # disposed on exit -> False
+
+        self.assertFalse(run_coro(test()))
+
+
+@skipUnlessIronPython()
+class AsyncGeneratorTest(unittest.TestCase):
+    """Tests for PEP 525 async generators (await + yield). Bodies await .NET Tasks."""
+
+
+    def test_await_and_yield(self):
+        """An async generator body mixing await and yield, consumed via async for."""
+        from System.Threading.Tasks import Task
+
+        async def agen():
+            yield 1
+            x = await Task.FromResult(10)
+            yield x + 1       # await result feeds the next yield
+            if x > 5:
+                return        # bare return ends the async iteration
+            yield 'unreached'
+
+        async def consume():
+            out = []
+            async for v in agen():
+                out.append(v)
+            return out
+
+        self.assertEqual(run_coro(consume()), [1, 11])
+
+
+    def test_yield_task_is_value_not_await(self):
+        """A yielded Task is the produced value, not a suspension point."""
+        from System.Threading.Tasks import Task
+
+        async def agen():
+            yield Task.FromResult(99)
+
+        async def consume():
+            out = []
+            async for item in agen():
+                out.append(item)
+            return out
+
+        items = run_coro(consume())
+        self.assertEqual(len(items), 1)
+        # The item is the Task itself; if it had been awaited we'd have gotten 99.
+        self.assertEqual(items[0].Result, 99)
+
+
+    def test_async_generator_type(self):
+        async def agen():
+            yield 1
+        g = agen()
+        self.assertEqual(type(g).__name__, 'async_generator')
+
+
+    def test_asend(self):
+        """asend feeds a value into `x = yield z` (PEP 525 two-way communication)."""
+        async def agen():
+            got1 = yield 1
+            got2 = yield ('after1', got1)
+            yield ('after2', got2)
+
+        async def drive():
+            g = agen()
+            out = []
+            out.append(await g.asend(None))    # start -> yields 1
+            out.append(await g.asend('A'))     # got1 == 'A' -> ('after1', 'A')
+            out.append(await g.asend('B'))     # got2 == 'B' -> ('after2', 'B')
+            try:
+                await g.asend('C')
+            except StopAsyncIteration:
+                out.append('stop')
+            return out
+
+        self.assertEqual(run_coro(drive()), [1, ('after1', 'A'), ('after2', 'B'), 'stop'])
+
+
+    def test_athrow(self):
+        """athrow injects an exception at the yield; the body can catch and continue."""
+        async def agen():
+            try:
+                yield 1
+            except ValueError as e:
+                yield ('caught', str(e))
+            yield 3
+
+        async def drive():
+            g = agen()
+            out = []
+            out.append(await g.asend(None))                 # -> 1
+            out.append(await g.athrow(ValueError('boom')))  # caught -> ('caught', 'boom')
+            out.append(await g.asend(None))                 # -> 3
+            try:
+                await g.asend(None)
+            except StopAsyncIteration:
+                out.append('stop')
+            return out
+
+        self.assertEqual(run_coro(drive()), [1, ('caught', 'boom'), 3, 'stop'])
+
+
+    def test_aclose_runs_finally(self):
+        """aclose injects GeneratorExit at the yield so the body's finally runs."""
+        log = []
+
+        async def agen():
+            try:
+                yield 1
+                yield 2
+            finally:
+                log.append('cleanup')
+
+        async def drive():
+            g = agen()
+            first = await g.asend(None)   # -> 1
+            await g.aclose()              # GeneratorExit at the yield -> finally runs
+            return first
+
+        self.assertEqual(run_coro(drive()), 1)
+        self.assertEqual(log, ['cleanup'])
+
+
+@skipUnlessIronPython()
+class NestedAsyncGeneratorTest(unittest.TestCase):
+    """An async generator lexically nested inside another async generator.
+
+    Both functions own the async send/throw slots; their slot variables must stay
+    distinct per function so the inner generator's slots don't collide with the
+    outer's when the inner lambda is nested inside the outer.
+    """
+
+
+    def test_nested_async_generator(self):
+        """Outer async gen consumes a nested async gen via async for and re-yields."""
+        async def outer():
+            async def inner():
+                yield 'a'
+                yield 'b'
+            async for x in inner():
+                yield x.upper()
+
+        async def consume():
+            out = []
+            async for v in outer():
+                out.append(v)
+            return out
+
+        self.assertEqual(run_coro(consume()), ['A', 'B'])
+
+
+    def test_nested_async_generator_with_await(self):
+        """Both nested async gens await a .NET Task between yields."""
+        from System.Threading.Tasks import Task
+
+        async def outer():
+            async def inner():
+                yield 1
+                n = await Task.FromResult(10)
+                yield n + 1
+            async for v in inner():
+                doubled = await Task.FromResult(v * 2)
+                yield doubled
+
+        async def consume():
+            out = []
+            async for v in outer():
+                out.append(v)
+            return out
+
+        self.assertEqual(run_coro(consume()), [2, 22])
+
+
+    def test_nested_inner_asend(self):
+        """Inner nested async gen driven with asend (sendSlot); outer re-yields the pairs."""
+        async def outer():
+            async def inner():
+                a = yield 1
+                b = yield ('a', a)
+                yield ('b', b)
+            g = inner()
+            yield await g.asend(None)    # -> 1
+            yield await g.asend('X')     # a == 'X' -> ('a', 'X')
+            yield await g.asend('Y')     # b == 'Y' -> ('b', 'Y')
+
+        async def consume():
+            out = []
+            async for v in outer():
+                out.append(v)
+            return out
+
+        self.assertEqual(run_coro(consume()), [1, ('a', 'X'), ('b', 'Y')])
+
+
+    def test_nested_inner_athrow(self):
+        """athrow into the inner nested async gen (throwSlot); outer re-yields the recovery."""
+        async def outer():
+            async def inner():
+                try:
+                    yield 1
+                except ValueError as e:
+                    yield ('caught', str(e))
+            g = inner()
+            yield await g.asend(None)                 # -> 1
+            yield await g.athrow(ValueError('boom'))  # inner catches -> ('caught', 'boom')
+
+        async def consume():
+            out = []
+            async for v in outer():
+                out.append(v)
+            return out
+
+        self.assertEqual(run_coro(consume()), [1, ('caught', 'boom')])
+
+
+run_test(__name__)


### PR DESCRIPTION
This is an alternative implementation of PEP 492 from #2004 by @mikasoukhov (Python 3.5). It builds on top of async support in the DLR (IronLanguages/dlr#362), which is around native .NET async primitives: `Task`/`Task<T>`, `IAsyncEnumerable<T>`, `IAsyncDisposable`. As such, it fits better within a .NET ecosystem, e.g. IronPython engine embedded within a larger C# application. As a .NET async mechanism, it obeys the .NET scheduling and context following mechanisms. For Python behavioural compatibility, wrappers and bridges are provided.

It also implements PEP 525 (async generators), which are accepted in Python 3.6.

The previous async functionality in IronPython is still there, parallel to the new one, and which one is being used depends whether `FEATURE_NET_ASYNC` is being defined during compilation. If defined, the new functionality is being used, otherwise the previous functionality is being used. It is practical for testing and development, but perhaps some discrepancies will occur. I think in the end it is best to settle on just one mechanism, but I'd postpone this decision until the whole `asyncio` support is complete.

As it is now, `FEATURE_NET_ASYNC` is defined on .NET platforms, but undefined on .NET Framework 4.6.2.