### PR TITLE
Remove run_unittest usage

### DIFF
--- a/src/core/IronPython/Lib/iptest/ipunittest.py
+++ b/src/core/IronPython/Lib/iptest/ipunittest.py
@@ -192,8 +192,7 @@ class IronPythonTestCase(unittest.TestCase, FileUtil, ProcessUtil):
 
 def run_test(name):
     if name == '__main__':
-        from test import support
-        support.run_unittest(name)
+        unittest.main(verbosity=2)
 
 def _flatten_suite(suite):
     tests = []

--- a/tests/suite/modules/misc/test__warnings.py
+++ b/tests/suite/modules/misc/test__warnings.py
@@ -6,69 +6,57 @@
 CPython's _warnings module. http://docs.python.org/library/warnings.html
 '''
 
-import unittest
 import _warnings
-from iptest import IronPythonTestCase, run_test, stderr_trapper as stderr_trapper
+from iptest import IronPythonTestCase, stderr_trapper, run_test
 
 #--GLOBALS---------------------------------------------------------------------
-EXPECTED = [] # expected output (ignoring filename, lineno, and line)
 WARN_TYPES = [Warning, UserWarning, PendingDeprecationWarning, SyntaxWarning,
               RuntimeWarning, FutureWarning, ImportWarning, UnicodeWarning,
               BytesWarning]
 
-def cleanup():
-    '''Clean up after possible incomplete test runs.'''
-    global EXPECTED
-    EXPECTED = []
-
-
-def expect(warn_type, message):
-    '''Helper for test output'''
-    for filter in _warnings.filters:
-        if filter[0] == "ignore" and issubclass(warn_type, filter[2]):
-            return
-    EXPECTED.append(": " + warn_type.__name__ + ": " + message + "\n")
-
-
 class _WarningsTest(IronPythonTestCase):
     #TODO: @skip("multiple_execute")
     def test_sanity(self):
-        global EXPECTED
-        try:
-            with stderr_trapper() as output:
-                # generate test output
-                _warnings.warn("Warning Message!")
-                expect(UserWarning, "Warning Message!")
-                for warn_type in WARN_TYPES:
-                    _warnings.warn(warn_type("Type-overriding message!"), UnicodeWarning)
-                    expect(warn_type, "Type-overriding message!")
-                    _warnings.warn("Another Warning Message!", warn_type)
-                    expect(warn_type, "Another Warning Message!")
-                    _warnings.warn_explicit("Explicit Warning!", warn_type, "nonexistent_file.py", 12)
-                    expect(warn_type, "Explicit Warning!")
-                    _warnings.warn_explicit("Explicit Warning!", warn_type, "test_python26.py", 34)
-                    expect(warn_type, "Explicit Warning!")
-                    _warnings.warn_explicit("Explicit Warning!", warn_type, "nonexistent_file.py", 56, "module.py")
-                    expect(warn_type, "Explicit Warning!")
-                    _warnings.warn_explicit("Explicit Warning!", warn_type, "test_python26.py", 78, "module.py")
-                    expect(warn_type, "Explicit Warning!")
+        EXPECTED = [] # expected output (ignoring filename, lineno, and line)
 
-            temp_messages = output.messages
+        def expect(warn_type, message):
+            '''Helper for test output'''
+            # unittest will reset the warning filters so the base filters do nothing
+            #for filter in _warnings.filters:
+            #    if filter[0] == "ignore" and issubclass(warn_type, filter[2]):
+            #        return
+            EXPECTED.append(": " + warn_type.__name__ + ": " + message + "\n")
 
-            #No point in going further if the number of lines is not what we expect
-            nlines = len([x for x in temp_messages if not x.startswith("  ")])
-            self.assertEqual(nlines, len(EXPECTED))
+        with stderr_trapper() as output:
+            # generate test output
+            _warnings.warn("Warning Message!")
+            expect(UserWarning, "Warning Message!")
+            for warn_type in WARN_TYPES:
+                _warnings.warn(warn_type("Type-overriding message!"), UnicodeWarning)
+                expect(warn_type, "Type-overriding message!")
+                _warnings.warn("Another Warning Message!", warn_type)
+                expect(warn_type, "Another Warning Message!")
+                _warnings.warn_explicit("Explicit Warning!", warn_type, "nonexistent_file.py", 12)
+                expect(warn_type, "Explicit Warning!")
+                _warnings.warn_explicit("Explicit Warning!", warn_type, "test_python26.py", 34)
+                expect(warn_type, "Explicit Warning!")
+                _warnings.warn_explicit("Explicit Warning!", warn_type, "nonexistent_file.py", 56, "module.py")
+                expect(warn_type, "Explicit Warning!")
+                _warnings.warn_explicit("Explicit Warning!", warn_type, "test_python26.py", 78, "module.py")
+                expect(warn_type, "Explicit Warning!")
 
-            # match lines
-            for line in temp_messages:
-                if line.startswith("  "):
-                    continue
-                temp = EXPECTED.pop(0).rstrip()
-                self.assertTrue(line.endswith(temp), str(line) + " does not end with " + temp)
+        temp_messages = output.messages
 
-        finally:
-            # remove generated files
-            cleanup()
+        #No point in going further if the number of lines is not what we expect
+        nlines = len([x for x in temp_messages if not x.startswith("  ")])
+        self.assertEqual(nlines, len(EXPECTED))
+
+        # match lines
+        for line in temp_messages:
+            if line.startswith("  "):
+                continue
+            temp = EXPECTED.pop(0).rstrip()
+            self.assertTrue(line.endswith(temp), str(line) + " does not end with " + temp)
 
     def test_ipy2_gh23(self):
         def test():

--- a/tests/suite/test_cliclass.py
+++ b/tests/suite/test_cliclass.py
@@ -4,11 +4,14 @@
 
 import sys
 import unittest
-from iptest import IronPythonTestCase, is_cli, is_debug, is_mono, is_net70, is_net80, is_net100, is_netcoreapp, is_netcoreapp21, is_posix, is_arm64, big, run_test, skipUnlessIronPython
+from iptest import IronPythonTestCase, is_cli, is_debug, is_mono, is_net70, is_net80, is_net100, is_netcoreapp, is_posix, is_arm64, big, run_test, skipUnlessIronPython
+from iptest.ipunittest import load_ironpython_test
 
 if is_cli:
     import clr
     import System
+
+    load_ironpython_test()
 
 @skipUnlessIronPython()
 class CliClassTestCase(IronPythonTestCase):
@@ -19,11 +22,6 @@ class CliClassTestCase(IronPythonTestCase):
             warnings.simplefilter('always')
             result = callable(*args, **kwds)
             self.assertFalse(any(item.category == warning for item in warning_list))
-
-    def setUp(self):
-        super(CliClassTestCase, self).setUp()
-
-        self.load_iron_python_test()
 
     def test_inheritance(self):
         import System
@@ -1087,7 +1085,6 @@ End Class""")
         self.assertRaisesPartialMessage(TypeError, 'System.Single', f)
         self.assertRaisesPartialMessage(TypeError, 'System.Version', g)
 
-    @unittest.skipIf(is_netcoreapp21, "TODO: figure out")
     def test_disposable(self):
         """classes implementing IDisposable should automatically support the with statement"""
         from IronPythonTest import DisposableTest
@@ -1890,21 +1887,18 @@ if not hasattr(A, 'Rank'):
         finally:
             os.unlink(fname)
 
-    @unittest.skipIf(is_netcoreapp21, "TODO: figure out")
-    def test_extension_methods(self):
-        import clr, os
-        if is_netcoreapp:
-            clr.AddReference('System.Linq')
-        else:
-            clr.AddReference('System.Core')
+def get_extension_method_test_cases():
+        import os
 
         test_cases = [
 """
 # add reference via type
-import clr
-from System.Linq import Enumerable
+@skipUnlessIronPython()
 class TheTestCase(IronPythonTestCase):
     def test_reference_via_type(self):
+        import clr
+        from System.Linq import Enumerable
+
         self.assertNotIn('Where', dir([]))
         clr.ImportExtensions(Enumerable)
         self.assertIn('Where', dir([]))
@@ -1912,10 +1906,12 @@ class TheTestCase(IronPythonTestCase):
 """,
 """
 # add reference via namespace
-import clr
-import System
+@skipUnlessIronPython()
 class TheTestCase(IronPythonTestCase):
     def test_reference_via_namespace(self):
+        import clr
+        import System
+
         self.assertNotIn('Where', dir([]))
         clr.ImportExtensions(System.Linq)
         self.assertIn('Where', dir([]))
@@ -1923,11 +1919,13 @@ class TheTestCase(IronPythonTestCase):
 """,
 """
 # add reference via namespace, add new namespace w/ more specific type
-import clr
-import System
-from IronPythonTest.ExtensionMethodTest import LinqCollision
+@skipUnlessIronPython()
 class TheTestCase(IronPythonTestCase):
     def test_namespace_reference(self):
+        import clr
+        import System
+        from IronPythonTest.ExtensionMethodTest import LinqCollision
+
         self.assertNotIn('Where', dir([]))
         clr.ImportExtensions(System.Linq)
         self.assertIn('Where', dir([]))
@@ -1937,7 +1935,6 @@ class TheTestCase(IronPythonTestCase):
 """,
 
 """
-import clr
 class UserType(object): pass
 class UserTypeWithValue(object):
     def __init__(self):
@@ -1949,13 +1946,15 @@ class UserTypeWithSlotsWithValue(object):
     def __init__(self):
         self.BaseClass = 100
 
+@skipUnlessIronPython()
 class TheTestCase(IronPythonTestCase):
     def test_user_type(self):
+        import clr
+
         self.assertRaises(AttributeError, lambda : UserType().BaseClass)
         self.assertRaises(AttributeError, lambda : UserTypeWithSlots().BaseClass)
         self.assertEqual(UserTypeWithValue().BaseClass, 200)
 
-        import clr
         from IronPythonTest.ExtensionMethodTest import ClassRelationship
         clr.ImportExtensions(ClassRelationship)
 
@@ -1978,13 +1977,14 @@ class TheTestCase(IronPythonTestCase):
         self.assertEqual(UserTypeWithValue().BaseClass, 200)
 """,
 """
-import clr
-import System
-from IronPythonTest.ExtensionMethodTest import ClassRelationship
-clr.ImportExtensions(ClassRelationship)
-
+@skipUnlessIronPython()
 class TheTestCase(IronPythonTestCase):
     def test_class_relationship(self):
+        import clr
+        import System
+        from IronPythonTest.ExtensionMethodTest import ClassRelationship
+        clr.ImportExtensions(ClassRelationship)
+
         self.assertEqual([].Interface(), 23)
         self.assertEqual([].GenericInterface(), 23)
         self.assertEqual([].GenericInterfaceAndMethod(), 23)
@@ -1998,12 +1998,6 @@ class TheTestCase(IronPythonTestCase):
         self.assertEqual(object().GenericMethod(), 23)
 """,
 """
-import clr
-import System
-from System import Linq
-
-clr.ImportExtensions(Linq)
-
 class Product(object):
     def __init__(self, cat, id, qtyOnHand ):
         self.Cat = cat
@@ -2011,8 +2005,15 @@ class Product(object):
         self.QtyOnHand = qtyOnHand
         self.Q = self.QtyOnHand
 
+@skipUnlessIronPython()
 class TheTestCase(IronPythonTestCase):
     def test_extension_method(self):
+        import clr
+        import System
+        from System import Linq
+
+        clr.ImportExtensions(Linq)
+
         products = [Product(prod[0], prod[1], prod[2]) for prod in
             (('DrillRod', 'DR123', 45), ('Flange', 'F423', 12), ('Gizmo', 'G9872', 214), ('Sprocket', 'S534', 42))]
 
@@ -2058,20 +2059,22 @@ class TheTestCase(IronPythonTestCase):
             try:
                 old_path = [x for x in sys.path]
                 sys.path.append('.')
-                with open(fname, 'w+') as f:
+                with open(fname, 'w') as f:
                     f.write('''
-from test import support
-from iptest import IronPythonTestCase
+from iptest import IronPythonTestCase, skipUnlessIronPython
 ''')
                     f.write(test_case)
-                    f.write('''
-
-support.run_unittest(TheTestCase)''')
 
                 __import__(temp_module)
+                yield sys.modules[temp_module].TheTestCase
                 del sys.modules[temp_module]
             finally:
                 os.unlink(fname)
                 sys.path = [x for x in old_path]
+
+def load_tests(loader, tests, pattern):
+    for test_case in get_extension_method_test_cases():
+        tests.addTests(loader.loadTestsFromTestCase(test_case))
+    return tests
 
 run_test(__name__)

--- a/tests/suite/test_pow.py
+++ b/tests/suite/test_pow.py
@@ -1,8 +1,12 @@
-import test.support, unittest
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+import unittest
 
 class PowTest(unittest.TestCase):
     # taken from test_complex.py
-    # needed for negative real values with a fractional exponent    
+    # needed for negative real values with a fractional exponent
     def assertAlmostEqual(self, a, b):
         if isinstance(a, complex):
             if isinstance(b, complex):
@@ -55,8 +59,5 @@ class PowTest(unittest.TestCase):
         self.assertAlmostEqual(pow(-1, 1/3), 0.5 + 0.8660254037844386j)
         self.assertAlmostEqual((-1)**(1/3), 0.5 + 0.8660254037844386j)
 
-def test_main():
-    test.support.run_unittest(PowTest)
-
 if __name__ == "__main__":
-    test_main()
+    unittest.main(verbosity=2)

--- a/tests/suite/test_unpack.py
+++ b/tests/suite/test_unpack.py
@@ -3,7 +3,6 @@
 # See the LICENSE file in the project root for more information.
 
 import sys
-import test.support
 import unittest
 
 class UnpackTest(unittest.TestCase):
@@ -22,7 +21,7 @@ class UnpackTest(unittest.TestCase):
         self.assertEqual(a, [0, 1, 2, 3])
         self.assertEqual(b, 4)
         self.assertEqual(c, 5)
-    
+
     def test_unpack_into_exprlist_3(self):
         a, *b, c = range(6)
         self.assertEqual(a, 0)
@@ -46,7 +45,7 @@ class UnpackTest(unittest.TestCase):
         self.assertEqual(f, [1, 2, 3])
         self.assertEqual(g, 4)
         self.assertEqual(h, 5)
-        
+
     def test_unpack_into_list_1(self):
         [*a] = range(2)
         self.assertEqual(a, [0, 1])
@@ -75,7 +74,7 @@ class UnpackTest(unittest.TestCase):
             self.assertEqual(b, index)
             self.assertEqual(a, [index])
             index = index + 1
-    
+
     def test_unpack_into_for_target_3(self):
         index = 0
         expected_a = [1, 4]
@@ -236,8 +235,5 @@ class UnpackTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             exec("{*1}")
 
-def test_main():
-    test.support.run_unittest(UnpackTest)
-
 if __name__ == "__main__":
-    test_main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Remove `test.support.run_unittest` usage. It was removed from CPython in 3.11 so this makes it easier to run the our suite against newer CPython versions.