### PR TITLE
Add tracing point for async generator

### DIFF
--- a/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
+++ b/src/core/IronPython/Compiler/Ast/FunctionDefinition.cs
@@ -740,6 +740,7 @@ namespace IronPython.Compiler.Ast {
                     var throwSlot = AsyncThrowSlot;
                     body = MSAst.Expression.Block(
                         [cts, excBox, sendSlot, throwSlot],
+                        MakeFunctionEntrySequencePoint(StartIndex),
                         MSAst.Expression.Assign(cts, MSAst.Expression.New(typeof(CancellationTokenSource))),
                         MSAst.Expression.Assign(excBox, MSAst.Expression.New(typeof(StrongBox<Exception>))),
                         MSAst.Expression.Assign(sendSlot, MSAst.Expression.New(typeof(StrongBox<object>))),


### PR DESCRIPTION
This is the counterpart of #2056. It does not solve #2057, but it aligns async generators with coroutines, regardless how those two are being traced (to be done in a separate PR).