### PR TITLE
Remove obsolete NotParallelSafe flag for test_zlib

### DIFF
--- a/tests/IronPython.Tests/Cases/IronPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/IronPythonCasesManifest.ini
@@ -191,7 +191,6 @@ NotParallelSafe=true # Uses a temporary module with a fixed name
 RetryCount=2
 
 [IronPython.modules.misc.test_zlib]
-NotParallelSafe=true # test_data.gz
 
 [IronPython.modules.system_related.test_nt]
 RunCondition=NOT $(IS_POSIX)


### PR DESCRIPTION
# Summary

This PR removes the `NotParallelSafe=true` flag for `IronPython.modules.misc.test_zlib`.

Issue #1177 originally reported that `test_zlib` was not safe to run in parallel because it could raise a `FileNotFoundError` involving `test_data.gz`. According to the maintainer, the concurrency issue was resolved in #2002, but the `NotParallelSafe=true` setting added in #1397 was never removed.

After removing the flag, I ran:

- `.\make.ps1 test-zlib`

and the tests passed successfully on all configured targets (`net462`, `net8.0`, and `net10.0`).

Fixes #1177