### PR TITLE
Enable test_os

### DIFF
--- a/src/core/IronPython.Modules/nt.cs
+++ b/src/core/IronPython.Modules/nt.cs
@@ -285,8 +285,8 @@ namespace IronPython.Modules {
 #if FEATURE_FILESYSTEM
 
         public static void chdir([NotNone] string path) {
-            if (String.IsNullOrEmpty(path)) {
-                throw PythonOps.OSError(PythonExceptions._OSError.ERROR_INVALID_NAME, "Path cannot be an empty string", path, PythonExceptions._OSError.ERROR_INVALID_NAME);
+            if (string.IsNullOrEmpty(path)) {
+                throw GetOsOrWinError(PythonErrno.ENOENT, PythonExceptions._OSError.ERROR_INVALID_NAME, path);
             }
 
             try {
@@ -553,7 +553,7 @@ namespace IronPython.Modules {
             }
 
             if (path == string.Empty) {
-                throw PythonOps.OSError(PythonExceptions._OSError.ERROR_PATH_NOT_FOUND, "The system cannot find the path specified", path, PythonExceptions._OSError.ERROR_PATH_NOT_FOUND);
+                throw GetOsOrWinError(PythonErrno.ENOENT, PythonExceptions._OSError.ERROR_PATH_NOT_FOUND, path);
             }
 
 #if !NETFRAMEWORK
@@ -628,7 +628,7 @@ namespace IronPython.Modules {
 
             [LightThrowing]
             public object? inode() {
-                var obj = stat(follow_symlinks: false);
+                var obj = PythonNT.stat(info.FullName, new Dictionary<string, object>());
                 if (obj is stat_result res) return res.st_ino;
                 return obj;
             }
@@ -640,9 +640,15 @@ namespace IronPython.Modules {
             public bool is_symlink() => info.Attributes.HasFlag(FileAttributes.ReparsePoint) ? throw new NotImplementedException() : false;
 
             [LightThrowing]
-            public object? stat(bool follow_symlinks = true) => PythonNT.stat(info.FullName, new Dictionary<string, object>());
+            public object? stat(bool follow_symlinks = true) {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    return statWindowsImpl(info);
+                return PythonNT.stat(info.FullName, new Dictionary<string, object>());
+            }
 
             public string __repr__(CodeContext context) => $"<DirEntry {PythonOps.Repr(context, name)}>";
+
+            public object __fspath__(CodeContext context) => path;
         }
 
         [PythonType, PythonHidden]
@@ -675,6 +681,8 @@ namespace IronPython.Modules {
 
             [PythonHidden]
             public void Reset() => enumerator.Reset();
+
+            public void close() => Dispose();
         }
 
         public static ScandirIterator scandir(CodeContext context, string? path = null)
@@ -689,7 +697,7 @@ namespace IronPython.Modules {
             }
 
             if (path == string.Empty) {
-                throw PythonOps.OSError(PythonExceptions._OSError.ERROR_PATH_NOT_FOUND, "The system cannot find the path specified", path, PythonExceptions._OSError.ERROR_PATH_NOT_FOUND);
+                throw GetOsOrWinError(PythonErrno.ENOENT, PythonExceptions._OSError.ERROR_PATH_NOT_FOUND, path);
             }
 
 #if !NETFRAMEWORK
@@ -1396,8 +1404,8 @@ namespace IronPython.Modules {
             }
         }
 
-        private static bool HasExecutableExtension(string path) {
-            string extension = Path.GetExtension(path).ToLower(CultureInfo.InvariantCulture);
+        private static bool HasExecutableExtension(string extension) {
+            extension = extension.ToLower(CultureInfo.InvariantCulture);
             return (extension == ".exe" || extension == ".dll" || extension == ".com" || extension == ".bat");
         }
 
@@ -1456,50 +1464,22 @@ namespace IronPython.Modules {
             VerifyPath(path, functionName: nameof(stat), argName: nameof(path));
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                if (IsNulFile(path)) {
+                    return new stat_result(0x2000);
+                }
+
                 try {
                     FileInfo fi = new FileInfo(path);
-                    int mode = 0;
-                    long size;
-
-                    if (IsNulFile(path)) {
-                        return new stat_result(0x2000);
-                    } else if (Directory.Exists(path)) {
-                        size = 0;
-                        mode = 0x4000 | S_IEXEC;
-                    } else if (File.Exists(path)) {
-                        size = fi.Length;
-                        mode = 0x8000;
-                        if (HasExecutableExtension(path)) {
-                            mode |= S_IEXEC;
-                        }
-                    } else {
-                        return LightExceptions.Throw(PythonOps.OSError(0, "file does not exist", path, PythonExceptions._OSError.ERROR_PATH_NOT_FOUND));
+                    if (fi.Exists) {
+                        return statWindowsImpl(fi);
                     }
-
-                    mode |= S_IREAD;
-                    if ((fi.Attributes & FileAttributes.ReadOnly) == 0) {
-                        mode |= S_IWRITE;
+                    DirectoryInfo di = new DirectoryInfo(path);
+                    if (di.Exists) {
+                        return statWindowsImpl(di);
                     }
-
-                    const long epochDifferenceLong = 62135596800 * TimeSpan.TicksPerSecond;
-
-                    // 1 tick = 100 nanoseconds
-                    long st_atime_ns = (fi.LastAccessTime.ToUniversalTime().Ticks - epochDifferenceLong) * 100;
-                    long st_mtime_ns = (fi.LastWriteTime.ToUniversalTime().Ticks - epochDifferenceLong) * 100;
-                    long st_ctime_ns = (fi.CreationTime.ToUniversalTime().Ticks - epochDifferenceLong) * 100;
-
-                    ulong fileIdx = 0;
-                    var handle = CreateFile(path, FILE_READ_ATTRIBUTES, 0, IntPtr.Zero, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, IntPtr.Zero);
-                    if (!handle.IsInvalid) {
-                        if (GetFileInformationByHandle(handle, out BY_HANDLE_FILE_INFORMATION fileInfo)) {
-                            fileIdx = (((ulong)fileInfo.FileIndexHigh) << 32) + fileInfo.FileIndexLow;
-                        }
-                        handle.Close();
-                    }
-
-                    return new stat_result(mode, fileIdx, size, st_atime_ns, st_mtime_ns, st_ctime_ns);
+                    return LightExceptions.Throw(GetOsOrWinError(PythonErrno.ENOENT, PythonExceptions._OSError.ERROR_FILE_NOT_FOUND, path));
                 } catch (ArgumentException) {
-                    return LightExceptions.Throw(PythonOps.OSError(0, "The path is invalid", path, PythonExceptions._OSError.ERROR_INVALID_NAME));
+                    return LightExceptions.Throw(GetOsOrWinError(PythonErrno.ENOENT, PythonExceptions._OSError.ERROR_INVALID_NAME, path));
                 } catch (Exception e) {
                     return LightExceptions.Throw(ToPythonException(e, path));
                 }
@@ -1508,6 +1488,46 @@ namespace IronPython.Modules {
             } else {
                 throw new PlatformNotSupportedException();
             }
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static stat_result statWindowsImpl(FileSystemInfo fsi) {
+            int mode = 0;
+            long size;
+            if (fsi is FileInfo fi) {
+                size = fi.Length;
+                mode = 0x8000;
+                if (HasExecutableExtension(fi.Extension)) {
+                    mode |= S_IEXEC;
+                }
+            } else {
+                Debug.Assert(fsi is DirectoryInfo);
+                size = 0;
+                mode = 0x4000 | S_IEXEC;
+            }
+
+            mode |= S_IREAD;
+            if ((fsi.Attributes & FileAttributes.ReadOnly) == 0) {
+                mode |= S_IWRITE;
+            }
+
+            const long epochDifferenceLong = 62135596800 * TimeSpan.TicksPerSecond;
+
+            // 1 tick = 100 nanoseconds
+            long st_atime_ns = (fsi.LastAccessTime.ToUniversalTime().Ticks - epochDifferenceLong) * 100;
+            long st_mtime_ns = (fsi.LastWriteTime.ToUniversalTime().Ticks - epochDifferenceLong) * 100;
+            long st_ctime_ns = (fsi.CreationTime.ToUniversalTime().Ticks - epochDifferenceLong) * 100;
+
+            ulong fileIdx = 0;
+            var handle = CreateFile(fsi.FullName, FILE_READ_ATTRIBUTES, 0, IntPtr.Zero, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, IntPtr.Zero);
+            if (!handle.IsInvalid) {
+                if (GetFileInformationByHandle(handle, out BY_HANDLE_FILE_INFORMATION fileInfo)) {
+                    fileIdx = (((ulong)fileInfo.FileIndexHigh) << 32) + fileInfo.FileIndexLow;
+                }
+                handle.Close();
+            }
+
+            return new stat_result(mode, fileIdx, size, st_atime_ns, st_mtime_ns, st_ctime_ns);
         }
 
         [LightThrowing, Documentation("")]
@@ -1663,7 +1683,20 @@ namespace IronPython.Modules {
                         throw PythonOps.TypeError("'{0}' is an invalid keyword argument for this function", key);
                 }
             }
-            UnlinkWorker(path);
+
+            if (path.IndexOfAny(Path.GetInvalidPathChars()) != -1 || Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1) {
+                throw GetOsOrWinError(PythonErrno.ENOENT, PythonExceptions._OSError.ERROR_INVALID_NAME, path);
+            }
+
+            bool existing = File.Exists(path); // will return false also on access denied
+            try {
+                File.Delete(path); // will throw an exception on access denied, no exception on file not existing
+            } catch (Exception e) {
+                throw ToPythonException(e, path);
+            }
+            if (!existing) { // file was not existing in the first place
+                throw GetOsOrWinError(PythonErrno.ENOENT, PythonExceptions._OSError.ERROR_FILE_NOT_FOUND, path);
+            }
         }
 
         [Documentation("")]
@@ -1685,24 +1718,6 @@ namespace IronPython.Modules {
         [Documentation("")]
         public static void unlink(CodeContext context, object? path, [ParamDictionary] IDictionary<string, object> kwargs)
             => unlink(ConvertToFsString(context, path, nameof(path)), kwargs);
-
-        private static void UnlinkWorker(string path) {
-            if (path == null) {
-                throw new ArgumentNullException(nameof(path));
-            } else if (path.IndexOfAny(Path.GetInvalidPathChars()) != -1 || Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1) {
-                throw PythonOps.OSError(PythonExceptions._OSError.ERROR_INVALID_NAME, "The filename, directory name, or volume label syntax is incorrect", path, PythonExceptions._OSError.ERROR_INVALID_NAME);
-            }
-
-            bool existing = File.Exists(path); // will return false also on access denied
-            try {
-                File.Delete(path); // will throw an exception on access denied, no exception on file not existing
-            } catch (Exception e) {
-                throw ToPythonException(e, path);
-            }
-            if (!existing) { // file was not existing in the first place
-                throw PythonOps.OSError(PythonExceptions._OSError.ERROR_FILE_NOT_FOUND, "The system cannot find the file specified", path, PythonExceptions._OSError.ERROR_FILE_NOT_FOUND);
-            }
-        }
 #endif
 
 #if FEATURE_PROCESS
@@ -2127,15 +2142,13 @@ the 'status' value."),
                 message = e.Message;
                 isWindowsError = true;
             } else if (e is UnauthorizedAccessException unauth) {
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                    GetWin32Error(PythonExceptions._OSError.ERROR_ACCESS_DENIED, filename) :
-                    GetOsError(PythonErrno.EACCES, filename);
+                return GetOsOrWinError(PythonErrno.EACCES, PythonExceptions._OSError.ERROR_ACCESS_DENIED, filename);
             } else {
                 var ioe = e as IOException;
                 Exception? pe = IOExceptionToPythonException(ioe, error, filename);
                 if (pe != null) return pe;
 
-                errorCode = System.Runtime.InteropServices.Marshal.GetHRForException(e);
+                errorCode = Marshal.GetHRForException(e);
 
                 if ((errorCode & ~0xfff) == (unchecked((int)0x80070000))) {
                     // Win32 HR, translate HR to Python error code if possible, otherwise
@@ -2310,18 +2323,20 @@ the 'status' value."),
 
 #endif
 
-        private static Exception DirectoryExistsError(string? filename) {
-#if FEATURE_NATIVE
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                return GetWin32Error(PythonExceptions._OSError.ERROR_ALREADY_EXISTS, filename);
-            }
-#endif
-            return GetOsError(PythonErrno.EEXIST, filename);
-        }
-
+        private static Exception DirectoryExistsError(string? filename)
+            => GetOsOrWinError(PythonErrno.EEXIST, PythonExceptions._OSError.ERROR_ALREADY_EXISTS, filename);
 
         internal static Exception GetOsError(int errno, string? filename = null, string? filename2 = null)
             => PythonOps.OSError(errno, strerror(errno), filename, null, filename2);
+
+        internal static Exception GetOsOrWinError(int errno, int winerror, string? filename = null, string? filename2 = null) {
+#if FEATURE_NATIVE
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                return GetWin32Error(winerror, filename, filename2);
+            }
+#endif
+            return PythonOps.OSError(errno, strerror(errno), filename, null, filename2);
+        }
 
 #if FEATURE_NATIVE || FEATURE_CTYPES
 

--- a/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
@@ -640,9 +640,6 @@ RunCondition=$(IS_POSIX)
 Ignore=true
 Reason=unittest.case.SkipTest: os.openpty() not available.
 
-[CPython.test_os]
-Ignore=true
-
 [CPython.test_ossaudiodev] # Module has been removed in 3.13 - https://github.com/IronLanguages/ironpython3/issues/1352
 Ignore=true
 Reason=unittest.case.SkipTest: No module named 'ossaudiodev'

--- a/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
+++ b/tests/IronPython.Tests/Cases/CPythonCasesManifest.ini
@@ -640,6 +640,9 @@ RunCondition=$(IS_POSIX)
 Ignore=true
 Reason=unittest.case.SkipTest: os.openpty() not available.
 
+[CPython.test_os]
+IsolationLevel=PROCESS # TODO: test_urandom_subprocess fails to import stat otherwise...
+
 [CPython.test_ossaudiodev] # Module has been removed in 3.13 - https://github.com/IronLanguages/ironpython3/issues/1352
 Ignore=true
 Reason=unittest.case.SkipTest: No module named 'ossaudiodev'

--- a/tests/suite/stdlib/test_os.py
+++ b/tests/suite/stdlib/test_os.py
@@ -8,9 +8,21 @@
 
 import sys
 
-from iptest import is_ironpython, generate_suite, run_test, is_posix
+from iptest import is_ironpython, generate_suite, run_test, is_posix, is_windows
 
 import test.test_os
+
+def is_exfat():
+    import clr
+    clr.AddReference("System.IO.FileSystem.DriveInfo")
+    import os
+    import System.IO
+    try:
+        drive = os.path.splitdrive(os.getcwd())[0]
+        format = System.IO.DriveInfo(drive).DriveFormat.lower()
+        return format == "exfat"
+    except:
+        return False
 
 def load_tests(loader, standard_tests, pattern):
     tests = loader.loadTestsFromModule(test.test_os, pattern=pattern)
@@ -31,10 +43,6 @@ def load_tests(loader, standard_tests, pattern):
             test.test_os.FileTests('test_symlink_keywords'), # IndexError: Index was outside the bounds of the array.
             test.test_os.OSErrorTests('test_oserror_filename'), # AssertionError: '@test_732_tmp' is not b'@test_732_tmp'
             test.test_os.StatAttributeTests('test_stat_result_pickle'), # AssertionError
-            test.test_os.UtimeTests('test_utime'), # OSError: [WinError 87] The parameter is incorrect.
-            test.test_os.UtimeTests('test_utime_by_indexed'), # OSError: [WinError 87] The parameter is incorrect.
-            test.test_os.UtimeTests('test_utime_by_times'), # OSError: [WinError 87] The parameter is incorrect.
-            test.test_os.UtimeTests('test_utime_directory'), # OSError: [WinError 87] The parameter is incorrect.
             test.test_os.Win32KillTests('test_kill_int'), # AssertionError
             test.test_os.Win32KillTests('test_kill_sigterm'), # AssertionError
         ]
@@ -43,11 +51,6 @@ def load_tests(loader, standard_tests, pattern):
                 test.test_os.EnvironTests('test_unset_error'), # ValueError: Environment variable name cannot contain equal character. (Parameter 'variable')
                 test.test_os.FDInheritanceTests('test_get_inheritable_cloexec'), # AttributeError: 'module' object has no attribute 'get_inheritable'
                 test.test_os.FDInheritanceTests('test_set_inheritable_cloexec'), # AssertionError
-            ]
-        else:
-            failing_tests += [
-                test.test_os.UtimeTests('test_utime_current'), # AssertionError
-                test.test_os.UtimeTests('test_utime_current_old'), # AssertionError
             ]
         if sys.version_info < (3, 6):
             failing_tests += [
@@ -75,12 +78,19 @@ def load_tests(loader, standard_tests, pattern):
                     test.test_os.TestScandir('test_removed_file'), # FileNotFoundError
                 ]
 
-        skip_tests = [
-            # these require symlink support on drive
-            test.test_os.LinkTests('test_link'),
-            test.test_os.LinkTests('test_link_bytes'),
-            test.test_os.LinkTests('test_unicode_name'),
-        ]
+        skip_tests = []
+        if is_windows and is_exfat():
+            skip_tests += [
+                test.test_os.LinkTests('test_link'),
+                test.test_os.LinkTests('test_link_bytes'),
+                test.test_os.LinkTests('test_unicode_name'),
+                test.test_os.UtimeTests('test_utime'),
+                test.test_os.UtimeTests('test_utime_by_indexed'),
+                test.test_os.UtimeTests('test_utime_by_times'),
+                test.test_os.UtimeTests('test_utime_directory'),
+                test.test_os.UtimeTests('test_utime_current'),
+                test.test_os.UtimeTests('test_utime_current_old'),
+            ]
         if sys.version_info >= (3, 6):
             skip_tests += [
                 # SpawnTests seem to create a console

--- a/tests/suite/stdlib/test_os.py
+++ b/tests/suite/stdlib/test_os.py
@@ -1,0 +1,110 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+##
+## Run selected tests from test_os from StdLib
+##
+
+import sys
+
+from iptest import is_ironpython, generate_suite, run_test, is_posix
+
+import test.test_os
+
+def load_tests(loader, standard_tests, pattern):
+    tests = loader.loadTestsFromModule(test.test_os, pattern=pattern)
+
+    if is_ironpython:
+        failing_tests = [
+            test.test_os.DeviceEncodingTests('test_bad_fd'), # AttributeError: 'module' object has no attribute 'device_encoding'
+            test.test_os.DeviceEncodingTests('test_device_encoding'), # AttributeError: 'module' object has no attribute 'device_encoding'
+            test.test_os.ExecTests('test_execvpe_with_bad_arglist'), # NameError: name 'execv' is not defined
+            test.test_os.ExecTests('test_execvpe_with_bad_program'), # NameError: name 'execv' is not defined
+            test.test_os.ExecTests('test_internal_execvpe_str'), # NameError: name 'execv' is not defined
+            test.test_os.FDInheritanceTests('test_dup'), # AttributeError: 'module' object has no attribute 'get_inheritable'
+            test.test_os.FDInheritanceTests('test_dup2'), # AttributeError: 'module' object has no attribute 'get_inheritable'
+            test.test_os.FDInheritanceTests('test_get_set_inheritable'), # AttributeError: 'module' object has no attribute 'get_inheritable'
+            test.test_os.FDInheritanceTests('test_open'), # AttributeError: 'module' object has no attribute 'get_inheritable'
+            test.test_os.FDInheritanceTests('test_pipe'), # AttributeError: 'module' object has no attribute 'get_inheritable'
+            test.test_os.FileTests('test_open_keywords'), # IndexError: Index was outside the bounds of the array.
+            test.test_os.FileTests('test_symlink_keywords'), # IndexError: Index was outside the bounds of the array.
+            test.test_os.OSErrorTests('test_oserror_filename'), # AssertionError: '@test_732_tmp' is not b'@test_732_tmp'
+            test.test_os.StatAttributeTests('test_stat_result_pickle'), # AssertionError
+            test.test_os.UtimeTests('test_utime'), # OSError: [WinError 87] The parameter is incorrect.
+            test.test_os.UtimeTests('test_utime_by_indexed'), # OSError: [WinError 87] The parameter is incorrect.
+            test.test_os.UtimeTests('test_utime_by_times'), # OSError: [WinError 87] The parameter is incorrect.
+            test.test_os.UtimeTests('test_utime_directory'), # OSError: [WinError 87] The parameter is incorrect.
+            test.test_os.Win32KillTests('test_kill_int'), # AssertionError
+            test.test_os.Win32KillTests('test_kill_sigterm'), # AssertionError
+        ]
+        if is_posix:
+            failing_tests += [
+                test.test_os.EnvironTests('test_unset_error'), # ValueError: Environment variable name cannot contain equal character. (Parameter 'variable')
+                test.test_os.FDInheritanceTests('test_get_inheritable_cloexec'), # AttributeError: 'module' object has no attribute 'get_inheritable'
+                test.test_os.FDInheritanceTests('test_set_inheritable_cloexec'), # AssertionError
+            ]
+        else:
+            failing_tests += [
+                test.test_os.UtimeTests('test_utime_current'), # AssertionError
+                test.test_os.UtimeTests('test_utime_current_old'), # AssertionError
+            ]
+        if sys.version_info < (3, 6):
+            failing_tests += [
+                test.test_os.Win32DeprecatedBytesAPI('test_deprecated'), # AttributeError: 'module' object has no attribute '_isdir'
+            ]
+        if sys.version_info >= (3, 6):
+            failing_tests += [
+                test.test_os.BytesWalkTests('test_walk_bottom_up'), # AssertionError
+                test.test_os.ExecTests('test_execv_with_bad_arglist'), # NameError: name 'execv' is not defined
+                test.test_os.ExecTests('test_execve_invalid_env'), # NameError: name 'execve' is not defined
+                test.test_os.ExecTests('test_execve_with_empty_path'), # NameError: name 'execve' is not defined
+                test.test_os.PathTConverterTests('test_path_t_converter'), # AssertionError
+                test.test_os.StatAttributeTests('test_file_attributes'), # AssertionError
+                test.test_os.TestInvalidFD('test_inheritable'), # AttributeError: 'module' object has no attribute 'get_inheritable'
+                test.test_os.TestScandir('test_attributes'), # OSError: [WinError 1] Incorrect function
+                test.test_os.TestScandir('test_resource_warning'), # AssertionError: ResourceWarning not triggered
+                test.test_os.UtimeTests('test_utime_invalid_arguments'), # OSError: [WinError 87] The parameter is incorrect.
+                test.test_os.WalkTests('test_walk_bottom_up'), # AssertionError
+                test.test_os.Win32JunctionTests('test_create_junction'), # AttributeError: 'module' object has no attribute 'CreateJunction'
+                test.test_os.Win32JunctionTests('test_unlink_removes_junction'), # AttributeError: 'module' object has no attribute 'CreateJunction'
+            ]
+            if is_posix:
+                failing_tests += [
+                    test.test_os.TestScandir('test_removed_dir'), # FileNotFoundError
+                    test.test_os.TestScandir('test_removed_file'), # FileNotFoundError
+                ]
+
+        skip_tests = [
+            # these require symlink support on drive
+            test.test_os.LinkTests('test_link'),
+            test.test_os.LinkTests('test_link_bytes'),
+            test.test_os.LinkTests('test_unicode_name'),
+        ]
+        if sys.version_info >= (3, 6):
+            skip_tests += [
+                # SpawnTests seem to create a console
+                test.test_os.SpawnTests('test_nowait'),
+                test.test_os.SpawnTests('test_spawnl'),
+                test.test_os.SpawnTests('test_spawnl_noargs'),
+                test.test_os.SpawnTests('test_spawnle'),
+                test.test_os.SpawnTests('test_spawnle_noargs'),
+                test.test_os.SpawnTests('test_spawnlp'),
+                test.test_os.SpawnTests('test_spawnlpe'),
+                test.test_os.SpawnTests('test_spawnv'),
+                test.test_os.SpawnTests('test_spawnv_noargs'),
+                test.test_os.SpawnTests('test_spawnve'),
+                test.test_os.SpawnTests('test_spawnve_bytes'),
+                test.test_os.SpawnTests('test_spawnve_invalid_env'),
+                test.test_os.SpawnTests('test_spawnve_noargs'),
+                test.test_os.SpawnTests('test_spawnvp'),
+                test.test_os.SpawnTests('test_spawnvpe'),
+                test.test_os.SpawnTests('test_spawnvpe_invalid_env'),
+            ]
+
+        return generate_suite(tests, failing_tests, skip_tests)
+
+    else:
+        return tests
+
+run_test(__name__)


### PR DESCRIPTION
Enable some tests from the CPython stdlib with the main goal of getting improved `os.scandir` coverage (tests under 3.6). I think with these changes it may be possible to close https://github.com/IronLanguages/ironpython3/issues/1106 (requires a bit more testing). Also makes some of the error messages closer to those of CPython.